### PR TITLE
feat(drift): Support appending arbitrary message

### DIFF
--- a/.github/actions/iam-drift-detection/action.yml
+++ b/.github/actions/iam-drift-detection/action.yml
@@ -31,11 +31,15 @@ inputs:
     default: 'labels:terraform'
     required: false
   issue_assignees:
-    description: 'The assignees to use on the created github issue.'
+    description: 'A comma delimited list of assignees to assign the created github issue.'
+    default: ''
+    required: false
+  issue_mentions:
+    description: 'A comma delimited list of people or teams to mention in created github issue comment.'
     default: ''
     required: false
   issue_labels:
-    description: 'The label to use on the created github issue. This will be used to discover previously created issues and manage them.'
+    description: 'A comma delimited list of labels to use on the created github issue. This will be used to discover previously created issues and manage them.'
     default: 'guardian-iam-drift'
     required: false
   guardian_cli_version:
@@ -69,11 +73,15 @@ runs:
         GITHUB_OWNER: '${{ github.repository_owner }}'
         GITHUB_REPO: '${{ github.event.repository.name }}'
         ISSUE_ASSIGNEES: '${{ inputs.issue_assignees }}'
+        ISSUE_MENTIONS: '${{ inputs.issue_mentions }}'
         ISSUE_LABELS: '${{ inputs.issue_labels }}'
       run: |
         EXTRA_ARGS=()
         if [[ "$ISSUE_ASSIGNEES" != "" ]]; then
             EXTRA_ARGS+=(-github-issue-assignees="$ISSUE_ASSIGNEES")
+        fi
+        if [[ "$ISSUE_MENTIONS" != "" ]]; then
+            EXTRA_ARGS+=(-github-issue-mentions="$ISSUE_MENTIONS")
         fi
         DRIFTIGNORE_FILE="$(pwd)/.driftignore"
         diff_snippet="$(guardian detect-iam-drift \

--- a/.github/actions/iam-drift-detection/action.yml
+++ b/.github/actions/iam-drift-detection/action.yml
@@ -34,8 +34,8 @@ inputs:
     description: 'A comma delimited list of assignees to assign the created github issue.'
     default: ''
     required: false
-  issue_mentions:
-    description: 'A comma delimited list of people or teams to mention in created github issue comment.'
+  comment_message_append:
+    description: 'An arbitrary message to append to the created drift GitHub comments.'
     default: ''
     required: false
   issue_labels:
@@ -73,15 +73,12 @@ runs:
         GITHUB_OWNER: '${{ github.repository_owner }}'
         GITHUB_REPO: '${{ github.event.repository.name }}'
         ISSUE_ASSIGNEES: '${{ inputs.issue_assignees }}'
-        ISSUE_MENTIONS: '${{ inputs.issue_mentions }}'
         ISSUE_LABELS: '${{ inputs.issue_labels }}'
+        COMMENT_MESSAGE_APPEND: '${{ inputs.comment_message_append }}'
       run: |
         EXTRA_ARGS=()
         if [[ "$ISSUE_ASSIGNEES" != "" ]]; then
             EXTRA_ARGS+=(-github-issue-assignees="$ISSUE_ASSIGNEES")
-        fi
-        if [[ "$ISSUE_MENTIONS" != "" ]]; then
-            EXTRA_ARGS+=(-github-issue-mentions="$ISSUE_MENTIONS")
         fi
         DRIFTIGNORE_FILE="$(pwd)/.driftignore"
         diff_snippet="$(guardian detect-iam-drift \
@@ -91,6 +88,7 @@ runs:
           -github-owner="$GITHUB_OWNER" \
           -github-repo="$GITHUB_REPO" \
           -github-issue-labels="$ISSUE_LABELS" \
+          -github-comment-message-append="$COMMENT_MESSAGE_APPEND" \
           -driftignore-file="$DRIFTIGNORE_FILE" \
           "${EXTRA_ARGS[@]}")"
 

