### PR TITLE
remove gcloud in favor of node cloud storage sdk

### DIFF
--- a/.github/actions/admin/action.yml
+++ b/.github/actions/admin/action.yml
@@ -92,5 +92,6 @@ runs:
       working-directory: '${{ inputs.working_directory }}'
       env:
         TF_IN_AUTOMATION: 'true'
+        TF_CLI_ARGS: '-input=false'
       run: |-
         terraform ${{ inputs.command }}

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -39,10 +39,6 @@ inputs:
     description: 'The maxiumum number of retries when handling failures.'
     required: false
     default: '5'
-  base_retry_delay:
-    description: 'The base retry delay in seconds when handling failures.'
-    required: false
-    default: '2'
   max_retry_delay:
     description: 'The max retry delay in seconds when handling failures.'
     required: false
@@ -117,19 +113,15 @@ runs:
         protect_lockfile: '${{ inputs.protect_lockfile }}'
         terraform_wrapper: false
 
-    - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587' # ratchet:google-github-actions/setup-gcloud@v1
+    - name: 'Setup Node'
+      uses: 'actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c' # ratchet:actions/setup-node@v3
+      with:
+        node-version: '16'
 
-    - name: 'Cloud SDK Config'
+    - name: 'Install Google Cloud Storage SDK'
       shell: 'bash'
-      working-directory: '${{ inputs.working_directory }}'
-      env:
-        OUT_FILENAME: 'out_${{ github.run_id }}_${{ github.run_attempt }}.txt'
       run: |-
-        echo "# Cloud SDK Config" > ${{ env.OUT_FILENAME }}
-        gcloud config set storage/max_retries ${{ inputs.max_retries }} 2>&1 | tee -a ${{ env.OUT_FILENAME }}
-        gcloud config set storage/base_retry_delay ${{ inputs.base_retry_delay }} 2>&1 | tee -a ${{ env.OUT_FILENAME }}
-        gcloud config set storage/max_retry_delay ${{ inputs.max_retry_delay }} 2>&1 | tee -a ${{ env.OUT_FILENAME }}
+        npm install @google-cloud/storage@~6.9.5
 
     - name: 'Terraform Init'
       shell: 'bash'
@@ -142,17 +134,47 @@ runs:
         terraform init -input=false -no-color 2>&1 | tee -a ${{ env.OUT_FILENAME }}
 
     - name: 'Download Plan File'
-      shell: 'bash'
-      working-directory: '${{ inputs.working_directory }}'
+      uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # ratchet:actions/github-script@v6
       env:
-        OUT_FILENAME: 'out_${{ github.run_id }}_${{ github.run_attempt }}.txt'
+        OUT_FILEPATH: '${{ inputs.working_directory }}/out_${{ github.run_id }}_${{ github.run_attempt }}.txt'
         GUARDIAN_PLAN_PREFIX: 'guardian-plans/${{ github.repository }}/${{ steps.get-pr.outputs.result }}/${{ inputs.working_directory }}'
-      run: |-
-        echo "# Download Plan File" > ${{ env.OUT_FILENAME }}
-        gcloud storage cp \
-          gs://${{ inputs.bucket_name }}/${{ env.GUARDIAN_PLAN_PREFIX }}/tfplan.binary \
-          tfplan.binary \
-          2>&1 | tee -a ${{ env.OUT_FILENAME }}
+      with:
+        script: |-
+          const fs = require("fs");
+          const { EOL } = require("os");
+
+          try {
+            const { Storage, IdempotencyStrategy } = require("@google-cloud/storage");
+            const bucketName = "${{ inputs.bucket_name }}";
+            const fileName = "${{ env.GUARDIAN_PLAN_PREFIX }}/tfplan.binary";
+            const destFileName = "${{ inputs.working_directory }}/tfplan.binary";
+
+            const storage = new Storage({
+              retryOptions: {
+                autoRetry: true,
+                retryDelayMultiplier: 3,
+                totalTimeout: 500,
+                maxRetryDelay: "${{ inputs.max_retry_delay }}",
+                maxRetries: "${{ inputs.max_retries }}",
+                idempotencyStrategy: IdempotencyStrategy.RetryAlways,
+              },
+            });
+
+            // TODO(verbanicm): does this delete all versions?
+            await storage
+              .bucket(bucketName)
+              .file(fileName)
+              .download({ destination: destFileName });
+          } catch (err) {
+            const errString = JSON.stringify(err, undefined, 2);
+            const errorData = `# Download Plan File${EOL}Error: ${errString}`;
+
+            fs.writeFileSync("${{ env.OUT_FILEPATH }}", errorData, { encoding: "utf8" });
+
+            core.error("Failed to download plan file");
+            core.error(errString);
+            core.setFailed("Failed to download plan file.");
+          }
 
     - name: 'Terraform Apply'
       shell: 'bash'
