### PR TITLE
fix(drift): Context cancelled issue

### DIFF
--- a/pkg/commands/drift/drift.go
+++ b/pkg/commands/drift/drift.go
@@ -235,7 +235,7 @@ func (d *IAMDriftDetector) actualGCPIAM(ctx context.Context) (map[string]*iam.As
 	gcpIAM := make(map[string]*iam.AssetIAM)
 	for _, r := range iamResults {
 		if r.Error != nil {
-			return nil, fmt.Errorf("failed to execute IAM task: %w", err)
+			return nil, fmt.Errorf("failed to execute IAM task: %w", r.Error)
 		}
 		for _, iamF := range r.Value {
 			gcpIAM[d.URI(iamF)] = iamF
@@ -275,7 +275,7 @@ func (d *IAMDriftDetector) terraformStateIAM(ctx context.Context, gcsBuckets []s
 	tfIAM := make(map[string]*iam.AssetIAM)
 	for _, r := range iamResults {
 		if r.Error != nil {
-			return nil, fmt.Errorf("failed to execute IAM task: %w", err)
+			return nil, fmt.Errorf("failed to execute IAM task: %w", r.Error)
 		}
 		for _, iamF := range r.Value {
 			tfIAM[d.URI(iamF)] = iamF

--- a/pkg/commands/drift/drift_test.go
+++ b/pkg/commands/drift/drift_test.go
@@ -172,9 +172,9 @@ func TestDrift_DetectDrift(t *testing.T) {
 				t.Errorf("ProcessStates() failed to read json file %v", err)
 			}
 			gcsClient := &storage.MockStorageClient{
-				GetData:        string(data),
-				GetCancelFunc:  func() {},
-				ListObjectURIs: []string{bucketGCSURI},
+				DownloadData:       string(data),
+				DownloadCancelFunc: func() {},
+				ListObjectURIs:     []string{bucketGCSURI},
 			}
 			d := &IAMDriftDetector{
 				assetInventoryClient:  tc.assetInventoryClient,

--- a/pkg/commands/drift/drift_test.go
+++ b/pkg/commands/drift/drift_test.go
@@ -173,6 +173,7 @@ func TestDrift_DetectDrift(t *testing.T) {
 			}
 			gcsClient := &storage.MockStorageClient{
 				GetData:        string(data),
+				GetCancelFunc:  func() {},
 				ListObjectURIs: []string{bucketGCSURI},
 			}
 			d := &IAMDriftDetector{

--- a/pkg/storage/google_cloud_storage.go
+++ b/pkg/storage/google_cloud_storage.go
@@ -154,16 +154,16 @@ func (s *GoogleCloudStorage) UploadObject(ctx context.Context, bucket, name stri
 }
 
 // DownloadObject downloads an object from a Google Cloud Storage bucket. The caller must call Close on the returned Reader when done reading.
-func (s *GoogleCloudStorage) DownloadObject(ctx context.Context, bucket, name string) (io.ReadCloser, error) {
-	o, ctx, _ := s.objectHandleWithRetries(ctx, bucket, name)
-	// defer cancel()
+func (s *GoogleCloudStorage) DownloadObject(ctx context.Context, bucket, name string) (io.ReadCloser, context.CancelFunc, error) {
+	o, ctx, cancel := s.objectHandleWithRetries(ctx, bucket, name)
 
 	r, err := o.NewReader(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get google cloud storage reader: %w", err)
+		cancel()
+		return nil, nil, fmt.Errorf("failed to get google cloud storage reader: %w", err)
 	}
 
-	return r, nil
+	return r, cancel, nil
 }
 
 // ObjectMetadata gets the metadata for a Google Cloud Storage object.

--- a/pkg/storage/google_cloud_storage.go
+++ b/pkg/storage/google_cloud_storage.go
@@ -155,8 +155,8 @@ func (s *GoogleCloudStorage) UploadObject(ctx context.Context, bucket, name stri
 
 // DownloadObject downloads an object from a Google Cloud Storage bucket. The caller must call Close on the returned Reader when done reading.
 func (s *GoogleCloudStorage) DownloadObject(ctx context.Context, bucket, name string) (io.ReadCloser, error) {
-	o, ctx, cancel := s.objectHandleWithRetries(ctx, bucket, name)
-	defer cancel()
+	o, ctx, _ := s.objectHandleWithRetries(ctx, bucket, name)
+	// defer cancel()
 
 	r, err := o.NewReader(ctx)
 	if err != nil {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -28,7 +28,7 @@ type Storage interface {
 	UploadObject(ctx context.Context, bucket, name string, contents []byte, opts ...UploadOption) error
 
 	// DownloadObject downloads a blob storage object. The caller must call Close on the returned Reader when done reading.
-	DownloadObject(ctx context.Context, bucket, name string) (io.ReadCloser, error)
+	DownloadObject(ctx context.Context, bucket, name string) (io.ReadCloser, context.CancelFunc, error)
 
 	// ObjectMetadata gets metadata for a blob storage object.
 	ObjectMetadata(ctx context.Context, bucket, name string) (map[string]string, error)

--- a/pkg/storage/storage_mock.go
+++ b/pkg/storage/storage_mock.go
@@ -33,17 +33,15 @@ type MockStorageClient struct {
 	reqMu sync.Mutex
 	Reqs  []*Request
 
-	UploadErr      string
-	GetData        string
-	GetErr         string
-	GetCancelFunc  context.CancelFunc
-	GetLimitData   string
-	GetLimitErr    string
-	Metadata       map[string]string
-	MetadataErr    string
-	DeleteErr      string
-	ListObjectURIs []string
-	ListObjectErr  string
+	UploadErr          string
+	DownloadData       string
+	DownloadErr        string
+	DownloadCancelFunc context.CancelFunc
+	Metadata           map[string]string
+	MetadataErr        string
+	DeleteErr          string
+	ListObjectURIs     []string
+	ListObjectErr      string
 }
 
 type BufferReadCloser struct {
@@ -74,10 +72,10 @@ func (m *MockStorageClient) DownloadObject(ctx context.Context, bucket, name str
 		Params: []any{bucket, name},
 	})
 
-	if m.GetErr != "" {
-		return nil, nil, fmt.Errorf("%s", m.GetErr)
+	if m.DownloadErr != "" {
+		return nil, nil, fmt.Errorf("%s", m.DownloadErr)
 	}
-	return &BufferReadCloser{bytes.NewBufferString(m.GetData)}, m.GetCancelFunc, nil
+	return &BufferReadCloser{bytes.NewBufferString(m.DownloadData)}, m.DownloadCancelFunc, nil
 }
 
 func (m *MockStorageClient) ObjectMetadata(ctx context.Context, bucket, name string) (map[string]string, error) {

--- a/pkg/terraform/parser/parser.go
+++ b/pkg/terraform/parser/parser.go
@@ -123,10 +123,11 @@ func (p *TerraformParser) ProcessStates(ctx context.Context, gcsUris []string) (
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse GCS URI: %w", err)
 		}
-		r, err := p.GCS.DownloadObject(ctx, *bucket, *name)
+		r, cancel, err := p.GCS.DownloadObject(ctx, *bucket, *name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to download gcs URI for terraform: %w", err)
 		}
+		defer cancel()
 		defer r.Close()
 		lr := io.LimitReader(r, defaultTerraformStateFileSizeLimit)
 		if err := json.NewDecoder(lr).Decode(&state); err != nil {

--- a/pkg/terraform/parser/parser_test.go
+++ b/pkg/terraform/parser/parser_test.go
@@ -41,10 +41,12 @@ func TestParser_StateFileURIs(t *testing.T) {
 	}{
 		{
 			name: "success",
-			gcsClient: &storage.MockStorageClient{ListObjectURIs: []string{
-				"gs://my-bucket-123/abcsdasd/12312/default.tfstate",
-				"gs://my-bucket-123/abcsdasd/12313/default.tfstate",
-			}},
+			gcsClient: &storage.MockStorageClient{
+				ListObjectURIs: []string{
+					"gs://my-bucket-123/abcsdasd/12312/default.tfstate",
+					"gs://my-bucket-123/abcsdasd/12313/default.tfstate",
+				},
+			},
 			want: []string{
 				"gs://my-bucket-123/abcsdasd/12312/default.tfstate",
 				"gs://my-bucket-123/abcsdasd/12313/default.tfstate",
@@ -52,8 +54,10 @@ func TestParser_StateFileURIs(t *testing.T) {
 			gcsBuckets: []string{"my-bucket-123"},
 		},
 		{
-			name:       "failure",
-			gcsClient:  &storage.MockStorageClient{ListObjectErr: "Failed cause 404"},
+			name: "failure",
+			gcsClient: &storage.MockStorageClient{
+				ListObjectErr: "Failed cause 404",
+			},
 			gcsBuckets: []string{"my-bucket-123"},
 			wantErr:    "Failed cause 404",
 		},
@@ -209,7 +213,11 @@ func TestParser_ProcessStates(t *testing.T) {
 				t.Errorf("ProcessStates() failed to read json file %v", err)
 			}
 
-			gcsClient := &storage.MockStorageClient{GetData: string(data), GetErr: tc.wantErr}
+			gcsClient := &storage.MockStorageClient{
+				GetData:       string(data),
+				GetErr:        tc.wantErr,
+				GetCancelFunc: func() {},
+			}
 			p := &TerraformParser{GCS: gcsClient, OrganizationID: orgID}
 
 			if tc.knownFolders != nil && tc.knownProjects != nil {

--- a/pkg/terraform/parser/parser_test.go
+++ b/pkg/terraform/parser/parser_test.go
@@ -214,9 +214,9 @@ func TestParser_ProcessStates(t *testing.T) {
 			}
 
 			gcsClient := &storage.MockStorageClient{
-				GetData:       string(data),
-				GetErr:        tc.wantErr,
-				GetCancelFunc: func() {},
+				DownloadData:       string(data),
+				DownloadErr:        tc.wantErr,
+				DownloadCancelFunc: func() {},
 			}
 			p := &TerraformParser{GCS: gcsClient, OrganizationID: orgID}
 


### PR DESCRIPTION
Fails to download subsequent TF state files because the ctx::Cancel() was already called.