### PR TITLE
remove cli args from admin

### DIFF
--- a/.github/actions/admin/action.yml
+++ b/.github/actions/admin/action.yml
@@ -92,6 +92,5 @@ runs:
       working-directory: '${{ inputs.working_directory }}'
       env:
         TF_IN_AUTOMATION: 'true'
-        TF_CLI_ARGS: '-input=false'
       run: |-
         terraform ${{ inputs.command }}


### PR DESCRIPTION
Some commands dont have the input flag, so removing this as a cli option.