@@ -182,17 +204,54 @@ runs:
       run: |-
         cp ${{ env.OUT_FILENAME }} ${{ env.SUCCESS_FILENAME }}
 
+        # Since the delete plan action always runs, we should clear the outfile.
+        # If the delete plan action fails, it can append to empty file and not to successful output.
+        rm ${{ env.OUT_FILENAME }}
+
     - name: 'Delete Plan File'
       if: ${{ always() }}
-      shell: 'bash'
-      working-directory: '${{ inputs.working_directory }}'
+      uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # ratchet:actions/github-script@v6
       env:
-        OUT_FILENAME: 'out_${{ github.run_id }}_${{ github.run_attempt }}.txt'
+        OUT_FILEPATH: '${{ inputs.working_directory }}/out_${{ github.run_id }}_${{ github.run_attempt }}.txt'
         GUARDIAN_PLAN_PREFIX: 'guardian-plans/${{ github.repository }}/${{ steps.get-pr.outputs.result }}/${{ inputs.working_directory }}'
-      run: |-
-        echo "# Delete Plan File" > ${{ env.OUT_FILENAME }}
-        gcloud storage rm --all-versions gs://${{ inputs.bucket_name }}/${{ env.GUARDIAN_PLAN_PREFIX }}/tfplan.binary 2>&1 | tee -a ${{ env.OUT_FILENAME }}
+      with:
+        script: |-
+          const fs = require("fs");
+          const { EOL } = require("os");
 
+          try {
+            const { Storage, IdempotencyStrategy } = require("@google-cloud/storage");
+            const bucketName = "${{ inputs.bucket_name }}";
+            const fileName = "${{ env.GUARDIAN_PLAN_PREFIX }}/tfplan.binary";
+
+            const storage = new Storage({
+              retryOptions: {
+                autoRetry: true,
+                retryDelayMultiplier: 3,
+                totalTimeout: 500,
+                maxRetryDelay: "${{ inputs.max_retry_delay }}",
+                maxRetries: "${{ inputs.max_retries }}",
+                idempotencyStrategy: IdempotencyStrategy.RetryAlways,
+              },
+            });
+
+            await storage
+              .bucket(bucketName)
+              .file(fileName)
+              .delete({ ignoreNotFound: true });
+          } catch (err) {
+            const errString = JSON.stringify(err, undefined, 2);
+            const errorData = `${EOL}${EOL}# Delete Plan File${EOL}Error: ${errString}`;
+
+            // Append here since this always runs, regardless of previous failures
+            fs.appendFileSync("${{ env.OUT_FILEPATH }}", errorData, { encoding: "utf8" });
+
+            core.error("Failed to delete plan file");
+            core.error(errString);
+            core.setFailed("Failed to delete plan file.");
+          }
+
+    # Precaution to ensure outfile exists to prevent unneccessary i/o errors
     - name: 'Ensure Outfile'
       if: ${{ failure() }}
       shell: 'bash'

