### PR TITLE
add action to hide previous plan comments

### DIFF
--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -100,7 +100,7 @@ runs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: '${{ steps.get-pr.outputs.result }}',
-            body: `**\`🔱 Guardian 🔱\`** - 🟨 Running Apply in dir: \`${{inputs.working_directory}}\` [[logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})]`,
+            body: `**\`🔱 Guardian 🔱\`** - 🟨 **\`APPLY\`** Running for dir: \`${{inputs.working_directory}}\` [[logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})]`,
           });
           return prComment.id;
 
@@ -277,7 +277,7 @@ runs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             comment_id: '${{ steps.comment.outputs.result }}',
-            body: `**\`🔱 Guardian 🔱\`** - 🟥 Failed to run Apply in dir: \`${{inputs.working_directory}}\` [[logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})]\n
+            body: `**\`🔱 Guardian 🔱\`** - 🟥 **\`APPLY\`** Failed for dir: \`${{inputs.working_directory}}\` [[logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})]\n
           <details>
           <summary>Details</summary>\n
           \`\`\`diff\n
@@ -302,7 +302,7 @@ runs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             comment_id: '${{ steps.comment.outputs.result }}',
-            body: `**\`🔱 Guardian 🔱\`** - 🟩 Ran Apply in dir: \`${{inputs.working_directory}}\` [[logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})]\n
+            body: `**\`🔱 Guardian 🔱\`** - 🟩 **\`APPLY\`** Successful for dir: \`${{inputs.working_directory}}\` [[logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})]\n
           <details>
           <summary>Details</summary>\n
           \`\`\`diff\n

--- a/.github/actions/hide-plan-comments/action.yml
+++ b/.github/actions/hide-plan-comments/action.yml
@@ -1,0 +1,83 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Guardian Hide Previous Plan Comments'
+description: |-
+  Use this action to hide Guardian Plan comments from previous runs.
+
+runs:
+  using: composite
+  steps:
+    - name: 'Hide Previous Plan Comments'
+      uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # ratchet:actions/github-script@v6
+      with:
+        github-token: '${{ github.token }}'
+        retries: '${{ inputs.max_retries }}'
+        script: |-
+          const commentsQuery = `query paginate($cursor: String, $owner: String!, $repo: String!, $number: Int!) {
+            repository(owner: $owner, name: $repo) {
+              pullRequest(number: $number) {
+                comments(first: 100, after: $cursor) {
+                  nodes {
+                    id
+                    author {
+                      login
+                    }
+                    body
+                    bodyText
+                    isMinimized
+                  }
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                }
+              }
+            }
+          }`;
+
+          let hasNextPage = false;
+          const commentQueryOpts = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            number: context.issue.number,
+          };
+
+          const allComments = [];
+
+          do {
+            const commentsResponse = await github.graphql(commentsQuery, commentQueryOpts);
+            allComments.push(...commentsResponse.repository.pullRequest.comments.nodes)
+            hasNextPage = commentsResponse.repository.pullRequest.comments.pageInfo.hasNextPage;
+            commentQueryOpts.cursor = commentsResponse.repository.pullRequest.comments.pageInfo.endCursor;
+          } while (hasNextPage);
+
+          await Promise.all(
+            allComments
+              .filter(
+                (comment) =>
+                  comment.author.login == "github-actions" &&
+                  comment.bodyText.match(/^🔱 Guardian 🔱(.*)PLAN/g) &&
+                  !comment.isMinimized
+              )
+              .map(async (comment) => {
+                const minimizeCommentQuery = `mutation minimizeComment($id: ID!) {
+                  minimizeComment(input: { classifier: OUTDATED, subjectId: $id }) {
+                    clientMutationId
+                  }
+                }`;
+
+                await github.graphql(minimizeCommentQuery, { id: comment.id });
+              })
+          );

--- a/.github/actions/plan/action.yml
+++ b/.github/actions/plan/action.yml
@@ -66,7 +66,7 @@ runs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.issue.number,
-            body: `**\`🔱 Guardian 🔱\`** - 🟨 Running Plan in dir: \`${{inputs.working_directory}}\` [[logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})]`,
+            body: `**\`🔱 Guardian 🔱\`** - 🟨 **\`PLAN\`** Running for dir: \`${{inputs.working_directory}}\` [[logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})]`,
           });
           return prComment.id;
 
@@ -223,7 +223,7 @@ runs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             comment_id: '${{ steps.comment.outputs.result }}',
-            body: `**\`🔱 Guardian 🔱\`** - 🟥 Failed to run Plan in dir: \`${{inputs.working_directory}}\` [[logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})]\n
+            body: `**\`🔱 Guardian 🔱\`** - 🟥 **\`PLAN\`** Failed for dir: \`${{inputs.working_directory}}\` [[logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})]\n
           <details>
           <summary>Details</summary>\n
           \`\`\`diff\n
@@ -248,7 +248,7 @@ runs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             comment_id: '${{ steps.comment.outputs.result }}',
-            body: `**\`🔱 Guardian 🔱\`** - 🟩 Ran Plan in dir: \`${{inputs.working_directory}}\` [[logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})]\n
+            body: `**\`🔱 Guardian 🔱\`** - 🟩 **\`PLAN\`** Successful for dir: \`${{inputs.working_directory}}\` [[logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})]\n
           <details>
           <summary>Diff</summary>\n
           \`\`\`diff\n

--- a/.github/workflows/test-plan.yml
+++ b/.github/workflows/test-plan.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           detect_plan_changes: 'true'
 
+      - name: 'Guardian Hide Previous Plan Comments'
+        uses: './.github/actions/hide-plan-comments'
+
   plan:
     if: ${{ needs.init.outputs.directories != '[]' }}
     needs:

--- a/examples/guardian-plan.yml
+++ b/examples/guardian-plan.yml
@@ -50,6 +50,9 @@ jobs:
         with:
           detect_plan_changes: 'true'
 
+      - name: 'Guardian Hide Previous Plan Comments'
+        uses: 'abcxyz/guardian/.github/actions/hide-plan-comments@main' # TODO: pin this to the latest sha in the guardian repo
+
   plan:
     if: ${{ needs.init.outputs.directories != '[]' }}
     needs:

--- a/terraform/child/main.tf
+++ b/terraform/child/main.tf
@@ -14,7 +14,7 @@
 
 locals {
   project_id = "guardian-ci-4cab"
-  name       = "test-child-app"
+  name       = "test-child-app-change"
 }
 
 data "github_repository" "infra" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -14,7 +14,7 @@
 
 locals {
   project_id = "guardian-ci-4cab"
-  name       = "test-app"
+  name       = "test-app-change"
 }
 
 data "github_repository" "infra" {


### PR DESCRIPTION
Implemented an action to hide previous PR run comments. This is to help clean up PRs with multiple plan runs. Created as an action to provide opt-in functionality.