### PR TITLE
fix(drift): Output message for both click ops and missing tf changes

### DIFF
--- a/pkg/commands/drift/command.go
+++ b/pkg/commands/drift/command.go
@@ -123,7 +123,9 @@ func (c *DetectIamDriftCommand) Run(ctx context.Context, args []string) error {
 		uris := keys(iamDiff.ClickOpsChanges)
 		sort.Strings(uris)
 		c.Outf("Found Click Ops Changes \n> %s", strings.Join(uris, "\n> "))
-		c.Outf("\n\n"))
+		if len(iamDiff.MissingTerraformChanges) > 0 {
+			c.Outf("\n\n"))
+		}
 	}
 	if len(iamDiff.MissingTerraformChanges) > 0 {
 		uris := keys(iamDiff.MissingTerraformChanges)

--- a/pkg/commands/drift/command.go
+++ b/pkg/commands/drift/command.go
@@ -123,6 +123,7 @@ func (c *DetectIamDriftCommand) Run(ctx context.Context, args []string) error {
 		uris := keys(iamDiff.ClickOpsChanges)
 		sort.Strings(uris)
 		c.Outf("Found Click Ops Changes \n> %s", strings.Join(uris, "\n> "))
+		c.Outf("\n\n"))
 	}
 	if len(iamDiff.MissingTerraformChanges) > 0 {
 		uris := keys(iamDiff.MissingTerraformChanges)

--- a/pkg/commands/drift/command.go
+++ b/pkg/commands/drift/command.go
@@ -124,7 +124,7 @@ func (c *DetectIamDriftCommand) Run(ctx context.Context, args []string) error {
 		sort.Strings(uris)
 		c.Outf("Found Click Ops Changes \n> %s", strings.Join(uris, "\n> "))
 		if len(iamDiff.MissingTerraformChanges) > 0 {
-			c.Outf("\n\n"))
+			c.Outf("\n\n")
 		}
 	}
 	if len(iamDiff.MissingTerraformChanges) > 0 {


### PR DESCRIPTION
Currently the output is incorrectly formatted:
<img width="761" alt="Screenshot 2023-07-12 at 9 31 05 AM" src="https://github.com/abcxyz/guardian/assets/25069953/22021f5d-3295-4293-9475-766ea99de408">