--- a/.github/actions/plan/action.yml
+++ b/.github/actions/plan/action.yml
@@ -147,32 +147,55 @@ runs:
       run: |-
         cp ${{ env.OUT_FILENAME }} ${{ env.SUCCESS_FILENAME }}
 
+    - name: 'Setup Node'
+      uses: 'actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c' # ratchet:actions/setup-node@v3
+      with:
+        node-version: '16'
+
+    - name: 'Install Google Cloud Storage SDK'
+      shell: 'bash'
+      run: |-
+        npm install @google-cloud/storage@~6.9.5
+
     - name: 'Upload Plan File'
       uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # ratchet:actions/github-script@v6
       env:
-        OUT_FILENAME: 'out_${{ github.run_id }}_${{ github.run_attempt }}.txt'
+        OUT_FILEPATH: '${{ inputs.working_directory }}/out_${{ github.run_id }}_${{ github.run_attempt }}.txt'
         GUARDIAN_PLAN_PREFIX: 'guardian-plans/${{ github.repository }}/${{ github.event.pull_request.number }}/${{ inputs.working_directory }}'
       with:
-        github-token: '${{ github.token }}'
-        retries: '${{ inputs.max_retries }}'
         script: |-
+          const fs = require("fs");
+          const { EOL } = require("os");
+
           try {
             const { Storage, IdempotencyStrategy } = require("@google-cloud/storage");
+            const bucketName = "${{inputs.bucket_name}}";
+            const fileName = "${{inputs.working_directory }}/tfplan.binary";
+            const destFileName = "${{env.GUARDIAN_PLAN_PREFIX }}/tfplan.binary";
+
             const storage = new Storage({
               retryOptions: {
                 autoRetry: true,
                 retryDelayMultiplier: 3,
                 totalTimeout: 500,
-                maxRetryDelay: `${{ inputs.max_retries }}`,
-                maxRetries: `${{ inputs.max_retry_delay }}`,
+                maxRetryDelay: "${{inputs.max_retry_delay}}",
+                maxRetries: "${{inputs.max_retries}}",
                 idempotencyStrategy: IdempotencyStrategy.RetryAlways,
               },
             });
-            await storage.bucket(bucketName).upload(`${{ inputs.working_directory }}/tfplan.binary`, {
-              destination: `${{ env.GUARDIAN_PLAN_PREFIX }}/tfplan.binary`,
-            });
+
+            await storage
+              .bucket(bucketName)
+              .upload(fileName, { destination: destFileName });
           } catch (err) {
-            core.setFailed("Failed to delete ");
+            const errString = JSON.stringify(err, undefined, 2);
+            const errorData = `# Upload Plan File${EOL}Error: ${errString}`;
+
+            fs.writeFileSync("${{ env.OUT_FILEPATH }}", errorData, { encoding: "utf8" });
+
+            core.error("Failed to upload plan file");
+            core.error(errString);
+            core.setFailed("Failed to upload plan file");
           }
 
     - name: 'Ensure Outfile'

--- a/.github/actions/plan/action.yml
+++ b/.github/actions/plan/action.yml
@@ -39,10 +39,6 @@ inputs:
     description: 'The maxiumum number of retries when handling failures.'
     required: false
     default: '5'
-  base_retry_delay:
-    description: 'The base retry delay in seconds when handling failures.'
-    required: false
-    default: '2'
   max_retry_delay:
     description: 'The max retry delay in seconds when handling failures.'
     required: false
@@ -83,20 +79,6 @@ runs:
         protect_lockfile: '${{ inputs.protect_lockfile }}'
         terraform_wrapper: false
 
