### PR TITLE
prevent apply re-runs and allow admin to prevent terraform init command

### DIFF
--- a/.github/actions/admin/action.yml
+++ b/.github/actions/admin/action.yml
@@ -23,6 +23,9 @@ inputs:
   number:
     description: 'PR NUMBER - The Pull Request number to run the actions for (if blank, this runs for the default branch).'
     required: false
+  terraform_init:
+    description: 'TERRAFORM_INIT - Run the Terraform Init command prior to running the admin command.'
+    default: 'true'
   working_directory:
     description: 'The working directory for Guardian to execute commands in.'
     required: false
@@ -67,8 +70,9 @@ runs:
       shell: 'bash'
       env:
         GITHUB_TOKEN: '${{ github.token }}'
+        NUMBER: '${{ inputs.number }}'
       run: |-
-        gh pr checkout ${{ inputs.number }}
+        gh pr checkout $NUMBER
 
     - name: 'Setup Terraform'
       uses: 'abcxyz/secure-setup-terraform@78e3f2fdfb7ebf59ce42141f6dd93bdd65bf04ed' # ratchet:abcxyz/secure-setup-terraform@v0.2.5
@@ -79,7 +83,9 @@ runs:
         protect_lockfile: '${{ inputs.protect_lockfile }}'
         terraform_wrapper: false
 
-    - name: 'Init'
+    - name: 'Terraform Init'
+      # only if inputs.terraform_init is a truthy value
+      if: ${{ contains(fromJSON('["true", "True", "TRUE", "1", "T", "t"]'), inputs.terraform_init) }}
       shell: 'bash'
       working-directory: '${{ inputs.working_directory }}'
       env:
@@ -92,5 +98,6 @@ runs:
       working-directory: '${{ inputs.working_directory }}'
       env:
         TF_IN_AUTOMATION: 'true'
+        COMMAND: '${{ inputs.command }}'
       run: |-
-        terraform ${{ inputs.command }}
+        terraform $COMMAND

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -47,6 +47,15 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: 'Validate Run Number'
+      if: ${{ github.run_number > 1 }}
+      shell: 'bash'
+      run: |-
+        MSG="Guardian Apply workflow re-run attempted. Guardian Apply workflows cannot be re-run. To run apply again, create another Pull Request or contact a repo admin."
+        echo "$MSG" > "${{ env.OUT_FILENAME }}"
+        echo "::error ::$MSG"
+        exit 1
+
     # must come first to ensure these exist to delete plan file on errors
     - name: 'Setup Node'
       uses: 'actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c' # ratchet:actions/setup-node@v3

--- a/.github/workflows/test-admin.yml
+++ b/.github/workflows/test-admin.yml
@@ -24,6 +24,13 @@ on:
       directories:
         description: 'DIRECTORIES - A CSV list of directories execute the Terraform command in. If left blank, the Terraform command will run for all configured directories.'
         type: string
+      terraform_init:
+        description: 'TERRAFORM_INIT - Run the Terraform Init command prior to running the admin command.'
+        type: 'choice'
+        options:
+          - 'true'
+          - 'false'
+        default: 'true'
 
 permissions:
   contents: 'read'
@@ -88,5 +95,6 @@ jobs:
           GITHUB_TOKEN: '${{ steps.mint-token.outputs.token }}'
         with:
           command: '${{ inputs.command }}'
+          terraform_init: '${{ inputs.terraform_init }}'
           working_directory: '${{ matrix.working_directory }}'
           terraform_version: '1.3.6'

--- a/examples/guardian-admin.yml
+++ b/examples/guardian-admin.yml
@@ -24,6 +24,13 @@ on:
       directories:
         description: 'DIRECTORIES - A CSV list of directories execute the Terraform command in. If left blank, the Terraform command will run for all configured directories.'
         type: string
+      terraform_init:
+        description: 'TERRAFORM_INIT - Run the Terraform Init command prior to running the admin command.'
+        type: 'choice'
+        options:
+          - 'true'
+          - 'false'
+        default: 'true'
 
 permissions:
   contents: 'read'
@@ -88,6 +95,7 @@ jobs:
         with:
           command: '${{ inputs.command }}'
           number: '${{ inputs.number }}'
+          terraform_init: '${{ inputs.terraform_init }}'
           working_directory: '${{ matrix.working_directory }}'
           terraform_version: '1.3.6' # TODO: update with required terraform version
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -14,7 +14,7 @@
 
 locals {
   project_id = "guardian-i-42c69c"
-  name       = "test-change"
+  name       = "test-change-update"
 }
 
 data "github_repository" "infra" {


### PR DESCRIPTION
fixes #81 - Prevent users from triggering a re-run of the apply command after merge
fixes #80 - Allow users to prevent running terraform init on admin operations