--- a/pkg/commands/drift/command.go
+++ b/pkg/commands/drift/command.go
@@ -42,6 +42,7 @@ type DetectIamDriftCommand struct {
 	flagGitHubRepo            string
 	flagGitHubIssueLabels     []string
 	flagGitHubIssueAssignees  []string
+	flagGitHubIssueMentions   []string
 }
 
 func (c *DetectIamDriftCommand) Desc() string {
@@ -119,6 +120,12 @@ func (c *DetectIamDriftCommand) Flags() *cli.FlagSet {
 		Usage:   `The assignees to assign to for any created GitHub Issues.`,
 	})
 	f.StringSliceVar(&cli.StringSliceVar{
+		Name:    "github-issue-mentions",
+		Target:  &c.flagGitHubIssueMentions,
+		Example: "dcreey, my-org/my-team",
+		Usage:   `The people or teams to mention on any new drift comments.`,
+	})
+	f.StringSliceVar(&cli.StringSliceVar{
 		Name:    "github-issue-labels",
 		Target:  &c.flagGitHubIssueLabels,
 		Example: "guardian-iam-drift",
@@ -172,7 +179,7 @@ func (c *DetectIamDriftCommand) Run(ctx context.Context, args []string) error {
 		return nil
 	}
 	if changesDetected {
-		if err := createOrUpdateIssue(ctx, c.flagGitHubToken, c.flagGitHubOwner, c.flagGitHubRepo, c.flagGitHubIssueAssignees, c.flagGitHubIssueLabels, m); err != nil {
+		if err := createOrUpdateIssue(ctx, c.flagGitHubToken, c.flagGitHubOwner, c.flagGitHubRepo, c.flagGitHubIssueAssignees, c.flagGitHubIssueMentions, c.flagGitHubIssueLabels, m); err != nil {
 			return fmt.Errorf("failed to create or update GitHub Issue: %w", err)
 		}
 	} else {

--- a/pkg/commands/drift/command.go
+++ b/pkg/commands/drift/command.go
@@ -17,6 +17,7 @@ package drift
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
@@ -32,17 +33,17 @@ type DetectIamDriftCommand struct {
 	// testFlagSetOpts is only used for testing.
 	testFlagSetOpts []cli.Option
 
-	flagOrganizationID        string
-	flagGCSBucketQuery        string
-	flagDriftignoreFile       string
-	flagMaxConcurrentRequests int64
-	flagSkipGitHubIssue       bool
-	flagGitHubToken           string
-	flagGitHubOwner           string
-	flagGitHubRepo            string
-	flagGitHubIssueLabels     []string
-	flagGitHubIssueAssignees  []string
-	flagGitHubIssueMentions   []string
+	flagOrganizationID             string
+	flagGCSBucketQuery             string
+	flagDriftignoreFile            string
+	flagMaxConcurrentRequests      int64
+	flagSkipGitHubIssue            bool
+	flagGitHubToken                string
+	flagGitHubOwner                string
+	flagGitHubRepo                 string
+	flagGitHubIssueLabels          []string
+	flagGitHubIssueAssignees       []string
+	flagGitHubCommentMessageAppend string
 }
 
 func (c *DetectIamDriftCommand) Desc() string {
@@ -120,17 +121,17 @@ func (c *DetectIamDriftCommand) Flags() *cli.FlagSet {
 		Usage:   `The assignees to assign to for any created GitHub Issues.`,
 	})
 	f.StringSliceVar(&cli.StringSliceVar{
-		Name:    "github-issue-mentions",
-		Target:  &c.flagGitHubIssueMentions,
-		Example: "dcreey, my-org/my-team",
-		Usage:   `The people or teams to mention on any new drift comments.`,
-	})
-	f.StringSliceVar(&cli.StringSliceVar{
 		Name:    "github-issue-labels",
 		Target:  &c.flagGitHubIssueLabels,
 		Example: "guardian-iam-drift",
 		Usage:   `The labels to use on any created GitHub Issues.`,
 		Default: []string{"guardian-iam-drift"},
+	})
+	f.StringVar(&cli.StringVar{
+		Name:    "github-comment-message-append",
+		Target:  &c.flagGitHubCommentMessageAppend,
+		Example: "@dcreey, @my-org/my-team",
+		Usage:   `Any arbitrary string message to append to the drift GitHub comment.`,
 	})
 
 	return set
@@ -178,8 +179,11 @@ func (c *DetectIamDriftCommand) Run(ctx context.Context, args []string) error {
 	if c.flagSkipGitHubIssue {
 		return nil
 	}
+	if c.flagGitHubCommentMessageAppend != "" {
+		m = strings.Join([]string{m, c.flagGitHubCommentMessageAppend}, "\n\n")
+	}
 	if changesDetected {
-		if err := createOrUpdateIssue(ctx, c.flagGitHubToken, c.flagGitHubOwner, c.flagGitHubRepo, c.flagGitHubIssueAssignees, c.flagGitHubIssueMentions, c.flagGitHubIssueLabels, m); err != nil {
+		if err := createOrUpdateIssue(ctx, c.flagGitHubToken, c.flagGitHubOwner, c.flagGitHubRepo, c.flagGitHubIssueAssignees, c.flagGitHubIssueLabels, m); err != nil {
 			return fmt.Errorf("failed to create or update GitHub Issue: %w", err)
 		}
 	} else {

--- a/pkg/commands/drift/github.go
+++ b/pkg/commands/drift/github.go
@@ -37,7 +37,7 @@ const (
         Re-run drift detection manually once complete to verify all diffs are properly resolved.`
 )
 
-func createOrUpdateIssue(ctx context.Context, token, owner, repo string, assignees, mentions, labels []string, message string) error {
+func createOrUpdateIssue(ctx context.Context, token, owner, repo string, assignees, labels []string, message string) error {
 	// Labels are used to uniquely identify Drift issues.
 	if len(labels) == 0 {
 		return fmt.Errorf("invalid argument - at least one 'label' must be provided")
@@ -63,13 +63,7 @@ func createOrUpdateIssue(ctx context.Context, token, owner, repo string, assigne
 		issueNumber = issues[0].Number
 	}
 
-	messageParts := []string{message}
-	for _, v := range mentions {
-		messageParts = append(messageParts, fmt.Sprintf("@%s", v))
-	}
-	commentBody := strings.Join(messageParts, "\n")
-
-	if _, err := gh.CreateIssueComment(ctx, owner, repo, issueNumber, commentBody); err != nil {
+	if _, err := gh.CreateIssueComment(ctx, owner, repo, issueNumber, message); err != nil {
 		return fmt.Errorf("failed to comment on issue %s/%s %d: %w", owner, repo, issueNumber, err)
 	}
 

--- a/pkg/commands/drift/github.go
+++ b/pkg/commands/drift/github.go
@@ -37,7 +37,7 @@ const (
         Re-run drift detection manually once complete to verify all diffs are properly resolved.`
 )
 
-func createOrUpdateIssue(ctx context.Context, token, owner, repo string, assignees, labels []string, message string) error {
+func createOrUpdateIssue(ctx context.Context, token, owner, repo string, assignees, mentions, labels []string, message string) error {
 	// Labels are used to uniquely identify Drift issues.
 	if len(labels) == 0 {
 		return fmt.Errorf("invalid argument - at least one 'label' must be provided")
@@ -63,7 +63,13 @@ func createOrUpdateIssue(ctx context.Context, token, owner, repo string, assigne
 		issueNumber = issues[0].Number
 	}
 
-	if _, err := gh.CreateIssueComment(ctx, owner, repo, issueNumber, message); err != nil {
+	messageParts := []string{message}
+	for _, v := range mentions {
+		messageParts = append(messageParts, fmt.Sprintf("@%s", v))
+	}
+	commentBody := strings.Join(messageParts, "\n")
+
+	if _, err := gh.CreateIssueComment(ctx, owner, repo, issueNumber, commentBody); err != nil {
 		return fmt.Errorf("failed to comment on issue %s/%s %d: %w", owner, repo, issueNumber, err)
 	}
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -120,12 +120,12 @@ func NewClient(ctx context.Context, token string, opts ...Option) *GitHubClient 
 
 // ListIssues lists all issues and returns their numbers in a repository matching the given criteria.
 func (g *GitHubClient) ListIssues(ctx context.Context, owner, repo string, opts *github.IssueListByRepoOptions) ([]*Issue, error) {
-	var uniqueResponses map[int]*Issue
-	var page *int // Use nil to indicate start of request.
-
 	pageStart := func(i *int) bool { return i == nil }
 	pageEnd := func(i *int) bool { return *i == 0 }
+	uniqueResponses := make(map[int]*Issue)
 	opt := *opts
+
+	var page *int // Use nil to indicate start of request.
 
 	for pageStart(page) || !pageEnd(page) {
 		if err := g.withRetries(ctx, func(ctx context.Context) error {


### PR DESCRIPTION
GitHub Issues do not support assigning to Teams. Instead you must mention them.

fix(drift): Init map for GitHub Issue List method

Tested: https://github.com/theteamatx/x-refinery-org/issues/206