### PR TITLE
add change detection to limit plans/applies

### DIFF
--- a/.github/actions/directories/action.yml
+++ b/.github/actions/directories/action.yml
@@ -1,0 +1,74 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Guardian Directories'
+description: |-
+  Use this action to get a list of the Terraform directories to use with Guardian for your repository. Allowed directories are identified by containing a .guardian file.
+
+inputs:
+  detect_changes:
+    description: 'Uses the list of changed files to determine the directories run Guardian commands for.'
+    required: false
+    default: 'false'
+  directories:
+    description: 'A CSV list of directories to run Guardian commands for.'
+    required: false
+    default: ''
+
+outputs:
+  dirs:
+    description: 'The directories to use as inputs to Guardian actions.'
+    value: ${{ steps.get_dirs.outputs.dirs }}
+
+runs:
+  using: composite
+  steps:
+    - name: 'Get Directories'
+      id: 'get_dirs'
+      if: ${{ inputs.detect_changes == 'true' }}
+      shell: 'bash'
+      run: |-
+        DETECT_CHANGES="${{ inputs.detect_changes }}"
+
+        if [ "$DETECT_CHANGES" == "true" ]; then        
+          ALLOWED=$(find . -name '.guardian' | xargs dirname | cut -c 3- | sort | uniq)
+          MODIFIED=$(git diff HEAD~1 --name-only | xargs dirname | sort | uniq)
+
+          # Get the intersection of allowed and modified as an array
+          DIRS=$(comm -12 <(echo "$ALLOWED") <(echo "$MODIFIED") | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
+
+          echo "dirs=${DIRS}"
+          echo "dirs=${DIRS}" >> $GITHUB_OUTPUT
+          exit
+        fi
+
+        INPUT_DIRS="${{ inputs.directories }}"
+
+        if [ "$INPUT_DIRS" != "" ]; then
+          ALLOWED=$(find . -name '.guardian' | xargs dirname | cut -c 3- | sort | uniq)
+          REQUESTED=$(echo "$INPUT_DIRS" | sed 's/,[[:space:]]*/\n/g' | sort | uniq)
+
+          # Get the intersection of allowed and requested as an array
+          DIRS=$(comm -12 <(echo "$ALLOWED") <(echo "$REQUESTED") | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
+
+          echo "dirs=${DIRS}"
+          echo "dirs=${DIRS}" >> $GITHUB_OUTPUT
+          exit
+        fi
+
+        # Default to returning all directories with a .guardian file as an array
+        DIRS=$(find . -name '.guardian' | xargs dirname | cut -c 3- | sort | uniq | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
+
+        echo "dirs=${DIRS}"
+        echo "dirs=${DIRS}" >> $GITHUB_OUTPUT

--- a/.github/actions/directories/action.yml
+++ b/.github/actions/directories/action.yml
@@ -14,13 +14,17 @@
 
 name: 'Guardian Directories'
 description: |-
-  Use this action to get a list of the Terraform directories to use with Guardian for your repository. Allowed directories are identified by containing a .guardian file.
+  Use this action to get a list of the Terraform directories to use with Guardian for your repository. Guardian will find and use all directories that contain a Terraform backend as an allowlist.
 
 inputs:
   detect_changes:
     description: 'Uses the list of changed files to determine the directories run Guardian commands for.'
     required: false
     default: 'false'
+  terraform_directory:
+    description: 'A subfolder to use as the root of all Terraform configuration for this repository.'
+    required: false
+    default: '.'
   directories:
     description: 'A CSV list of directories to run Guardian commands for.'
     required: false
@@ -36,17 +40,21 @@ runs:
   steps:
     - name: 'Get Directories'
       id: 'get_dirs'
-      if: ${{ inputs.detect_changes == 'true' }}
       shell: 'bash'
       run: |-
+        TERRAFORM_GLOB=$(echo "./${{ inputs.terraform_directory }}/**/*.tf" | sed 's|././|./|g' | sed 's|//|/|g')
+        DIRS_WITH_BACKENDS=$(grep -E 'backend\s?".*"\s?{' $TERRAFORM_GLOB -l | xargs dirname | sed 's|^[\.?][/?]*||g' | sort | uniq)
+
+        echo "DIRS_WITH_BACKENDS=$DIRS_WITH_BACKENDS"
+
         DETECT_CHANGES="${{ inputs.detect_changes }}"
 
         if [ "$DETECT_CHANGES" == "true" ]; then        
-          ALLOWED=$(find . -name '.guardian' | xargs dirname | cut -c 3- | sort | uniq)
           MODIFIED=$(git diff HEAD~1 --name-only | xargs dirname | sort | uniq)
+          echo "MODIFIED=$MODIFIED"
 
-          # Get the intersection of allowed and modified as an array
-          DIRS=$(comm -12 <(echo "$ALLOWED") <(echo "$MODIFIED") | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
+          # Get the intersection of directories with backends and modified as an array
+          DIRS=$(comm -12 <(echo "$DIRS_WITH_BACKENDS") <(echo "$MODIFIED") | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
 
           echo "dirs=${DIRS}"
           echo "dirs=${DIRS}" >> $GITHUB_OUTPUT
@@ -56,19 +64,18 @@ runs:
         INPUT_DIRS="${{ inputs.directories }}"
 
         if [ "$INPUT_DIRS" != "" ]; then
-          ALLOWED=$(find . -name '.guardian' | xargs dirname | cut -c 3- | sort | uniq)
           REQUESTED=$(echo "$INPUT_DIRS" | sed 's/,[[:space:]]*/\n/g' | sort | uniq)
 
-          # Get the intersection of allowed and requested as an array
-          DIRS=$(comm -12 <(echo "$ALLOWED") <(echo "$REQUESTED") | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
+          # Get the intersection of directories with backends and requested as an array
+          DIRS=$(comm -12 <(echo "$DIRS_WITH_BACKENDS") <(echo "$REQUESTED") | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
 
           echo "dirs=${DIRS}"
           echo "dirs=${DIRS}" >> $GITHUB_OUTPUT
           exit
         fi
 
-        # Default to returning all directories with a .guardian file as an array
-        DIRS=$(find . -name '.guardian' | xargs dirname | cut -c 3- | sort | uniq | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
+        # Default to returning all directories with backends as an array
+        DIRS=$(echo "$DIRS_WITH_BACKENDS" | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
 
         echo "dirs=${DIRS}"
         echo "dirs=${DIRS}" >> $GITHUB_OUTPUT

--- a/.github/actions/directories/action.yml
+++ b/.github/actions/directories/action.yml
@@ -17,65 +17,93 @@ description: |-
   Use this action to get a list of the Terraform directories to use with Guardian for your repository. Guardian will find and use all directories that contain a Terraform backend as an allowlist.
 
 inputs:
-  detect_changes:
-    description: 'Uses the list of changed files to determine the directories run Guardian commands for.'
-    required: false
-    default: 'false'
-  terraform_directory:
-    description: 'A subfolder to use as the root of all Terraform configuration for this repository.'
-    required: false
-    default: '.'
   directories:
     description: 'A CSV list of directories to run Guardian commands for.'
     required: false
     default: ''
+  detect_plan_changes:
+    description: 'Use the pull request base and head refs to get all file changes to determine the directories run Guardian Plan commands for.'
+    required: false
+    default: 'false'
+  detect_apply_changes:
+    description: 'Use the respository default branch HEAD and HEAD~1 to get all file changes to determine the directories run Guardian Apply commands for.'
+    required: false
+    default: 'false'
 
 outputs:
-  dirs:
-    description: 'The directories to use as inputs to Guardian actions.'
-    value: ${{ steps.get_dirs.outputs.dirs }}
+  directories:
+    description: 'The directories with Terraform changes as configured by the action input.'
+    value: ${{ steps.plan_dirs.outputs.dirs || steps.apply_dirs.outputs.dirs || steps.dirs.outputs.dirs }}
 
 runs:
   using: composite
   steps:
     - name: 'Get Directories'
-      id: 'get_dirs'
+      id: 'dirs'
       shell: 'bash'
       run: |-
-        TERRAFORM_GLOB=$(echo "./${{ inputs.terraform_directory }}/**/*.tf" | sed 's|././|./|g' | sed 's|//|/|g')
-        DIRS_WITH_BACKENDS=$(grep -E 'backend\s?".*"\s?{' $TERRAFORM_GLOB -l | xargs dirname | sed 's|^[\.?][/?]*||g' | sort | uniq)
+        # Get Directories
 
-        echo "DIRS_WITH_BACKENDS=$DIRS_WITH_BACKENDS"
-
-        DETECT_CHANGES="${{ inputs.detect_changes }}"
-
-        if [ "$DETECT_CHANGES" == "true" ]; then        
-          MODIFIED=$(git diff HEAD~1 --name-only | xargs dirname | sort | uniq)
-          echo "MODIFIED=$MODIFIED"
-
-          # Get the intersection of directories with backends and modified as an array
-          DIRS=$(comm -12 <(echo "$DIRS_WITH_BACKENDS") <(echo "$MODIFIED") | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
-
-          echo "dirs=${DIRS}"
-          echo "dirs=${DIRS}" >> $GITHUB_OUTPUT
-          exit
-        fi
+        # Get all terraform file directores that contain a backend config
+        BACKEND_DIRS=$(find . -name "*.tf" | xargs grep -l 'backend ".*" {' | xargs dirname | sed 's|[\.?][/]*||g' | sort | uniq)
 
         INPUT_DIRS="${{ inputs.directories }}"
 
         if [ "$INPUT_DIRS" != "" ]; then
+          # Convert CSV string to newline delimited string for sorting (replace `, ` to `\n`)
           REQUESTED=$(echo "$INPUT_DIRS" | sed 's/,[[:space:]]*/\n/g' | sort | uniq)
 
           # Get the intersection of directories with backends and requested as an array
-          DIRS=$(comm -12 <(echo "$DIRS_WITH_BACKENDS") <(echo "$REQUESTED") | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
+          DIRS=$(comm -12 <(echo "$BACKEND_DIRS") <(echo "$REQUESTED") | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
 
-          echo "dirs=${DIRS}"
-          echo "dirs=${DIRS}" >> $GITHUB_OUTPUT
+          echo "dirs=$DIRS"
+          echo "dirs=$DIRS" >> $GITHUB_OUTPUT
           exit
         fi
 
         # Default to returning all directories with backends as an array
-        DIRS=$(echo "$DIRS_WITH_BACKENDS" | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
+        DIRS=$(echo "$BACKEND_DIRS" | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
 
-        echo "dirs=${DIRS}"
-        echo "dirs=${DIRS}" >> $GITHUB_OUTPUT
+        echo "dirs=$DIRS"
+        echo "dirs=$DIRS" >> $GITHUB_OUTPUT
+
+    - name: 'Get Plan Directories'
+      if: ${{ inputs.detect_plan_changes == 'true' }}
+      id: 'plan_dirs'
+      shell: 'bash'
+      run: |-
+        # Get Plan Directories
+
+        # Get all terraform file directores that contain a backend config
+        BACKEND_DIRS=$(find . -name "*.tf" | xargs grep -l 'backend ".*" {' | xargs dirname | sed 's|[\.?][/]*||g' | sort | uniq)
+
+        HEAD_REF="origin/${{ github.event.pull_request.head.ref }}"
+        BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
+
+        MODIFIED=$(git diff "$BASE_REF..$HEAD_REF" --name-only | xargs dirname | sort | uniq)
+        echo "MODIFIED=$MODIFIED"
+
+        # Get the intersection of directories with backends and modified as an array
+        DIRS=$(comm -12 <(echo "$BACKEND_DIRS") <(echo "$MODIFIED") | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
+
+        echo "dirs=$DIRS"
+        echo "dirs=$DIRS" >> $GITHUB_OUTPUT
+
+    - name: 'Get Apply Directories'
+      if: ${{ inputs.detect_apply_changes == 'true' }}
+      id: 'apply_dirs'
+      shell: 'bash'
+      run: |-
+        # Get Apply Directories
+
+        # Get all terraform file directores that contain a backend config
+        BACKEND_DIRS=$(find . -name "*.tf" | xargs grep -l 'backend ".*" {' | xargs dirname | sed 's|[\.?][/]*||g' | sort | uniq)
+
+        MODIFIED=$(git diff HEAD~1 --name-only | xargs dirname | sort | uniq)
+        echo "MODIFIED=$MODIFIED"
+
+        # Get the intersection of directories with backends and modified as an array
+        DIRS=$(comm -12 <(echo "$BACKEND_DIRS") <(echo "$MODIFIED") | jq -nRrc '[inputs|split("\n")] | flatten | tostring')
+
+        echo "dirs=$DIRS"
+        echo "dirs=$DIRS" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-admin.yml
+++ b/.github/workflows/test-admin.yml
@@ -38,7 +38,7 @@ jobs:
   init:
     runs-on: 'ubuntu-latest'
     outputs:
-      dirs: ${{ steps.dirs.outputs.dirs }}
+      directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
@@ -50,13 +50,14 @@ jobs:
           directories: '${{ inputs.directories }}'
 
   admin:
+    if: ${{ needs.init.outputs.directories != '[]' }}
     needs:
       - 'init'
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
-        working_directory: ${{ fromJSON(needs.init.outputs.dirs) }}
+        working_directory: ${{ fromJSON(needs.init.outputs.directories) }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3

--- a/.github/workflows/test-admin.yml
+++ b/.github/workflows/test-admin.yml
@@ -13,16 +13,17 @@
 # limitations under the License.
 
 name: 'test_guardian_admin'
-run-name: 'test_guardian_admin - ${{ inputs.command }} ${{ inputs.number }}'
+run-name: 'test_guardian_admin - ${{ inputs.command }}'
 
 on:
   workflow_dispatch:
     inputs:
       command:
-        description: 'COMMAND - The Terraform command to run including any arguments (this value is appended to the terraform command).'
+        description: 'COMMAND - The Terraform command to run including any arguments (this value is appended to the Terraform command).'
         required: true
-      number:
-        description: 'PR NUMBER - The Pull Request number to run the actions for (if blank, this runs for main).'
+      directories:
+        description: 'DIRECTORIES - A CSV list of directories execute the Terraform command in. If left blank, the Terraform command will run for all configured directories.'
+        type: string
 
 permissions:
   contents: 'read'
@@ -34,8 +35,28 @@ concurrency:
   group: '${{ github.workflow_ref }}'
 
 jobs:
-  admin:
+  init:
     runs-on: 'ubuntu-latest'
+    outputs:
+      dirs: ${{ steps.dirs.outputs.dirs }}
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: './.github/actions/directories'
+        with:
+          directories: '${{ inputs.directories }}'
+
+  admin:
+    needs:
+      - 'init'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        working_directory: ${{ fromJSON(needs.init.outputs.dirs) }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3
@@ -66,6 +87,5 @@ jobs:
           GITHUB_TOKEN: '${{ steps.mint-token.outputs.token }}'
         with:
           command: '${{ inputs.command }}'
-          number: '${{ inputs.number }}'
-          working_directory: 'terraform'
+          working_directory: '${{ matrix.working_directory }}'
           terraform_version: '1.3.6'

--- a/.github/workflows/test-apply.yml
+++ b/.github/workflows/test-apply.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
+        with:
+          fetch-depth: 2 # required to get diff between HEAD and HEAD-1
 
       - name: 'Guardian Directories'
         id: 'dirs'

--- a/.github/workflows/test-apply.yml
+++ b/.github/workflows/test-apply.yml
@@ -32,7 +32,7 @@ jobs:
   init:
     runs-on: 'ubuntu-latest'
     outputs:
-      dirs: ${{ steps.dirs.outputs.dirs }}
+      directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
@@ -43,16 +43,17 @@ jobs:
         id: 'dirs'
         uses: './.github/actions/directories'
         with:
-          detect_changes: 'true'
+          detect_apply_changes: 'true'
 
   apply:
+    if: ${{ needs.init.outputs.directories != '[]' }}
     needs:
       - 'init'
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
-        working_directory: ${{ fromJSON(needs.init.outputs.dirs) }}
+        working_directory: ${{ fromJSON(needs.init.outputs.directories) }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3

--- a/.github/workflows/test-apply.yml
+++ b/.github/workflows/test-apply.yml
@@ -29,8 +29,28 @@ concurrency:
   group: '${{ github.workflow_ref }}'
 
 jobs:
-  apply:
+  init:
     runs-on: 'ubuntu-latest'
+    outputs:
+      dirs: ${{ steps.dirs.outputs.dirs }}
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: './.github/actions/directories'
+        with:
+          detect_changes: 'true'
+
+  apply:
+    needs:
+      - 'init'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        working_directory: ${{ fromJSON(needs.init.outputs.dirs) }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3
@@ -60,6 +80,6 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ steps.mint-token.outputs.token }}'
         with:
-          working_directory: 'terraform'
+          working_directory: '${{ matrix.working_directory }}'
           bucket_name: '${{ vars.GUARDIAN_BUCKET_NAME }}'
           terraform_version: '1.3.6'

--- a/.github/workflows/test-plan.yml
+++ b/.github/workflows/test-plan.yml
@@ -42,7 +42,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 2 # required to get diff between HEAD and HEAD-1
 
       - name: 'Guardian Directories'
         id: 'dirs'
@@ -51,6 +51,7 @@ jobs:
           detect_changes: 'true'
 
   plan:
+    if: ${{ needs.init.outputs.dirs != '[]' }}
     needs:
       - 'init'
     runs-on: 'ubuntu-latest'
@@ -61,8 +62,6 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3
-        with:
-          ref: '${{ github.event.pull_request.head.ref }}'
 
       - name: 'Mint Token'
         id: 'mint-token'
@@ -94,6 +93,7 @@ jobs:
           terraform_version: '1.3.6'
 
   plan_success:
+    if: ${{ always() }}
     needs:
       - 'plan'
     runs-on: 'ubuntu-latest'
@@ -104,8 +104,14 @@ jobs:
           echo "All plans successful!"
           exit 0
 
-      - name: 'Failure'
-        if: ${{ needs.plan.result != 'success' }}
+      - name: 'Indeterminate'
+        if: ${{ contains(fromJSON('["skipped", "cancelled"]'), needs.plan.result) }}
         run: |-
-          echo "Plan run has failures."
+          echo "::warning Plans were skipped or cancelled."
+          exit 0
+
+      - name: 'Failure'
+        if: ${{ needs.plan.result == 'failure' }}
+        run: |-
+          echo "::error Plan has one or more failures."
           exit 1

--- a/.github/workflows/test-plan.yml
+++ b/.github/workflows/test-plan.yml
@@ -34,8 +34,30 @@ concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
 
 jobs:
-  plan:
+  init:
     runs-on: 'ubuntu-latest'
+    outputs:
+      dirs: ${{ steps.dirs.outputs.dirs }}
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: './.github/actions/directories'
+        with:
+          detect_changes: 'true'
+
+  plan:
+    needs:
+      - 'init'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        working_directory: ${{ fromJSON(needs.init.outputs.dirs) }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3
@@ -67,6 +89,23 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ steps.mint-token.outputs.token }}'
         with:
-          working_directory: 'terraform'
+          working_directory: '${{ matrix.working_directory }}'
           bucket_name: '${{ vars.GUARDIAN_BUCKET_NAME }}'
           terraform_version: '1.3.6'
+
+  plan_success:
+    needs:
+      - 'plan'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Success'
+        if: ${{ needs.plan.result == 'success' }}
+        run: |-
+          echo "All plans successful!"
+          exit 0
+
+      - name: 'Failure'
+        if: ${{ needs.plan.result != 'success' }}
+        run: |-
+          echo "Plan run has failures."
+          exit 1

--- a/.github/workflows/test-plan.yml
+++ b/.github/workflows/test-plan.yml
@@ -37,31 +37,34 @@ jobs:
   init:
     runs-on: 'ubuntu-latest'
     outputs:
-      dirs: ${{ steps.dirs.outputs.dirs }}
+      directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
+        uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3
         with:
-          fetch-depth: 2 # required to get diff between HEAD and HEAD-1
+          fetch-depth: 0
+          ref: '${{ github.event.pull_request.head.ref }}'
 
       - name: 'Guardian Directories'
         id: 'dirs'
         uses: './.github/actions/directories'
         with:
-          detect_changes: 'true'
+          detect_plan_changes: 'true'
 
   plan:
-    if: ${{ needs.init.outputs.dirs != '[]' }}
+    if: ${{ needs.init.outputs.directories != '[]' }}
     needs:
       - 'init'
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
-        working_directory: ${{ fromJSON(needs.init.outputs.dirs) }}
+        working_directory: ${{ fromJSON(needs.init.outputs.directories) }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3
+        with:
+          ref: '${{ github.event.pull_request.head.ref }}'
 
       - name: 'Mint Token'
         id: 'mint-token'
@@ -95,23 +98,24 @@ jobs:
   plan_success:
     if: ${{ always() }}
     needs:
+      - 'init'
       - 'plan'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Success'
-        if: ${{ needs.plan.result == 'success' }}
+        if: ${{ needs.init.result == 'success' && needs.plan.result == 'success' }}
         run: |-
           echo "All plans successful!"
           exit 0
 
-      - name: 'Indeterminate'
-        if: ${{ contains(fromJSON('["skipped", "cancelled"]'), needs.plan.result) }}
-        run: |-
-          echo "::warning Plans were skipped or cancelled."
-          exit 0
-
       - name: 'Failure'
-        if: ${{ needs.plan.result == 'failure' }}
+        if: ${{ needs.init.result == 'failure' || needs.plan.result == 'failure' }}
         run: |-
-          echo "::error Plan has one or more failures."
+          echo "::error ::Plan has one or more failures."
           exit 1
+
+      - name: 'Indeterminate'
+        if: ${{ contains(fromJSON('["skipped", "cancelled"]'), needs.init.result) || contains(fromJSON('["skipped", "cancelled"]'), needs.plan.result) }}
+        run: |-
+          echo "::warning ::Init or Plan was skipped or cancelled."
+          exit 0

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Branch protection is required to enable a safe and secure process. Ensuring thes
 - [x] Require signed commits (optional)
 - [x] Require linear history
 
+### Directories
+
+Guardian will only run Terraform commands for directories that have a Terraform [backend configuration](https://developer.hashicorp.com/terraform/language/settings/backends/configuration). This means if you add a new folder and you want Guardian to run the `terraform plan` and `terraform apply` commands from that directory as the root of the module, you should include a backend configuration within that directory.
+
 ### Creating Workflows
 
 To use Guardian in your repository, copy over the GitHub workflow YAMLs from the `examples` directory into your `.github/workflows` folder.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ The `Guardian Admin` workflow can be used to run commands manually as the servic
 - Fill out the inputs
   - BRANCH: Only works from the default branch e.g. `main`
   - COMMAND: The terraform command to run e.g. `apply -input=false -auto-approve`
-  - PR NUMBER: Run this command for a specific PR, the PR branch will be checked out before running the command
 
 ## Security
 
@@ -70,45 +69,3 @@ Branch protection is required to enable a safe and secure process. Ensuring thes
 ### Creating Workflows
 
 To use Guardian in your repository, copy over the GitHub workflow YAMLs from the `examples` directory into your `.github/workflows` folder.
-
-To run for multiple working directories, you can create a matrix strategy or use multiple jobs. The example workflows provided make use of a matrix strategy. If you need to use separate service accounts to different credentials, prefer using multiple jobs and provide separate inputs.
-
-```yaml
-apply_prod:
-  runs-on: "ubuntu-latest"
-  steps:
-    - name: "Checkout"
-      uses: "actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c" # ratchet:actions/checkout@v3
-
-    - name: "Authenticate to Google Cloud"
-      uses: "google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d" # ratchet:google-github-actions/auth@v1
-      with:
-        workload_identity_provider: "${{ vars.PROD_WIF_PROVIDER }}"
-        service_account: "${{ vars.PROD_WIF_SERVICE_ACCOUNT }}"
-
-    - name: "Guardian Apply"
-      uses: "abcxyz/guardian/.github/actions/apply@SHA" # TODO: pin this to the latest sha in the guardian repo
-      with:
-        working_directory: "${{ matrix.working_directory }}"
-        bucket_name: "${{ vars.GUARDIAN_BUCKET_NAME }}"
-        terraform_version: "1.3.6"
-
-apply_nonprod:
-  runs-on: "ubuntu-latest"
-  steps:
-    - name: "Checkout"
-      uses: "actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c" # ratchet:actions/checkout@v3
-
-    - name: "Authenticate to Google Cloud"
-      uses: "google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d" # ratchet:google-github-actions/auth@v1
-      with:
-        workload_identity_provider: "${{ vars.NON_PROD_WIF_PROVIDER }}"
-        service_account: "${{ vars.NON_PROD_WIF_SERVICE_ACCOUNT }}"
-
-    - name: "Guardian Apply"
-      uses: "abcxyz/guardian/.github/actions/apply@SHA" # TODO: pin this to the latest sha in the guardian repo
-      with:
-        working_directory: "${{ matrix.working_directory }}"
-        bucket_name: "${{ vars.GUARDIAN_BUCKET_NAME }}"
-        terraform_version: "1.3.6"
-```

--- a/examples/guardian-admin.yml
+++ b/examples/guardian-admin.yml
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'guardian_admin'
-run-name: 'Guardian Admin - ${{ inputs.command }} ${{ inputs.number }}'
+name: 'test_guardian_admin'
+run-name: 'test_guardian_admin - ${{ inputs.command }}'
 
 on:
   workflow_dispatch:
     inputs:
       command:
-        description: 'COMMAND - The Terraform command to run including any arguments (this value is appended to the terraform command).'
+        description: 'COMMAND - The Terraform command to run including any arguments (this value is appended to the Terraform command).'
         required: true
-      number:
-        description: 'PR NUMBER - The Pull Request number to run the actions for (if blank, runs for the repository default branch).'
+      directories:
+        description: 'DIRECTORIES - A CSV list of directories execute the Terraform command in. If left blank, the Terraform command will run for all configured directories.'
+        type: string
 
 permissions:
   contents: 'read'
@@ -34,13 +35,28 @@ concurrency:
   group: '${{ github.workflow_ref }}'
 
 jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      dirs: ${{ steps.dirs.outputs.dirs }}
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcyxz/guardian/.github/actions/directories@main' # TODO: pin this to the latest sha in the guardian repo
+        with:
+          directories: '${{ inputs.directories }}'
+
   admin:
+    needs:
+      - 'init'
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
-        working_directory:
-          - 'terraform' # TODO: update with repository working directories
+        working_directory: ${{ fromJSON(needs.init.outputs.dirs) }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3

--- a/examples/guardian-admin.yml
+++ b/examples/guardian-admin.yml
@@ -38,7 +38,7 @@ jobs:
   init:
     runs-on: 'ubuntu-latest'
     outputs:
-      dirs: ${{ steps.dirs.outputs.dirs }}
+      directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
@@ -50,13 +50,14 @@ jobs:
           directories: '${{ inputs.directories }}'
 
   admin:
+    if: ${{ needs.init.outputs.directories != '[]' }}
     needs:
       - 'init'
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
-        working_directory: ${{ fromJSON(needs.init.outputs.dirs) }}
+        working_directory: ${{ fromJSON(needs.init.outputs.directories) }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3

--- a/examples/guardian-apply.yml
+++ b/examples/guardian-apply.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
+        with:
+          fetch-depth: 2 # required to get diff between HEAD and HEAD-1
 
       - name: 'Guardian Directories'
         id: 'dirs'

--- a/examples/guardian-apply.yml
+++ b/examples/guardian-apply.yml
@@ -29,13 +29,28 @@ concurrency:
   group: '${{ github.workflow_ref }}'
 
 jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      dirs: ${{ steps.dirs.outputs.dirs }}
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@main' # TODO: pin this to the latest sha in the guardian repo
+        with:
+          detect_changes: 'true'
+
   apply:
+    needs:
+      - 'init'
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
-        working_directory:
-          - 'terraform' # TODO: update with repository working directories
+        working_directory: ${{ fromJSON(needs.init.outputs.dirs) }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3

--- a/examples/guardian-apply.yml
+++ b/examples/guardian-apply.yml
@@ -32,7 +32,7 @@ jobs:
   init:
     runs-on: 'ubuntu-latest'
     outputs:
-      dirs: ${{ steps.dirs.outputs.dirs }}
+      directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
@@ -43,16 +43,17 @@ jobs:
         id: 'dirs'
         uses: 'abcxyz/guardian/.github/actions/directories@main' # TODO: pin this to the latest sha in the guardian repo
         with:
-          detect_changes: 'true'
+          detect_apply_changes: 'true'
 
   apply:
+    if: ${{ needs.init.outputs.directories != '[]' }}
     needs:
       - 'init'
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
-        working_directory: ${{ fromJSON(needs.init.outputs.dirs) }}
+        working_directory: ${{ fromJSON(needs.init.outputs.directories) }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3

--- a/examples/guardian-plan.yml
+++ b/examples/guardian-plan.yml
@@ -36,28 +36,29 @@ jobs:
   init:
     runs-on: 'ubuntu-latest'
     outputs:
-      dirs: ${{ steps.dirs.outputs.dirs }}
+      directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
         with:
+          fetch-depth: 0
           ref: '${{ github.event.pull_request.head.ref }}'
-          fetch-depth: 2 # required to get diff between HEAD and HEAD-1
 
       - name: 'Guardian Directories'
         id: 'dirs'
         uses: 'abcxyz/guardian/.github/actions/directories@main' # TODO: pin this to the latest sha in the guardian repo
         with:
-          detect_changes: 'true'
+          detect_plan_changes: 'true'
 
   plan:
+    if: ${{ needs.init.outputs.directories != '[]' }}
     needs:
       - 'init'
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
-        working_directory: ${{ fromJSON(needs.init.outputs.dirs) }}
+        working_directory: ${{ fromJSON(needs.init.outputs.directories) }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3
@@ -97,11 +98,26 @@ jobs:
           # max_retry_delay: '60'  # default 60s
 
   plan_success:
-    if: ${{ jobs.plan.result == 'success' }}
+    if: ${{ always() }}
     needs:
+      - 'init'
       - 'plan'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Success'
+        if: ${{ needs.init.result == 'success' && needs.plan.result == 'success' }}
         run: |-
           echo "All plans successful!"
+          exit 0
+
+      - name: 'Failure'
+        if: ${{ needs.init.result == 'failure' || needs.plan.result == 'failure' }}
+        run: |-
+          echo "::error ::Plan has one or more failures."
+          exit 1
+
+      - name: 'Indeterminate'
+        if: ${{ contains(fromJSON('["skipped", "cancelled"]'), needs.init.result) || contains(fromJSON('["skipped", "cancelled"]'), needs.plan.result) }}
+        run: |-
+          echo "::warning ::Init or Plan was skipped or cancelled."
+          exit 0

--- a/examples/guardian-plan.yml
+++ b/examples/guardian-plan.yml
@@ -33,13 +33,30 @@ concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
 
 jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      dirs: ${{ steps.dirs.outputs.dirs }}
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@main' # TODO: pin this to the latest sha in the guardian repo
+        with:
+          detect_changes: 'true'
+
   plan:
+    needs:
+      - 'init'
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
-        working_directory:
-          - 'terraform' # TODO: update with repository working directories
+        working_directory: ${{ fromJSON(needs.init.outputs.dirs) }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3
@@ -71,10 +88,19 @@ jobs:
           bucket_name: '${{ vars.GUARDIAN_BUCKET_NAME }}'
           terraform_version: '1.3.6' # TODO: update with required terraform version
 
-
           # Optional:
           # protect_lockfile: true # default true
           # lock_timeout: '10m'    # default 10m
           # max_retries: '5'       # default 5
           # base_retry_delay: '2'  # default 2s
           # max_retry_delay: '60'  # default 60s
+
+  plan_success:
+    if: ${{ jobs.plan.result == 'success' }}
+    needs:
+      - 'plan'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Success'
+        run: |-
+          echo "All plans successful!"

--- a/examples/guardian-plan.yml
+++ b/examples/guardian-plan.yml
@@ -41,7 +41,8 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
         with:
-          fetch-depth: 2
+          ref: '${{ github.event.pull_request.head.ref }}'
+          fetch-depth: 2 # required to get diff between HEAD and HEAD-1
 
       - name: 'Guardian Directories'
         id: 'dirs'

--- a/terraform/child/.terraform.lock.hcl
+++ b/terraform/child/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.61.0"
+  constraints = ">= 4.45.0"
+  hashes = [
+    "h1:/Vz7xZfuNh2XR/tihF41QVbDPfvXimm3LQ9fFy/CB/s=",
+    "h1:RVUdU0scqcrWMr9/ItadGTgdxzZOCJ3EI2bQ8KT56so=",
+    "zh:05d6243b08fae8ea31c8ed01602e8803608761c89741814b5d78ecd90f0be83a",
+    "zh:1e377d9f4a27f10293fcfbf72250af410aee907de6a7ae82e6fa6b2ae7818d39",
+    "zh:3475fb54070337163faba1cdfb5c9e594e3e422df1e46b42cadbd478681f54c8",
+    "zh:55c3a1190ce1871768365577fdd2a518080f48d0fbd2da314438d9f9a36e518b",
+    "zh:890ff82e890850a32102075e0dc58a3e63f41b2021479209dd53ec82f67b479e",
+    "zh:91cb96cc1b4fc0ca86eb9eb529c4b11d70f7b468a83f40882b0efdb621f867a1",
+    "zh:b827b6ab8764f4aa410006dd5d078726303fe62c7b8847f9ca5d0f3e213070b6",
+    "zh:c3eac5ce6ec42eed310423348817f226030f3eac2dac7e799f303141ee411c81",
+    "zh:d0426bd21fda9754a279d1da1da40f7774fc321e34b3d73a320d11b73f649a5b",
+    "zh:f14137894838eb34f5d6f8a411b00f64f92a79de8fdb349bc26610e8bbc73077",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb75b8caf852189de72877585b1b27243c08451507d0770061410dcf2ae60e3a",
+  ]
+}
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "5.22.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:HSj4EZwLCNpz7XyAACAGqfRF6kipnr/PWV10sHClMb4=",
+    "h1:mmb5Tmm7GXwWgsjWkjevW221BQ/H1MnMffwq+0qtNrI=",
+    "zh:0213096dac52f010a6c39551cb40b25432cdbcd7e4dc4489bb7efa57fa5a6459",
+    "zh:024157904dfc4008951ba9ea0b63c287ed6efc1c9eddb714250d5cbdb5af5d2b",
+    "zh:1165acf5c62fc9e3017dd51007c3060519e3b74465cc152754c9383006af1d8f",
+    "zh:1629caa5949a49fa3b70ebd3139134d86e71fce889407f54db6769fe5dbd352d",
+    "zh:16c2557e54920383d4706eaee8c868c7925e0ed56d06fcdb7d41c69759da55fe",
+    "zh:201d87aa61f504393fab4b62d1c495d5707ebd1ed41072652afc6d0efa40e647",
+    "zh:5e21c2ce1b66eedb02507ac804dc40c99b3f58bfeaa792661b44bbc779199529",
+    "zh:7488f367669c6ab172222081de55dd82e017885d6dd63f946fdaee0fbd9f1eef",
+    "zh:76903dc808fd7123e1dc755d2da1005878bbabe0dc88c948dd4eeaa4a4be55c3",
+    "zh:82a3dbaa1cec2df55c29fba2a66f21ce439e07f8e9dc0363a7fd359e7d62b27e",
+    "zh:b820a096daaba7d12be42d22f2d57dfe86663f2179f9fd7ba8d47c39915efa71",
+    "zh:ebfa3022355d3dd35da2f07eb20fac87daf5130ed8c0c8f8b39cd0c80752f157",
+    "zh:ec7cada3edb2dd28ecb90f29044ec295e05ef0fff2921ec5401b62e9eccff039",
+    "zh:fc7e479651cc9c8425b99381f0dce892fdf8d391fae24117b59263096bb16b7a",
+  ]
+}

--- a/terraform/child/main.tf
+++ b/terraform/child/main.tf
@@ -1,0 +1,35 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  project_id = "guardian-ci-4cab"
+  name       = "test-child-app"
+}
+
+data "github_repository" "infra" {
+  full_name = "abcxyz/guardian"
+}
+
+resource "google_service_account" "default" {
+  project = local.project_id
+
+  account_id   = "${local.name}-${data.github_repository.infra.visibility}"
+  display_name = "${local.name} Service Account"
+  disabled     = true
+}
+
+output "service_account_name" {
+  description = "The service account name."
+  value       = google_service_account.default.name
+}

--- a/terraform/child/terraform.tf
+++ b/terraform/child/terraform.tf
@@ -1,0 +1,38 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = ">= 5.0"
+    }
+    google = {
+      version = ">= 4.45"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "guardian-terraform-state-4cab"
+    prefix = "state/test-child"
+  }
+}
+
+provider "google" {}
+
+provider "github" {
+  owner = "abcxyz"
+}


### PR DESCRIPTION
Adds the ability to detect git changes and only run guardian for those directories. 

A workflow job will be used to look for all terraform files with a `backend ".*" {` syntax. If a file exists in a directory with this syntax, it will be considered the root of a module and will be a target for plan/apply.

A second step will look for what files have changed and create the intersection between changed directories and the root directories.