-    - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587' # ratchet:google-github-actions/setup-gcloud@v1
-
-    - name: 'Cloud SDK Config'
-      shell: 'bash'
-      working-directory: '${{ inputs.working_directory }}'
-      env:
-        OUT_FILENAME: 'out_${{ github.run_id }}_${{ github.run_attempt }}.txt'
-      run: |-
-        echo "# Cloud SDK Config" > ${{ env.OUT_FILENAME }}
-        gcloud config set storage/max_retries ${{ inputs.max_retries }} 2>&1 | tee -a ${{ env.OUT_FILENAME }}
-        gcloud config set storage/base_retry_delay ${{ inputs.base_retry_delay }} 2>&1 | tee -a ${{ env.OUT_FILENAME }}
-        gcloud config set storage/max_retry_delay ${{ inputs.max_retry_delay }} 2>&1 | tee -a ${{ env.OUT_FILENAME }}
-
     - name: 'Terraform Format'
       shell: 'bash'
       working-directory: '${{ inputs.working_directory }}'
@@ -105,7 +87,7 @@ runs:
         TF_IN_AUTOMATION: 'true' # tell terraform this is an automated workflow https://developer.hashicorp.com/terraform/tutorials/automation/automate-terraform#controlling-terraform-output-in-automation
       run: |-
         echo "# Terraform Format" > ${{ env.OUT_FILENAME }}
-        terraform fmt -check -diff -recursive -no-color 2>&1 | tee -a ${{ env.OUT_FILENAME }}
+        terraform fmt -check -diff -recursive 2>&1 | tee -a ${{ env.OUT_FILENAME }}
 
     - name: 'Terraform Init'
       shell: 'bash'
@@ -166,16 +148,32 @@ runs:
         cp ${{ env.OUT_FILENAME }} ${{ env.SUCCESS_FILENAME }}
 
     - name: 'Upload Plan File'
-      shell: 'bash'
-      working-directory: '${{ inputs.working_directory }}'
+      uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # ratchet:actions/github-script@v6
       env:
         OUT_FILENAME: 'out_${{ github.run_id }}_${{ github.run_attempt }}.txt'
         GUARDIAN_PLAN_PREFIX: 'guardian-plans/${{ github.repository }}/${{ github.event.pull_request.number }}/${{ inputs.working_directory }}'
-      run: |-
-        echo "# Upload Plan File" > ${{ env.OUT_FILENAME }}
-        gcloud storage cp \
-          tfplan.binary \
-          gs://${{ inputs.bucket_name }}/${{ env.GUARDIAN_PLAN_PREFIX }}/tfplan.binary 2>&1 | tee -a ${{ env.OUT_FILENAME }}
+      with:
+        github-token: '${{ github.token }}'
+        retries: '${{ inputs.max_retries }}'
+        script: |-
+          try {
+            const { Storage, IdempotencyStrategy } = require("@google-cloud/storage");
+            const storage = new Storage({
+              retryOptions: {
+                autoRetry: true,
+                retryDelayMultiplier: 3,
+                totalTimeout: 500,
+                maxRetryDelay: `${{ inputs.max_retries }}`,
+                maxRetries: `${{ inputs.max_retry_delay }}`,
+                idempotencyStrategy: IdempotencyStrategy.RetryAlways,
+              },
+            });
+            await storage.bucket(bucketName).upload(`${{ inputs.working_directory }}/tfplan.binary`, {
+              destination: `${{ env.GUARDIAN_PLAN_PREFIX }}/tfplan.binary`,
+            });
+          } catch (err) {
+            core.setFailed("Failed to delete ");
+          }
 
     - name: 'Ensure Outfile'
       if: ${{ failure() }}


### PR DESCRIPTION
#### Details

Intentionally did not use `google-github-actions/upload-cloud-storage` so the action can comment with errors when upload fails. Composite actions cannot use conditionals to trap errors from a previous action when using upload-cloud-storage.

#### Notes 

- Dropping gcloud saves about 190 MB in transfer time to download: https://cloud.google.com/sdk/docs/install#linux

- Adding setup-node is minimal cost as version 16 is already cached on the runner image: https://github.com/abcxyz/guardian/actions/runs/4645596462/jobs/8221519755#step:6:392

- Adding `google-cloud/storage` is ~838 kB unpacked, and should be minimal overhead as it will be most likely be zipped: https://www.npmjs.com/package/@google-cloud/storage