### PR TITLE
feat(iam-cleanup): Add new subcommand for cleaning up IAM

### DIFF
--- a/cmd/guardian/main.go
+++ b/cmd/guardian/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/abcxyz/guardian/internal/version"
 	"github.com/abcxyz/guardian/pkg/commands/drift"
+	"github.com/abcxyz/guardian/pkg/commands/iamcleanup"
 	"github.com/abcxyz/guardian/pkg/commands/plan"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
@@ -59,6 +60,9 @@ var rootCmd = func() cli.Command {
 			// },
 			"detect-iam-drift": func() cli.Command {
 				return &drift.DetectIamDriftCommand{}
+			},
+			"iam-cleanup": func() cli.Command {
+				return &iamcleanup.IAMCleanupCommand{}
 			},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/asset v1.14.1
 	cloud.google.com/go/storage v1.31.0
 	github.com/abcxyz/pkg v0.5.0
+	github.com/google/cel-go v0.17.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v53 v53.2.0
 	github.com/googleapis/gax-go/v2 v2.12.0
@@ -15,6 +16,7 @@ require (
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/oauth2 v0.10.0
 	google.golang.org/api v0.132.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230717213848-3f92550aa753
 	google.golang.org/protobuf v1.31.0
 )
 
@@ -29,6 +31,7 @@ require (
 	cloud.google.com/go/osconfig v1.12.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
@@ -54,6 +57,7 @@ require (
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/sethvargo/go-envconfig v0.9.0 // indirect
 	github.com/zclconf/go-cty v1.13.2 // indirect
+	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
@@ -67,6 +71,5 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230717213848-3f92550aa753 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230717213848-3f92550aa753 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20230717213848-3f92550aa753 // indirect
 	google.golang.org/grpc v1.56.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -56,8 +56,8 @@ require (
 	github.com/posener/script v1.2.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/sethvargo/go-envconfig v0.9.0 // indirect
-	github.com/zclconf/go-cty v1.13.2 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
+	github.com/zclconf/go-cty v1.13.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/oauth2 v0.10.0
 	google.golang.org/api v0.132.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230717213848-3f92550aa753
+	google.golang.org/grpc v1.56.2
 	google.golang.org/protobuf v1.31.0
 )
 
@@ -71,5 +72,4 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230717213848-3f92550aa753 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230717213848-3f92550aa753 // indirect
-	google.golang.org/grpc v1.56.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/abcxyz/pkg v0.5.0/go.mod h1:+mrCPTB1XxtzHaBcogU7sjf12MFzlLNmWT5k8XQP6
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
+github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
@@ -82,6 +84,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/google/cel-go v0.17.0 h1:o8fqHUcM+0g5prwg4pHZR+EMdef2RBumnEYefCXAyPQ=
+github.com/google/cel-go v0.17.0/go.mod h1:HXZKzB0LXqer5lHHgfWAnlYwJaQBDKMjxjulNQzhwhY=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -147,6 +151,8 @@ github.com/sethvargo/go-githubactions v1.1.0 h1:mg03w+b+/s5SMS298/2G6tHv8P0w0VhU
 github.com/sethvargo/go-githubactions v1.1.0/go.mod h1:qIboSF7yq2Qnaw2WXDsqCReM0Lo1gU4QXUWmhBC3pxE=
 github.com/sethvargo/go-retry v0.2.4 h1:T+jHEQy/zKJf5s95UkguisicE0zuF9y7+/vgz08Ocec=
 github.com/sethvargo/go-retry v0.2.4/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=
+github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=
+github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/pkg/assetinventory/assetinventory.go
+++ b/pkg/assetinventory/assetinventory.go
@@ -47,6 +47,7 @@ var resourceNameIDPattern = regexp.MustCompile(`\/\/cloudresourcemanager\.google
 // resourceNamePattern is a Regex pattern used to parse name from the resource Name.
 var resourceNamePattern = regexp.MustCompile(`\/\/cloudresourcemanager\.googleapis\.com\/(?:folders|organizations|projects)\/(.*)`)
 
+// IAMCondition represents the IAM Condition for an IAM binding.
 type IAMCondition struct {
 	// The title of the IAM condition.
 	Title string
@@ -112,6 +113,7 @@ type AssetInventory interface {
 	IAM(ctx context.Context, scope, query string) ([]*AssetIAM, error)
 }
 
+// AssetInventoryClient exposes GCP Asset Inventory functionality.
 type AssetInventoryClient struct {
 	assetClient *asset.Client
 }

--- a/pkg/assetinventory/assetinventory.go
+++ b/pkg/assetinventory/assetinventory.go
@@ -30,15 +30,24 @@ import (
 const (
 	// Organization Node Type.
 	Organization = "Organization"
+
 	// Folder Node Type.
 	Folder = "Folder"
+
 	// Project Node Type.
 	Project = "Project"
 
+	// OrganizationAssetType represent the org asset type used in the cloud resource manager api.
 	OrganizationAssetType = "cloudresourcemanager.googleapis.com/Organization"
-	FolderAssetType       = "cloudresourcemanager.googleapis.com/Folder"
-	ProjectAssetType      = "cloudresourcemanager.googleapis.com/Project"
-	BucketAssetType       = "storage.googleapis.com/Bucket"
+
+	// FolderAssetType represent the folder asset type used in the cloud resource manager api.
+	FolderAssetType = "cloudresourcemanager.googleapis.com/Folder"
+
+	// ProjectAssetType represent the project asset type used in the cloud resource manager api.
+	ProjectAssetType = "cloudresourcemanager.googleapis.com/Project"
+
+	// BucketAssetType represent the bucket asset type used in the cloud resource manager api.
+	BucketAssetType = "storage.googleapis.com/Bucket"
 )
 
 // resourceNameIDPattern is a Regex pattern used to parse ID from the resource ParentFullResourceName.
@@ -49,50 +58,62 @@ var resourceNamePattern = regexp.MustCompile(`\/\/cloudresourcemanager\.googleap
 
 // IAMCondition represents the IAM Condition for an IAM binding.
 type IAMCondition struct {
-	// The title of the IAM condition.
+	// Title is the name of the IAM condition.
 	Title string
-	// The conditional expression describing when to apply the IAM policy.
+
+	// Expression describing when to apply the IAM policy.
 	Expression string
-	// The description of the IAM condition.
+
+	// Description of the IAM condition.
 	Description string
 }
 
 // AssetIAM represents the IAM of a GCP resource (e.g binding/policy/membership of GCP Project, Folder, Org).
 type AssetIAM struct {
-	// The ID of the resource (e.g. Project ID, Folder ID, Org ID).
+	// ResourceID is the ID of the resource (e.g. Project ID, Folder ID, Org ID).
 	ResourceID string
-	// The type of the resource (e.g. Project, Folder, Org).
+
+	// ResourceType is the type of the resource (e.g. Project, Folder, Org).
 	ResourceType string
-	// The IAM membership (e.g. group:my-group@google.com).
+
+	// Member is the IAM membership (e.g. group:my-group@google.com).
 	Member string
-	// The role (e.g. roles/owner).
+
+	// Role is the role of the IAM binding (e.g. roles/owner).
 	Role string
-	// The condition set on the iam.
+
+	// Condition is the condition set on the iam.
 	Condition *IAMCondition
 }
 
 // HierarchyNode represents a node in the GCP Resource Hierarchy.
 // Example: Organization, Folder, or Project.
 type HierarchyNode struct {
-	// The unique identifier of the GCP Organization, Folder, or Project
+	// ID is the unique identifier of the GCP Organization, Folder, or Project
 	// Example: 123123423423
 	ID string
-	// The unique string name of the Organization, Folder, or Project.
+
+	// Name is the unique string name of the Organization, Folder, or Project.
 	// Example: my-project-1234
 	Name string
-	// The unique identifier of the Folder or Organization this Folder or Project resides in.
+
+	// ParentID is the unique identifier of the Folder or Organization this Folder or Project resides in.
 	ParentID string
-	// The type of the parent node. Either Folder or Organization.
+
+	// ParentType is the type of the parent node. Either Folder or Organization.
 	ParentType string
-	// The type of node. Either Folder or Organization or Project
+
+	// NodeType is the type of node. Either Folder or Organization or Project
 	NodeType string
 }
 
 // HierarchyNodeWithChildren represents a node in the GCP Resource Hierarchy and all of its children.
 type HierarchyNodeWithChildren struct {
 	*HierarchyNode
+
 	// ProjectIDs contains the set of all projects that are immediate children of this node.
 	ProjectIDs []string
+
 	// FolderIDs contains the set of all folders that are immediate children of this node.
 	FolderIDs []string
 }
@@ -107,8 +128,10 @@ type HierarchyGraph struct {
 type AssetInventory interface {
 	// Buckets returns the GCS Buckets matching a given query.
 	Buckets(ctx context.Context, organizationID, query string) ([]string, error)
+
 	// HierarchyAssets returns the projects or folders in a given organization.
 	HierarchyAssets(ctx context.Context, organizationID, assetType string) ([]*HierarchyNode, error)
+
 	// IAM returns all IAM that matches the given query.
 	IAM(ctx context.Context, scope, query string) ([]*AssetIAM, error)
 }

--- a/pkg/assetinventory/assetinventory_mock.go
+++ b/pkg/assetinventory/assetinventory_mock.go
@@ -27,11 +27,20 @@ type Request struct {
 }
 
 type MockAssetInventoryClient struct {
-	BucketsErr       string
+	IAMData          []*AssetIAM
+	IAMErr           string
 	BucketsData      []string
+	BucketsErr       string
 	AssetFolderData  []*HierarchyNode
 	AssetProjectData []*HierarchyNode
 	AssetErr         string
+}
+
+func (m *MockAssetInventoryClient) IAM(ctx context.Context, scope, query string) ([]*AssetIAM, error) {
+	if m.IAMErr != "" {
+		return nil, fmt.Errorf("%s", m.IAMErr)
+	}
+	return m.IAMData, nil
 }
 
 func (m *MockAssetInventoryClient) Buckets(ctx context.Context, organizationID, query string) ([]string, error) {

--- a/pkg/commands/drift/command.go
+++ b/pkg/commands/drift/command.go
@@ -27,6 +27,7 @@ import (
 
 var _ cli.Command = (*DetectIamDriftCommand)(nil)
 
+// IAMCleanupCommand is a subcommand for Guardian that enables detecting IAM drift.
 type DetectIamDriftCommand struct {
 	cli.BaseCommand
 

--- a/pkg/commands/drift/command.go
+++ b/pkg/commands/drift/command.go
@@ -27,7 +27,7 @@ import (
 
 var _ cli.Command = (*DetectIamDriftCommand)(nil)
 
-// IAMCleanupCommand is a subcommand for Guardian that enables detecting IAM drift.
+// DetectIamDriftCommand is a subcommand for Guardian that enables detecting IAM drift.
 type DetectIamDriftCommand struct {
 	cli.BaseCommand
 
@@ -71,12 +71,14 @@ func (c *DetectIamDriftCommand) Flags() *cli.FlagSet {
 		Example: "123435456456",
 		Usage:   `The Google Cloud organization ID for which to detect drift.`,
 	})
+
 	f.StringVar(&cli.StringVar{
 		Name:    "gcs-bucket-query",
 		Target:  &c.flagGCSBucketQuery,
 		Example: "labels.terraform:*",
 		Usage:   `The label to use to find GCS buckets with Terraform statefiles.`,
 	})
+
 	f.StringVar(&cli.StringVar{
 		Name:    "driftignore-file",
 		Target:  &c.flagDriftignoreFile,
@@ -84,6 +86,7 @@ func (c *DetectIamDriftCommand) Flags() *cli.FlagSet {
 		Usage:   `The driftignore file to use which contains values to ignore.`,
 		Default: ".driftignore",
 	})
+
 	f.Int64Var(&cli.Int64Var{
 		Name:    "max-conncurrent-requests",
 		Target:  &c.flagMaxConcurrentRequests,
@@ -91,6 +94,7 @@ func (c *DetectIamDriftCommand) Flags() *cli.FlagSet {
 		Usage:   `The maximum number of concurrent requests allowed at any time to GCP.`,
 		Default: 10,
 	})
+
 	f.BoolVar(&cli.BoolVar{
 		Name:    "skip-github-issue",
 		Target:  &c.flagSkipGitHubIssue,
@@ -98,29 +102,34 @@ func (c *DetectIamDriftCommand) Flags() *cli.FlagSet {
 		Usage:   `Whether or not to create a GitHub Issue when a drift is detected.`,
 		Default: false,
 	})
+
 	f.StringVar(&cli.StringVar{
 		Name:   "github-token",
 		Target: &c.flagGitHubToken,
 		Usage:  `The github token to use to authenticate to create & manage GitHub Issues.`,
 		EnvVar: "GITHUB_TOKEN",
 	})
+
 	f.StringVar(&cli.StringVar{
 		Name:   "github-owner",
 		Target: &c.flagGitHubOwner,
 		Usage:  `The github token to use to authenticate to create & manage GitHub Issues.`,
 	})
+
 	f.StringVar(&cli.StringVar{
 		Name:    "github-repo",
 		Target:  &c.flagGitHubRepo,
 		Example: "guardian",
 		Usage:   `The github token to use to authenticate to create & manage GitHub Issues.`,
 	})
+
 	f.StringSliceVar(&cli.StringSliceVar{
 		Name:    "github-issue-assignees",
 		Target:  &c.flagGitHubIssueAssignees,
 		Example: "dcreey",
 		Usage:   `The assignees to assign to for any created GitHub Issues.`,
 	})
+
 	f.StringSliceVar(&cli.StringSliceVar{
 		Name:    "github-issue-labels",
 		Target:  &c.flagGitHubIssueLabels,
@@ -128,6 +137,7 @@ func (c *DetectIamDriftCommand) Flags() *cli.FlagSet {
 		Usage:   `The labels to use on any created GitHub Issues.`,
 		Default: []string{"guardian-iam-drift"},
 	})
+
 	f.StringVar(&cli.StringVar{
 		Name:    "github-comment-message-append",
 		Target:  &c.flagGitHubCommentMessageAppend,

--- a/pkg/commands/drift/drift.go
+++ b/pkg/commands/drift/drift.go
@@ -49,7 +49,7 @@ func NewIAMDriftDetector(ctx context.Context, organizationID string, maxConcurre
 		return nil, fmt.Errorf("failed to initialize assets client: %w", err)
 	}
 
-	iamClient, err := iam.NewClient(ctx, nil)
+	iamClient, err := iam.NewClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize iam client: %w", err)
 	}

--- a/pkg/commands/drift/drift_test.go
+++ b/pkg/commands/drift/drift_test.go
@@ -48,31 +48,31 @@ var (
 		ParentID:   folder.ID,
 		ParentType: assetinventory.Folder,
 	}
-	orgGroupBrowser = &iam.AssetIAM{
+	orgGroupBrowser = &assetinventory.AssetIAM{
 		ResourceID:   "1231231",
 		ResourceType: "Organization",
 		Member:       "group:my-group@google.com",
 		Role:         "roles/browser",
 	}
-	orgSABrowser = &iam.AssetIAM{
+	orgSABrowser = &assetinventory.AssetIAM{
 		ResourceID:   "1231231",
 		ResourceType: "Organization",
 		Member:       "serviceAccount:my-service-account@my-project.iam.gserviceaccount.com",
 		Role:         "roles/browser",
 	}
-	orgUserBrowser = &iam.AssetIAM{
+	orgUserBrowser = &assetinventory.AssetIAM{
 		ResourceID:   "1231231",
 		ResourceType: "Organization",
 		Member:       "user:dcreey@google.com",
 		Role:         "roles/browser",
 	}
-	folderViewer = &iam.AssetIAM{
+	folderViewer = &assetinventory.AssetIAM{
 		ResourceID:   "123123123123",
 		ResourceType: "Folder",
 		Member:       "group:my-group@google.com",
 		Role:         "roles/viewer",
 	}
-	projectAdmin = &iam.AssetIAM{
+	projectAdmin = &assetinventory.AssetIAM{
 		ResourceID:   "1231232222",
 		ResourceType: "Project",
 		Member:       "serviceAccount:my-service-account@my-project.iam.gserviceaccount.com",
@@ -101,9 +101,9 @@ func TestDrift_DetectDrift(t *testing.T) {
 				BucketsData:      []string{bucket},
 			},
 			iamClient: &iam.MockIAMClient{
-				OrgData:     []*iam.AssetIAM{orgSABrowser, orgGroupBrowser, orgUserBrowser},
-				FolderData:  []*iam.AssetIAM{folderViewer},
-				ProjectData: []*iam.AssetIAM{projectAdmin},
+				OrgData:     []*assetinventory.AssetIAM{orgSABrowser, orgGroupBrowser, orgUserBrowser},
+				FolderData:  []*assetinventory.AssetIAM{folderViewer},
+				ProjectData: []*assetinventory.AssetIAM{projectAdmin},
 			},
 			want: &IAMDrift{
 				ClickOpsChanges:         map[string]struct{}{},
@@ -119,9 +119,9 @@ func TestDrift_DetectDrift(t *testing.T) {
 				BucketsData:      []string{bucket},
 			},
 			iamClient: &iam.MockIAMClient{
-				OrgData:     []*iam.AssetIAM{orgSABrowser, orgGroupBrowser, orgUserBrowser},
-				FolderData:  []*iam.AssetIAM{folderViewer},
-				ProjectData: []*iam.AssetIAM{projectAdmin},
+				OrgData:     []*assetinventory.AssetIAM{orgSABrowser, orgGroupBrowser, orgUserBrowser},
+				FolderData:  []*assetinventory.AssetIAM{folderViewer},
+				ProjectData: []*assetinventory.AssetIAM{projectAdmin},
 			},
 			want: &IAMDrift{
 				ClickOpsChanges: map[string]struct{}{
@@ -143,9 +143,9 @@ func TestDrift_DetectDrift(t *testing.T) {
 				BucketsData:      []string{bucket},
 			},
 			iamClient: &iam.MockIAMClient{
-				OrgData:     []*iam.AssetIAM{},
-				FolderData:  []*iam.AssetIAM{},
-				ProjectData: []*iam.AssetIAM{},
+				OrgData:     []*assetinventory.AssetIAM{},
+				FolderData:  []*assetinventory.AssetIAM{},
+				ProjectData: []*assetinventory.AssetIAM{},
 			},
 			want: &IAMDrift{
 				ClickOpsChanges: map[string]struct{}{},

--- a/pkg/commands/drift/driftignore.go
+++ b/pkg/commands/drift/driftignore.go
@@ -25,7 +25,6 @@ import (
 	"github.com/abcxyz/pkg/logging"
 
 	"github.com/abcxyz/guardian/pkg/assetinventory"
-	"github.com/abcxyz/guardian/pkg/iam"
 )
 
 type ignoredAssets struct {
@@ -103,8 +102,8 @@ func filterDefaultURIs(uris map[string]struct{}) map[string]struct{} {
 }
 
 // filterIgnored removes any asset iam that is in the ignored assets.
-func filterIgnored(values map[string]*iam.AssetIAM, ignored *ignoredAssets) map[string]*iam.AssetIAM {
-	filtered := make(map[string]*iam.AssetIAM)
+func filterIgnored(values map[string]*assetinventory.AssetIAM, ignored *ignoredAssets) map[string]*assetinventory.AssetIAM {
+	filtered := make(map[string]*assetinventory.AssetIAM)
 	for k, a := range values {
 		if _, ok := ignored.roles[roleURI(a)]; ok {
 			continue
@@ -238,6 +237,6 @@ func mergeSets(setA, setB map[string]struct{}) {
 	}
 }
 
-func roleURI(a *iam.AssetIAM) string {
+func roleURI(a *assetinventory.AssetIAM) string {
 	return fmt.Sprintf("/%s/%s", a.Role, a.Member)
 }

--- a/pkg/commands/iamcleanup/command.go
+++ b/pkg/commands/iamcleanup/command.go
@@ -67,7 +67,7 @@ func (c *IAMCleanupCommand) Flags() *cli.FlagSet {
 	f.StringVar(&cli.StringVar{
 		Name:    "iam-query",
 		Target:  &c.flagIAMQuery,
-		Example: "organizations/123456",
+		Example: "policy:abcxyz-aod-expiry",
 		Usage:   `The query to use to filter on IAM.`,
 	})
 	f.BoolVar(&cli.BoolVar{
@@ -118,7 +118,7 @@ func (c *IAMCleanupCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("missing -scope")
 	}
 
-	iamCleaner, err := NewIAMCleaner(ctx, c.flagMaxConcurrentRequests)
+	iamCleaner, err := NewIAMCleaner(ctx, c.flagMaxConcurrentRequests, c.flagWorkingDirectory)
 	if err != nil {
 		return fmt.Errorf("failed to create iam cleaner: %w", err)
 	}

--- a/pkg/commands/iamcleanup/command.go
+++ b/pkg/commands/iamcleanup/command.go
@@ -65,22 +65,24 @@ func (c *IAMCleanupCommand) Flags() *cli.FlagSet {
 		Usage: `The scope to cleanup IAM for - organizations/123456 will cleanup all 
 		IAM matching your query in the organization and all folders and projects beneath it.`,
 	})
+
 	f.StringVar(&cli.StringVar{
 		Name:    "iam-query",
 		Target:  &c.flagIAMQuery,
 		Example: "policy:abcxyz-aod-expiry",
 		Usage:   `The query to use to filter on IAM.`,
 	})
+
 	f.BoolVar(&cli.BoolVar{
 		Name:    "disable-evaluate-condition",
 		Target:  &c.flagDisableEvaluateCondition,
 		Example: "true",
-		Default: false,
 		Usage: `Whether or not to evaluate the IAM Condition Expression and only delete
 		those IAM with false evaluation. Defaults to false.
 		Example: An IAM condition with expression 'request.time < timestamp("2019-01-01T00:00:00Z")'
 		will evaluate to false and the IAM will be deleted.`,
 	})
+
 	f.Int64Var(&cli.Int64Var{
 		Name:    "max-conncurrent-requests",
 		Target:  &c.flagMaxConcurrentRequests,

--- a/pkg/commands/iamcleanup/command.go
+++ b/pkg/commands/iamcleanup/command.go
@@ -1,0 +1,130 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iamcleanup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/abcxyz/pkg/cli"
+	"github.com/abcxyz/pkg/logging"
+
+	"github.com/abcxyz/guardian/internal/version"
+)
+
+var _ cli.Command = (*IAMCleanupCommand)(nil)
+
+type IAMCleanupCommand struct {
+	cli.BaseCommand
+
+	// testFlagSetOpts is only used for testing.
+	testFlagSetOpts []cli.Option
+
+	flagScope                 string
+	flagIAMQuery              string
+	flagExpiredOnly           bool
+	flagMaxConcurrentRequests int64
+	flagWorkingDirectory      string
+}
+
+func (c *IAMCleanupCommand) Desc() string {
+	return `Detect IAM drift in a GCP organization`
+}
+
+func (c *IAMCleanupCommand) Help() string {
+	return `
+Usage: {{ COMMAND }} [options]
+
+  Detect IAM drift in a GCP organization.
+`
+}
+
+func (c *IAMCleanupCommand) Flags() *cli.FlagSet {
+	set := cli.NewFlagSet(c.testFlagSetOpts...)
+
+	// Command options
+	f := set.NewSection("COMMAND OPTIONS")
+
+	f.StringVar(&cli.StringVar{
+		Name:    "scope",
+		Target:  &c.flagScope,
+		Example: "123435456456",
+		Usage: `The scope to cleanup IAM for - organizations/123456 will cleanup all 
+		IAM matching your query in the organization and all folders and projects beneath it.`,
+	})
+	f.StringVar(&cli.StringVar{
+		Name:    "iam-query",
+		Target:  &c.flagIAMQuery,
+		Example: "organizations/123456",
+		Usage:   `The query to use to filter on IAM.`,
+	})
+	f.BoolVar(&cli.BoolVar{
+		Name:    "expired-only",
+		Target:  &c.flagExpiredOnly,
+		Example: "false",
+		Usage:   `Whether or not to delete only IAM with time-based conditions that have expired. Defaults to true.`,
+		Default: true,
+	})
+	f.Int64Var(&cli.Int64Var{
+		Name:    "max-conncurrent-requests",
+		Target:  &c.flagMaxConcurrentRequests,
+		Example: "10",
+		Usage:   `The maximum number of concurrent requests allowed at any time to GCP.`,
+		Default: 10,
+	})
+	f.StringVar(&cli.StringVar{
+		Name:    "working-directory",
+		Target:  &c.flagWorkingDirectory,
+		Example: "terraform",
+		EnvVar:  "INPUTS_WORKING_DIRECTORY",
+		Usage:   "The working directory for Guardian to execute commands in.",
+	})
+
+	return set
+}
+
+func (c *IAMCleanupCommand) Run(ctx context.Context, args []string) error {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+
+	logger := logging.FromContext(ctx)
+
+	args = f.Args()
+	if len(args) > 0 {
+		return fmt.Errorf("unexpected arguments: %q", args)
+	}
+
+	logger.Debugw("Running IAM Cleanup...",
+		"name", version.Name,
+		"commit", version.Commit,
+		"version", version.Version)
+
+	if c.flagScope == "" {
+		return fmt.Errorf("missing -scope")
+	}
+
+	iamCleaner, err := NewIAMCleaner(ctx, c.flagMaxConcurrentRequests)
+	if err != nil {
+		return fmt.Errorf("failed to create iam cleaner: %w", err)
+	}
+	if err := iamCleaner.Do(ctx, c.flagScope, c.flagIAMQuery, c.flagExpiredOnly); err != nil {
+		return fmt.Errorf("failed to cleanup iam: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/commands/iamcleanup/command.go
+++ b/pkg/commands/iamcleanup/command.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package iamcleanup provides the functionality to cleanup IAM memberships.
 package iamcleanup
 
 import (
@@ -26,6 +27,7 @@ import (
 
 var _ cli.Command = (*IAMCleanupCommand)(nil)
 
+// IAMCleanupCommand is a subcommand for Guardian that enables cleaning up IAM.
 type IAMCleanupCommand struct {
 	cli.BaseCommand
 

--- a/pkg/commands/iamcleanup/command.go
+++ b/pkg/commands/iamcleanup/command.go
@@ -34,7 +34,7 @@ type IAMCleanupCommand struct {
 
 	flagScope                 string
 	flagIAMQuery              string
-	flagExpiredOnly           bool
+	flagEvaluateCondition     bool
 	flagMaxConcurrentRequests int64
 	flagWorkingDirectory      string
 }
@@ -71,11 +71,14 @@ func (c *IAMCleanupCommand) Flags() *cli.FlagSet {
 		Usage:   `The query to use to filter on IAM.`,
 	})
 	f.BoolVar(&cli.BoolVar{
-		Name:    "expired-only",
-		Target:  &c.flagExpiredOnly,
+		Name:    "evaluate-condition",
+		Target:  &c.flagEvaluateCondition,
 		Example: "false",
-		Usage:   `Whether or not to delete only IAM with time-based conditions that have expired. Defaults to true.`,
 		Default: true,
+		Usage: `Whether or not to evaluate the IAM Condition Expression and only delete
+		those IAM with false evaluation. Defaults to true.
+		Example: An IAM condition with expression 'request.time < timestamp("2019-01-01T00:00:00Z")'
+		will evaluate to false and the IAM will be deleted.`,
 	})
 	f.Int64Var(&cli.Int64Var{
 		Name:    "max-conncurrent-requests",
@@ -122,7 +125,7 @@ func (c *IAMCleanupCommand) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create iam cleaner: %w", err)
 	}
-	if err := iamCleaner.Do(ctx, c.flagScope, c.flagIAMQuery, c.flagExpiredOnly); err != nil {
+	if err := iamCleaner.Do(ctx, c.flagScope, c.flagIAMQuery, c.flagEvaluateCondition); err != nil {
 		return fmt.Errorf("failed to cleanup iam: %w", err)
 	}
 

--- a/pkg/commands/iamcleanup/iamcleanup.go
+++ b/pkg/commands/iamcleanup/iamcleanup.go
@@ -37,13 +37,13 @@ type IAMCleaner struct {
 
 var allowedRequestFieldsInCoditionExpression = []string{"time"}
 
-func NewIAMCleaner(ctx context.Context, maxConcurrentRequests int64, workingDirectory string) (*IAMCleaner, error) {
+func NewIAMCleaner(ctx context.Context, maxConcurrentRequests int64) (*IAMCleaner, error) {
 	assetInventoryClient, err := assetinventory.NewClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize assets client: %w", err)
 	}
 
-	iamClient, err := iam.NewClient(ctx, &workingDirectory)
+	iamClient, err := iam.NewClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize iam client: %w", err)
 	}

--- a/pkg/commands/iamcleanup/iamcleanup.go
+++ b/pkg/commands/iamcleanup/iamcleanup.go
@@ -1,0 +1,95 @@
+package iamcleanup
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/google/cel-go/cel"
+	rpcpb "google.golang.org/genproto/googleapis/rpc/context/attribute_context"
+
+	"github.com/abcxyz/guardian/pkg/assetinventory"
+	"github.com/abcxyz/guardian/pkg/iam"
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/worker"
+)
+
+type IAMCleaner struct {
+	assetInventoryClient  assetinventory.AssetInventory
+	iamClient             iam.IAM
+	maxConcurrentRequests int64
+}
+
+func NewIAMCleaner(ctx context.Context, maxConcurrentRequests int64, workingDirectory string) (*IAMCleaner, error) {
+	assetInventoryClient, err := assetinventory.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize assets client: %w", err)
+	}
+
+	iamClient, err := iam.NewClient(ctx, &workingDirectory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize iam client: %w", err)
+	}
+
+	return &IAMCleaner{
+		assetInventoryClient,
+		iamClient,
+		maxConcurrentRequests,
+	}, nil
+}
+
+// Do finds all IAM matching the given scope and query and deletes them.
+func (c *IAMCleaner) Do(
+	ctx context.Context,
+	scope string,
+	iamQuery string,
+	expiredOnly bool,
+) error {
+	logger := logging.FromContext(ctx)
+	iams, err := c.assetInventoryClient.IAM(ctx, scope, iamQuery)
+	if err != nil {
+		return fmt.Errorf("failed to get iam: %w", err)
+	}
+
+	w := worker.New[*worker.Void](c.maxConcurrentRequests)
+	filteredIAMs := iams
+
+	env, err := cel.NewEnv(
+		cel.Types(&rpcpb.AttributeContext_Request{}),
+		cel.Variable("request",
+			cel.ObjectType("google.rpc.context.AttributeContext.Request"),
+		),
+	)
+	ast, issues := env.Compile(`name.startsWith("/groups/" + group)`)
+	if issues != nil && issues.Err() != nil {
+		log.Fatalf("type-check error: %s", issues.Err())
+	}
+
+	for _, i := range filteredIAMs {
+		iamMembership := i
+		if err := w.Do(ctx, func() (*worker.Void, error) {
+			if iamMembership.ResourceType == assetinventory.Organization {
+				if err := c.iamClient.RemoveOrganizationIAM(ctx, iamMembership); err != nil {
+					return nil, fmt.Errorf("failed to remove org IAM: %w", err)
+				}
+			} else if iamMembership.ResourceType == assetinventory.Folder {
+				if err := c.iamClient.RemoveFolderIAM(ctx, iamMembership); err != nil {
+					return nil, fmt.Errorf("failed to remove folder IAM: %w", err)
+				}
+			} else if iamMembership.ResourceType == assetinventory.Project {
+				if err := c.iamClient.RemoveProjectIAM(ctx, iamMembership); err != nil {
+					return nil, fmt.Errorf("failed to remove project IAM: %w", err)
+				}
+			}
+			return nil, nil
+		}); err != nil {
+			return fmt.Errorf("failed to execute remove IAM task: %w", err)
+		}
+	}
+
+	logger.Debugw("got IAM",
+		"number_of_iam_memberships", len(iams),
+		"scope", scope,
+		"query", iamQuery)
+	return nil
+}

--- a/pkg/commands/iamcleanup/iamcleanup.go
+++ b/pkg/commands/iamcleanup/iamcleanup.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package iamcleanup
 
 import (

--- a/pkg/commands/iamcleanup/iamcleanup_test.go
+++ b/pkg/commands/iamcleanup/iamcleanup_test.go
@@ -47,6 +47,11 @@ func Test_evaluateIAMConditionExpression(t *testing.T) {
 			expression:    "request.made_up_time_arg < timestamp('3024-01-01T00:00:00Z')",
 			wantErrSubstr: "failed to compile Expression",
 		},
+		{
+			name:          "failed_to_parse",
+			expression:    "request.path == '/admin'",
+			wantErrSubstr: "unsupported field 'path' in Condition Expression",
+		},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/pkg/commands/iamcleanup/iamcleanup_test.go
+++ b/pkg/commands/iamcleanup/iamcleanup_test.go
@@ -1,0 +1,68 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iamcleanup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/abcxyz/guardian/pkg/util"
+	"github.com/abcxyz/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_isIAMConditionExpressionExpired(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		expression    string
+		want          *bool
+		wantErrSubstr string
+	}{
+		{
+			name:       "success_expired",
+			expression: "request.time < timestamp('2019-01-01T00:00:00Z')",
+			want:       util.Ptr(true),
+		},
+		{
+			name:       "success_not_expired",
+			expression: "request.time < timestamp('3024-01-01T00:00:00Z')",
+			want:       util.Ptr(false),
+		},
+		{
+			name:          "failed_to_parse",
+			expression:    "request.made_up_time_arg < timestamp('3024-01-01T00:00:00Z')",
+			wantErrSubstr: "failed to compile Expression",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Run test.
+			got, gotErr := isIAMConditionExpressionExpired(context.Background(), tc.expression)
+			if diff := testutil.DiffErrString(gotErr, tc.wantErrSubstr); diff != "" {
+				t.Errorf("Process(%+v) got unexpected error substring: %v", tc.name, diff)
+			}
+			// Verify that the ResourceMapping is modified with additional annotations fetched from Asset Inventory.
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Process(%+v) got diff (-want, +got): %v", tc.name, diff)
+			}
+		})
+	}
+}

--- a/pkg/commands/iamcleanup/iamcleanup_test.go
+++ b/pkg/commands/iamcleanup/iamcleanup_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func Test_isIAMConditionExpressionExpired(t *testing.T) {
+func Test_evaluateIAMConditionExpression(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -35,12 +35,12 @@ func Test_isIAMConditionExpressionExpired(t *testing.T) {
 		{
 			name:       "success_expired",
 			expression: "request.time < timestamp('2019-01-01T00:00:00Z')",
-			want:       util.Ptr(true),
+			want:       util.Ptr(false),
 		},
 		{
 			name:       "success_not_expired",
 			expression: "request.time < timestamp('3024-01-01T00:00:00Z')",
-			want:       util.Ptr(false),
+			want:       util.Ptr(true),
 		},
 		{
 			name:          "failed_to_parse",
@@ -55,7 +55,7 @@ func Test_isIAMConditionExpressionExpired(t *testing.T) {
 			t.Parallel()
 
 			// Run test.
-			got, gotErr := isIAMConditionExpressionExpired(context.Background(), tc.expression)
+			got, gotErr := evaluateIAMConditionExpression(context.Background(), tc.expression)
 			if diff := testutil.DiffErrString(gotErr, tc.wantErrSubstr); diff != "" {
 				t.Errorf("Process(%+v) got unexpected error substring: %v", tc.name, diff)
 			}

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -15,42 +15,40 @@
 package iam
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
 	"google.golang.org/api/cloudresourcemanager/v3"
 
 	"github.com/abcxyz/guardian/pkg/assetinventory"
+	"github.com/abcxyz/guardian/pkg/child"
+	"github.com/abcxyz/pkg/logging"
 )
 
 // IAM defines the common gcp iam functionality.
 type IAM interface {
 	// OrganizationIAM returns the IAM set on the Organization.
-	OrganizationIAM(ctx context.Context, organizationID string) ([]*AssetIAM, error)
+	OrganizationIAM(ctx context.Context, organizationID string) ([]*assetinventory.AssetIAM, error)
 	// FolderIAM returns the IAM set on the Folder.
-	FolderIAM(ctx context.Context, folderID string) ([]*AssetIAM, error)
+	FolderIAM(ctx context.Context, folderID string) ([]*assetinventory.AssetIAM, error)
 	// ProjectIAM returns the IAM set on the Project.
-	ProjectIAM(ctx context.Context, projectID string) ([]*AssetIAM, error)
-}
-
-// AssetIAM represents the IAM of a GCP resource (e.g binding/policy/membership of GCP Project, Folder, Org).
-type AssetIAM struct {
-	// The ID of the resource (e.g. Project ID, Folder ID, Org ID).
-	ResourceID string
-	// The type of the resource (e.g. Project, Folder, Org).
-	ResourceType string
-	// The IAM membership (e.g. group:my-group@google.com).
-	Member string
-	// The role (e.g. roles/owner).
-	Role string
+	ProjectIAM(ctx context.Context, projectID string) ([]*assetinventory.AssetIAM, error)
+	// RemoveOrganizationIAM removes the given IAM policy membership.
+	RemoveOrganizationIAM(ctx context.Context, projectIAMMember *assetinventory.AssetIAM) error
+	// RemoveFolderIAM removes the given IAM policy membership.
+	RemoveFolderIAM(ctx context.Context, projectIAMMember *assetinventory.AssetIAM) error
+	// RemoveProjectIAM removes the given IAM policy membership.
+	RemoveProjectIAM(ctx context.Context, projectIAMMember *assetinventory.AssetIAM) error
 }
 
 type IAMClient struct {
 	crmService *cloudresourcemanager.Service
+	workingDir *string
 }
 
 // NewClient creates a new iam client.
-func NewClient(ctx context.Context) (*IAMClient, error) {
+func NewClient(ctx context.Context, workingDir *string) (*IAMClient, error) {
 	crm, err := cloudresourcemanager.NewService(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize cloudresourcemanager service: %w", err)
@@ -58,11 +56,12 @@ func NewClient(ctx context.Context) (*IAMClient, error) {
 
 	return &IAMClient{
 		crmService: crm,
+		workingDir: workingDir,
 	}, nil
 }
 
 // ProjectIAM returns all IAM memberships, bindings, and policies for the given project.
-func (c *IAMClient) ProjectIAM(ctx context.Context, projectID string) ([]*AssetIAM, error) {
+func (c *IAMClient) ProjectIAM(ctx context.Context, projectID string) ([]*assetinventory.AssetIAM, error) {
 	req := &cloudresourcemanager.GetIamPolicyRequest{
 		Options: &cloudresourcemanager.GetPolicyOptions{
 			// Any operation that affects conditional role bindings must specify version `3`.
@@ -73,10 +72,10 @@ func (c *IAMClient) ProjectIAM(ctx context.Context, projectID string) ([]*AssetI
 	if err != nil {
 		return nil, fmt.Errorf("failed to get iam policy for project %s: %w", projectID, err)
 	}
-	var m []*AssetIAM
+	var m []*assetinventory.AssetIAM
 	for _, b := range policy.Bindings {
 		for _, member := range b.Members {
-			m = append(m, &AssetIAM{
+			m = append(m, &assetinventory.AssetIAM{
 				Role:         b.Role,
 				Member:       member,
 				ResourceID:   projectID,
@@ -89,7 +88,7 @@ func (c *IAMClient) ProjectIAM(ctx context.Context, projectID string) ([]*AssetI
 }
 
 // FolderIAM returns all IAM memberships, bindings, and policies for the given folder.
-func (c *IAMClient) FolderIAM(ctx context.Context, folderID string) ([]*AssetIAM, error) {
+func (c *IAMClient) FolderIAM(ctx context.Context, folderID string) ([]*assetinventory.AssetIAM, error) {
 	req := &cloudresourcemanager.GetIamPolicyRequest{
 		Options: &cloudresourcemanager.GetPolicyOptions{
 			// Any operation that affects conditional role bindings must specify
@@ -101,10 +100,10 @@ func (c *IAMClient) FolderIAM(ctx context.Context, folderID string) ([]*AssetIAM
 	if err != nil {
 		return nil, fmt.Errorf("failed to get iam policy for folder %s: %w", folderID, err)
 	}
-	var m []*AssetIAM
+	var m []*assetinventory.AssetIAM
 	for _, b := range policy.Bindings {
 		for _, member := range b.Members {
-			m = append(m, &AssetIAM{
+			m = append(m, &assetinventory.AssetIAM{
 				Role:         b.Role,
 				Member:       member,
 				ResourceID:   folderID,
@@ -117,7 +116,7 @@ func (c *IAMClient) FolderIAM(ctx context.Context, folderID string) ([]*AssetIAM
 }
 
 // OrganizationIAM returns all IAM memberships, bindings, and policies for the given organization.
-func (c *IAMClient) OrganizationIAM(ctx context.Context, organizationID string) ([]*AssetIAM, error) {
+func (c *IAMClient) OrganizationIAM(ctx context.Context, organizationID string) ([]*assetinventory.AssetIAM, error) {
 	req := &cloudresourcemanager.GetIamPolicyRequest{
 		Options: &cloudresourcemanager.GetPolicyOptions{
 			// Any operation that affects conditional role bindings must specify version `3`.
@@ -128,10 +127,10 @@ func (c *IAMClient) OrganizationIAM(ctx context.Context, organizationID string) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get iam policy for organization %s: %w", organizationID, err)
 	}
-	var m []*AssetIAM
+	var m []*assetinventory.AssetIAM
 	for _, b := range policy.Bindings {
 		for _, member := range b.Members {
-			m = append(m, &AssetIAM{
+			m = append(m, &assetinventory.AssetIAM{
 				Role:         b.Role,
 				Member:       member,
 				ResourceID:   organizationID,
@@ -141,4 +140,68 @@ func (c *IAMClient) OrganizationIAM(ctx context.Context, organizationID string) 
 	}
 
 	return m, nil
+}
+
+// RemoveProjectIAM removes the given IAM policy membership.
+func (c *IAMClient) RemoveProjectIAM(ctx context.Context, projectIAMMember *assetinventory.AssetIAM) error {
+	args := []string{
+		"projects", "remove-iam-policy-binding",
+		projectIAMMember.ResourceID,
+		fmt.Sprintf("--member=%s", projectIAMMember.Member),
+		fmt.Sprintf("--role=%s", projectIAMMember.Role),
+	}
+	if _, err := c.gcloud(ctx, args); err != nil {
+		return fmt.Errorf("failed to remove iam policy for project %s: %w", projectIAMMember.ResourceID, err)
+	}
+
+	return nil
+}
+
+// RemoveFolderIAM removes the given IAM policy membership.
+func (c *IAMClient) RemoveFolderIAM(ctx context.Context, projectIAMMember *assetinventory.AssetIAM) error {
+	args := []string{
+		"folders", "remove-iam-policy-binding",
+		projectIAMMember.ResourceID,
+		fmt.Sprintf("--member=%s", projectIAMMember.Member),
+		fmt.Sprintf("--role=%s", projectIAMMember.Role),
+	}
+	if _, err := c.gcloud(ctx, args); err != nil {
+		return fmt.Errorf("failed to remove iam policy for folder %s: %w", projectIAMMember.ResourceID, err)
+	}
+
+	return nil
+}
+
+// RemoveOrganizationIAM removes the given IAM policy membership.
+func (c *IAMClient) RemoveOrganizationIAM(ctx context.Context, projectIAMMember *assetinventory.AssetIAM) error {
+	args := []string{
+		"organizations", "remove-iam-policy-binding",
+		projectIAMMember.ResourceID,
+		fmt.Sprintf("--member=%s", projectIAMMember.Member),
+		fmt.Sprintf("--role=%s", projectIAMMember.Role),
+	}
+	if _, err := c.gcloud(ctx, args); err != nil {
+		return fmt.Errorf("failed to remove iam policy for organization %s: %w", projectIAMMember.ResourceID, err)
+	}
+
+	return nil
+}
+
+// gcloud runs the gcloud command.
+func (c *IAMClient) gcloud(ctx context.Context, args []string) (int, error) {
+	logger := logging.FromContext(ctx)
+	stdout := bytes.NewBufferString("")
+	stderr := bytes.NewBufferString("")
+	exitCode, err := child.Run(ctx, &child.RunConfig{ //nolint:wrapcheck
+		Stdout:     stdout,
+		Stderr:     stderr,
+		WorkingDir: *c.workingDir,
+		Command:    "gcloud",
+		Args:       args,
+	})
+	logger.Debugw("gcloud command executed", "args", args, "stdout", stdout)
+	if err != nil {
+		return exitCode, fmt.Errorf("failed to execute gcloud command: %w, \n\n %v", err, stderr)
+	}
+	return exitCode, nil
 }

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -143,45 +143,45 @@ func (c *IAMClient) OrganizationIAM(ctx context.Context, organizationID string) 
 }
 
 // RemoveProjectIAM removes the given IAM policy membership.
-func (c *IAMClient) RemoveProjectIAM(ctx context.Context, projectIAMMember *assetinventory.AssetIAM) error {
+func (c *IAMClient) RemoveProjectIAM(ctx context.Context, iamMember *assetinventory.AssetIAM) error {
 	args := []string{
 		"projects", "remove-iam-policy-binding",
-		projectIAMMember.ResourceID,
-		fmt.Sprintf("--member=%s", projectIAMMember.Member),
-		fmt.Sprintf("--role=%s", projectIAMMember.Role),
+		iamMember.ResourceID,
+		fmt.Sprintf("--member=%s", iamMember.Member),
+		fmt.Sprintf("--role=%s", iamMember.Role),
 	}
 	if _, err := c.gcloud(ctx, args); err != nil {
-		return fmt.Errorf("failed to remove iam policy for project %s: %w", projectIAMMember.ResourceID, err)
+		return fmt.Errorf("failed to remove iam policy for project %s: %w", iamMember.ResourceID, err)
 	}
 
 	return nil
 }
 
 // RemoveFolderIAM removes the given IAM policy membership.
-func (c *IAMClient) RemoveFolderIAM(ctx context.Context, projectIAMMember *assetinventory.AssetIAM) error {
+func (c *IAMClient) RemoveFolderIAM(ctx context.Context, iamMember *assetinventory.AssetIAM) error {
 	args := []string{
 		"folders", "remove-iam-policy-binding",
-		projectIAMMember.ResourceID,
-		fmt.Sprintf("--member=%s", projectIAMMember.Member),
-		fmt.Sprintf("--role=%s", projectIAMMember.Role),
+		iamMember.ResourceID,
+		fmt.Sprintf("--member=%s", iamMember.Member),
+		fmt.Sprintf("--role=%s", iamMember.Role),
 	}
 	if _, err := c.gcloud(ctx, args); err != nil {
-		return fmt.Errorf("failed to remove iam policy for folder %s: %w", projectIAMMember.ResourceID, err)
+		return fmt.Errorf("failed to remove iam policy for folder %s: %w", iamMember.ResourceID, err)
 	}
 
 	return nil
 }
 
 // RemoveOrganizationIAM removes the given IAM policy membership.
-func (c *IAMClient) RemoveOrganizationIAM(ctx context.Context, projectIAMMember *assetinventory.AssetIAM) error {
+func (c *IAMClient) RemoveOrganizationIAM(ctx context.Context, iamMember *assetinventory.AssetIAM) error {
 	args := []string{
 		"organizations", "remove-iam-policy-binding",
-		projectIAMMember.ResourceID,
-		fmt.Sprintf("--member=%s", projectIAMMember.Member),
-		fmt.Sprintf("--role=%s", projectIAMMember.Role),
+		iamMember.ResourceID,
+		fmt.Sprintf("--member=%s", iamMember.Member),
+		fmt.Sprintf("--role=%s", iamMember.Role),
 	}
 	if _, err := c.gcloud(ctx, args); err != nil {
-		return fmt.Errorf("failed to remove iam policy for organization %s: %w", projectIAMMember.ResourceID, err)
+		return fmt.Errorf("failed to remove iam policy for organization %s: %w", iamMember.ResourceID, err)
 	}
 
 	return nil

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -15,32 +15,40 @@
 package iam
 
 import (
-	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"golang.org/x/exp/slices"
 	"google.golang.org/api/cloudresourcemanager/v3"
+	"google.golang.org/api/googleapi"
 
 	"github.com/abcxyz/guardian/pkg/assetinventory"
-	"github.com/abcxyz/guardian/pkg/child"
-	"github.com/abcxyz/pkg/logging"
 	"github.com/sethvargo/go-retry"
+
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 // IAM defines the common gcp iam functionality.
 type IAM interface {
 	// OrganizationIAM returns the IAM set on the Organization.
 	OrganizationIAM(ctx context.Context, organizationID string) ([]*assetinventory.AssetIAM, error)
+
 	// FolderIAM returns the IAM set on the Folder.
 	FolderIAM(ctx context.Context, folderID string) ([]*assetinventory.AssetIAM, error)
+
 	// ProjectIAM returns the IAM set on the Project.
 	ProjectIAM(ctx context.Context, projectID string) ([]*assetinventory.AssetIAM, error)
+
 	// RemoveOrganizationIAM removes the given IAM policy membership.
 	RemoveOrganizationIAM(ctx context.Context, projectIAMMember *assetinventory.AssetIAM) error
+
 	// RemoveFolderIAM removes the given IAM policy membership.
 	RemoveFolderIAM(ctx context.Context, projectIAMMember *assetinventory.AssetIAM) error
+
 	// RemoveProjectIAM removes the given IAM policy membership.
 	RemoveProjectIAM(ctx context.Context, projectIAMMember *assetinventory.AssetIAM) error
 }
@@ -57,10 +65,6 @@ type Config struct {
 	initialRetryDelay time.Duration
 	maxRetryDelay     time.Duration
 }
-
-const (
-	concurrentPolicyErrMessage = "is the subject of a conflict: There were concurrent policy changes"
-)
 
 // NewClient creates a new iam client.
 func NewClient(ctx context.Context) (*IAMClient, error) {
@@ -83,6 +87,92 @@ func NewClient(ctx context.Context) (*IAMClient, error) {
 
 // ProjectIAM returns all IAM memberships, bindings, and policies for the given project.
 func (c *IAMClient) ProjectIAM(ctx context.Context, projectID string) ([]*assetinventory.AssetIAM, error) {
+	policy, err := c.projectIAMPolicy(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get iam policy for project: %w", err)
+	}
+	return policyToAssetIAM(projectID, assetinventory.Project, policy), nil
+}
+
+// FolderIAM returns all IAM memberships, bindings, and policies for the given folder.
+func (c *IAMClient) FolderIAM(ctx context.Context, folderID string) ([]*assetinventory.AssetIAM, error) {
+	policy, err := c.folderIAMPolicy(ctx, folderID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get iam policy for folder: %w", err)
+	}
+	return policyToAssetIAM(folderID, assetinventory.Folder, policy), nil
+}
+
+// OrganizationIAM returns all IAM memberships, bindings, and policies for the given organization.
+func (c *IAMClient) OrganizationIAM(ctx context.Context, organizationID string) ([]*assetinventory.AssetIAM, error) {
+	policy, err := c.organizationIAMPolicy(ctx, organizationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get iam policy for org: %w", err)
+	}
+	return policyToAssetIAM(organizationID, assetinventory.Organization, policy), nil
+}
+
+// RemoveProjectIAM removes the given IAM policy membership.
+func (c *IAMClient) RemoveProjectIAM(ctx context.Context, iamMember *assetinventory.AssetIAM) error {
+	if err := c.withRetries(ctx, func(ctx context.Context) error {
+		policy, err := c.projectIAMPolicy(ctx, iamMember.ResourceID)
+		if err != nil {
+			return fmt.Errorf("failed to get project policy: %w", err)
+		}
+		updatedPolicy := removeFromPolicy(policy, iamMember)
+
+		req := &cloudresourcemanager.SetIamPolicyRequest{Policy: updatedPolicy}
+		if _, err := c.crmService.Projects.SetIamPolicy(fmt.Sprintf("projects/%s", iamMember.ResourceID), req).Context(ctx).Do(); err != nil {
+			return fmt.Errorf("failed to set project policy: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to remove project IAM: %w", err)
+	}
+	return nil
+}
+
+// RemoveFolderIAM removes the given IAM policy membership.
+func (c *IAMClient) RemoveFolderIAM(ctx context.Context, iamMember *assetinventory.AssetIAM) error {
+	if err := c.withRetries(ctx, func(ctx context.Context) error {
+		policy, err := c.folderIAMPolicy(ctx, iamMember.ResourceID)
+		if err != nil {
+			return fmt.Errorf("failed to get folder policy: %w", err)
+		}
+		updatedPolicy := removeFromPolicy(policy, iamMember)
+
+		req := &cloudresourcemanager.SetIamPolicyRequest{Policy: updatedPolicy}
+		if _, err := c.crmService.Folders.SetIamPolicy(fmt.Sprintf("folders/%s", iamMember.ResourceID), req).Context(ctx).Do(); err != nil {
+			return fmt.Errorf("failed to set folder policy: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to remove folder IAM: %w", err)
+	}
+	return nil
+}
+
+// RemoveOrganizationIAM removes the given IAM policy membership.
+func (c *IAMClient) RemoveOrganizationIAM(ctx context.Context, iamMember *assetinventory.AssetIAM) error {
+	if err := c.withRetries(ctx, func(ctx context.Context) error {
+		policy, err := c.organizationIAMPolicy(ctx, iamMember.ResourceID)
+		if err != nil {
+			return fmt.Errorf("failed to get org policy: %w", err)
+		}
+		updatedPolicy := removeFromPolicy(policy, iamMember)
+
+		req := &cloudresourcemanager.SetIamPolicyRequest{Policy: updatedPolicy}
+		if _, err := c.crmService.Organizations.SetIamPolicy(fmt.Sprintf("organizations/%s", iamMember.ResourceID), req).Context(ctx).Do(); err != nil {
+			return fmt.Errorf("failed to set org policy: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to remove organization IAM: %w", err)
+	}
+	return nil
+}
+
+func (c *IAMClient) projectIAMPolicy(ctx context.Context, projectID string) (*cloudresourcemanager.Policy, error) {
 	req := &cloudresourcemanager.GetIamPolicyRequest{
 		Options: &cloudresourcemanager.GetPolicyOptions{
 			// Any operation that affects conditional role bindings must specify version `3`.
@@ -93,23 +183,10 @@ func (c *IAMClient) ProjectIAM(ctx context.Context, projectID string) ([]*asseti
 	if err != nil {
 		return nil, fmt.Errorf("failed to get iam policy for project %s: %w", projectID, err)
 	}
-	var m []*assetinventory.AssetIAM
-	for _, b := range policy.Bindings {
-		for _, member := range b.Members {
-			m = append(m, &assetinventory.AssetIAM{
-				Role:         b.Role,
-				Member:       member,
-				ResourceID:   projectID,
-				ResourceType: assetinventory.Project,
-			})
-		}
-	}
-
-	return m, nil
+	return policy, nil
 }
 
-// FolderIAM returns all IAM memberships, bindings, and policies for the given folder.
-func (c *IAMClient) FolderIAM(ctx context.Context, folderID string) ([]*assetinventory.AssetIAM, error) {
+func (c *IAMClient) folderIAMPolicy(ctx context.Context, folderID string) (*cloudresourcemanager.Policy, error) {
 	req := &cloudresourcemanager.GetIamPolicyRequest{
 		Options: &cloudresourcemanager.GetPolicyOptions{
 			// Any operation that affects conditional role bindings must specify
@@ -121,23 +198,10 @@ func (c *IAMClient) FolderIAM(ctx context.Context, folderID string) ([]*assetinv
 	if err != nil {
 		return nil, fmt.Errorf("failed to get iam policy for folder %s: %w", folderID, err)
 	}
-	var m []*assetinventory.AssetIAM
-	for _, b := range policy.Bindings {
-		for _, member := range b.Members {
-			m = append(m, &assetinventory.AssetIAM{
-				Role:         b.Role,
-				Member:       member,
-				ResourceID:   folderID,
-				ResourceType: assetinventory.Folder,
-			})
-		}
-	}
-
-	return m, nil
+	return policy, nil
 }
 
-// OrganizationIAM returns all IAM memberships, bindings, and policies for the given organization.
-func (c *IAMClient) OrganizationIAM(ctx context.Context, organizationID string) ([]*assetinventory.AssetIAM, error) {
+func (c *IAMClient) organizationIAMPolicy(ctx context.Context, organizationID string) (*cloudresourcemanager.Policy, error) {
 	req := &cloudresourcemanager.GetIamPolicyRequest{
 		Options: &cloudresourcemanager.GetPolicyOptions{
 			// Any operation that affects conditional role bindings must specify version `3`.
@@ -148,105 +212,7 @@ func (c *IAMClient) OrganizationIAM(ctx context.Context, organizationID string) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get iam policy for organization %s: %w", organizationID, err)
 	}
-	var m []*assetinventory.AssetIAM
-	for _, b := range policy.Bindings {
-		for _, member := range b.Members {
-			m = append(m, &assetinventory.AssetIAM{
-				Role:         b.Role,
-				Member:       member,
-				ResourceID:   organizationID,
-				ResourceType: assetinventory.Organization,
-			})
-		}
-	}
-
-	return m, nil
-}
-
-// RemoveProjectIAM removes the given IAM policy membership.
-func (c *IAMClient) RemoveProjectIAM(ctx context.Context, iamMember *assetinventory.AssetIAM) error {
-	// The Golang API does not support IAM removal on projects yet.
-	args := []string{
-		"projects", "remove-iam-policy-binding",
-		iamMember.ResourceID,
-		fmt.Sprintf("--member=%s", iamMember.Member),
-		fmt.Sprintf("--role=%s", iamMember.Role),
-	}
-	if iamMember.Condition != nil {
-		args = append(args, fmt.Sprintf("--condition=%s", conditionString(*iamMember.Condition)))
-	}
-	if _, err := c.gcloud(ctx, args); err != nil {
-		return fmt.Errorf("failed to remove iam policy for project %s: %w", iamMember.ResourceID, err)
-	}
-
-	return nil
-}
-
-// RemoveFolderIAM removes the given IAM policy membership.
-func (c *IAMClient) RemoveFolderIAM(ctx context.Context, iamMember *assetinventory.AssetIAM) error {
-	// The Golang API does not support IAM removal on folders yet.
-	args := []string{
-		"resource-manager", "folders", "remove-iam-policy-binding",
-		iamMember.ResourceID,
-		fmt.Sprintf("--member=%s", iamMember.Member),
-		fmt.Sprintf("--role=%s", iamMember.Role),
-	}
-	if iamMember.Condition != nil {
-		args = append(args, fmt.Sprintf("--condition=%s", conditionString(*iamMember.Condition)))
-	}
-	if _, err := c.gcloud(ctx, args); err != nil {
-		return fmt.Errorf("failed to remove iam policy for folder %s: %w", iamMember.ResourceID, err)
-	}
-
-	return nil
-}
-
-// RemoveOrganizationIAM removes the given IAM policy membership.
-func (c *IAMClient) RemoveOrganizationIAM(ctx context.Context, iamMember *assetinventory.AssetIAM) error {
-	// The Golang API does not support IAM removal on organizations yet.
-	args := []string{
-		"organizations", "remove-iam-policy-binding",
-		iamMember.ResourceID,
-		fmt.Sprintf("--member=%s", iamMember.Member),
-		fmt.Sprintf("--role=%s", iamMember.Role),
-	}
-	if iamMember.Condition != nil {
-		args = append(args, fmt.Sprintf("--condition=%s", conditionString(*iamMember.Condition)))
-	}
-	if _, err := c.gcloud(ctx, args); err != nil {
-		return fmt.Errorf("failed to remove iam policy for organization %s: %w", iamMember.ResourceID, err)
-	}
-
-	return nil
-}
-
-// gcloud runs the gcloud command.
-func (c *IAMClient) gcloud(ctx context.Context, args []string) (int, error) {
-	logger := logging.FromContext(ctx)
-	stdout := bytes.NewBufferString("")
-	stderr := bytes.NewBufferString("")
-	var exitCode int
-	if err := c.withRetries(ctx, func(ctx context.Context) error {
-		c, err := child.Run(ctx, &child.RunConfig{
-			Stdout:     stdout,
-			Stderr:     stderr,
-			WorkingDir: "",
-			Command:    "gcloud",
-			Args:       args,
-		})
-		exitCode = c
-		logger.Debugw("gcloud command executed", "args", args, "stdout", stdout)
-		if err != nil {
-			if strings.Contains(err.Error(), concurrentPolicyErrMessage) {
-				return retry.RetryableError(err)
-			}
-			return fmt.Errorf("gcloud command failed with exit code %d: %w, \n\n %v", exitCode, err, stderr)
-		}
-		return nil
-	}); err != nil {
-		return exitCode, fmt.Errorf("failed to execute gcloud command with retries: %w", err)
-	}
-	return exitCode, nil
+	return policy, nil
 }
 
 func (c *IAMClient) withRetries(ctx context.Context, retryFunc retry.RetryFunc) error {
@@ -255,12 +221,23 @@ func (c *IAMClient) withRetries(ctx context.Context, retryFunc retry.RetryFunc) 
 	backoff = retry.WithCappedDuration(c.cfg.maxRetryDelay, backoff)
 
 	if err := retry.Do(ctx, backoff, retryFunc); err != nil {
+		// IAM gRPC returns 10 on conflicts
+		if terr, ok := grpcstatus.FromError(err); ok && terr.Code() == grpccodes.Aborted {
+			return retry.RetryableError(err)
+		}
+
+		// IAM returns 412 while propagating, also retry on server errors
+		var terr *googleapi.Error
+		if ok := errors.As(err, &terr); ok && (terr.Code == 412 || terr.Code >= 500) {
+			return retry.RetryableError(err)
+		}
+
 		return fmt.Errorf("failed to execute retriable function: %w", err)
 	}
 	return nil
 }
 
-func conditionString(condition assetinventory.IAMCondition) string {
+func assetConditionString(condition assetinventory.IAMCondition) string {
 	parts := []string{fmt.Sprintf("expression=%s", condition.Expression)}
 	if condition.Title != "" {
 		parts = append(parts, fmt.Sprintf("title=%s", condition.Title))
@@ -269,4 +246,57 @@ func conditionString(condition assetinventory.IAMCondition) string {
 		parts = append(parts, fmt.Sprintf("description=%s", condition.Description))
 	}
 	return strings.Join(parts, ",")
+}
+
+func crmConditionString(condition cloudresourcemanager.Expr) string {
+	parts := []string{fmt.Sprintf("expression=%s", condition.Expression)}
+	if condition.Title != "" {
+		parts = append(parts, fmt.Sprintf("title=%s", condition.Title))
+	}
+	if condition.Description != "" {
+		parts = append(parts, fmt.Sprintf("description=%s", condition.Description))
+	}
+	return strings.Join(parts, ",")
+}
+
+func policyToAssetIAM(resourceID, resourceType string, policy *cloudresourcemanager.Policy) []*assetinventory.AssetIAM {
+	var m []*assetinventory.AssetIAM
+	for _, b := range policy.Bindings {
+		for _, member := range b.Members {
+			m = append(m, &assetinventory.AssetIAM{
+				Role:         b.Role,
+				Member:       member,
+				ResourceID:   resourceID,
+				ResourceType: resourceType,
+			})
+		}
+	}
+	return m
+}
+
+func removeFromPolicy(policy *cloudresourcemanager.Policy, iam *assetinventory.AssetIAM) *cloudresourcemanager.Policy {
+	var bindings []*cloudresourcemanager.Binding
+	for _, b := range policy.Bindings {
+		conditionsBothNil := iam.Condition == nil && b.Condition == nil
+		conditionsBothFound := iam.Condition != nil && b.Condition != nil
+		conditionMatch := conditionsBothNil || (conditionsBothFound && assetConditionString(*iam.Condition) == crmConditionString(*b.Condition))
+		if b.Role == iam.Role && slices.Contains(b.Members, iam.Member) && conditionMatch {
+			if len(b.Members) != 1 {
+				var members []string
+				for _, m := range b.Members {
+					if m != iam.Member {
+						members = append(members, m)
+					}
+				}
+				binding := *b
+				binding.Members = members
+				bindings = append(bindings, &binding)
+			}
+		} else {
+			bindings = append(bindings, b)
+		}
+	}
+	p := *policy
+	p.Bindings = bindings
+	return &p
 }

--- a/pkg/iam/iam_mock.go
+++ b/pkg/iam/iam_mock.go
@@ -29,12 +29,15 @@ type Request struct {
 }
 
 type MockIAMClient struct {
-	OrgErr      string
-	OrgData     []*assetinventory.AssetIAM
-	FolderErr   string
-	FolderData  []*assetinventory.AssetIAM
-	ProjectErr  string
-	ProjectData []*assetinventory.AssetIAM
+	OrgErr           string
+	OrgData          []*assetinventory.AssetIAM
+	FolderErr        string
+	FolderData       []*assetinventory.AssetIAM
+	ProjectErr       string
+	ProjectData      []*assetinventory.AssetIAM
+	RemoveOrgErr     string
+	RemoveFolderErr  string
+	RemoveProjectErr string
 }
 
 func (m *MockIAMClient) OrganizationIAM(ctx context.Context, organizationID string) ([]*assetinventory.AssetIAM, error) {
@@ -56,4 +59,25 @@ func (m *MockIAMClient) ProjectIAM(ctx context.Context, projectID string) ([]*as
 		return nil, fmt.Errorf("%s", m.ProjectErr)
 	}
 	return m.ProjectData, nil
+}
+
+func (m *MockIAMClient) RemoveOrganizationIAM(ctx context.Context, iamMember *assetinventory.AssetIAM) error {
+	if m.RemoveOrgErr != "" {
+		return fmt.Errorf("%s", m.RemoveOrgErr)
+	}
+	return nil
+}
+
+func (m *MockIAMClient) RemoveFolderIAM(ctx context.Context, iamMember *assetinventory.AssetIAM) error {
+	if m.RemoveFolderErr != "" {
+		return fmt.Errorf("%s", m.RemoveFolderErr)
+	}
+	return nil
+}
+
+func (m *MockIAMClient) RemoveProjectIAM(ctx context.Context, iamMember *assetinventory.AssetIAM) error {
+	if m.RemoveProjectErr != "" {
+		return fmt.Errorf("%s", m.RemoveProjectErr)
+	}
+	return nil
 }

--- a/pkg/iam/iam_mock.go
+++ b/pkg/iam/iam_mock.go
@@ -17,6 +17,8 @@ package iam
 import (
 	"context"
 	"fmt"
+
+	"github.com/abcxyz/guardian/pkg/assetinventory"
 )
 
 var _ IAM = (*MockIAMClient)(nil)
@@ -28,28 +30,28 @@ type Request struct {
 
 type MockIAMClient struct {
 	OrgErr      string
-	OrgData     []*AssetIAM
+	OrgData     []*assetinventory.AssetIAM
 	FolderErr   string
-	FolderData  []*AssetIAM
+	FolderData  []*assetinventory.AssetIAM
 	ProjectErr  string
-	ProjectData []*AssetIAM
+	ProjectData []*assetinventory.AssetIAM
 }
 
-func (m *MockIAMClient) OrganizationIAM(ctx context.Context, organizationID string) ([]*AssetIAM, error) {
+func (m *MockIAMClient) OrganizationIAM(ctx context.Context, organizationID string) ([]*assetinventory.AssetIAM, error) {
 	if m.OrgErr != "" {
 		return nil, fmt.Errorf("%s", m.OrgErr)
 	}
 	return m.OrgData, nil
 }
 
-func (m *MockIAMClient) FolderIAM(ctx context.Context, folderID string) ([]*AssetIAM, error) {
+func (m *MockIAMClient) FolderIAM(ctx context.Context, folderID string) ([]*assetinventory.AssetIAM, error) {
 	if m.FolderErr != "" {
 		return nil, fmt.Errorf("%s", m.FolderErr)
 	}
 	return m.FolderData, nil
 }
 
-func (m *MockIAMClient) ProjectIAM(ctx context.Context, projectID string) ([]*AssetIAM, error) {
+func (m *MockIAMClient) ProjectIAM(ctx context.Context, projectID string) ([]*assetinventory.AssetIAM, error) {
 	if m.ProjectErr != "" {
 		return nil, fmt.Errorf("%s", m.ProjectErr)
 	}

--- a/pkg/iam/iam_test.go
+++ b/pkg/iam/iam_test.go
@@ -1,0 +1,166 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iam
+
+import (
+	"testing"
+
+	"github.com/abcxyz/guardian/pkg/assetinventory"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/cloudresourcemanager/v3"
+)
+
+func Test_removeFromPolicy(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		iam    *assetinventory.AssetIAM
+		policy *cloudresourcemanager.Policy
+		want   *cloudresourcemanager.Policy
+	}{
+		{
+			name: "success_no_condition",
+			iam: &assetinventory.AssetIAM{
+				ResourceID:   "123",
+				ResourceType: assetinventory.Folder,
+				Role:         "roles/editor",
+				Member:       "user:12312@google.com",
+			},
+			policy: &cloudresourcemanager.Policy{
+				Etag: "asdasda123",
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Members: []string{"user:12312@google.com", "serviceAccount:123123@prod.google.com"},
+						Role:    "roles/viewer",
+					},
+					{
+						Members: []string{"user:12312@google.com", "serviceAccount:123123@prod.google.com"},
+						Role:    "roles/editor",
+					},
+				},
+				Version: 3,
+			},
+			want: &cloudresourcemanager.Policy{
+				Etag: "asdasda123",
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Members: []string{"user:12312@google.com", "serviceAccount:123123@prod.google.com"},
+						Role:    "roles/viewer",
+					},
+					{
+						Members: []string{"serviceAccount:123123@prod.google.com"},
+						Role:    "roles/editor",
+					},
+				},
+				Version: 3,
+			},
+		},
+		{
+			name: "success_condition",
+			iam: &assetinventory.AssetIAM{
+				ResourceID:   "123",
+				ResourceType: assetinventory.Folder,
+				Role:         "roles/editor",
+				Member:       "user:12312@google.com",
+				Condition:    &assetinventory.IAMCondition{Title: "my-condition", Expression: "request.time > 0", Description: "my description"},
+			},
+			policy: &cloudresourcemanager.Policy{
+				Etag: "asdasda123",
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Members: []string{"user:12312@google.com", "serviceAccount:123123@prod.google.com"},
+						Role:    "roles/viewer",
+					},
+					{
+						Members: []string{"serviceAccount:123123@prod.google.com"},
+						Role:    "roles/editor",
+					},
+					{
+						Members:   []string{"user:12312@google.com"},
+						Role:      "roles/editor",
+						Condition: &cloudresourcemanager.Expr{Title: "my-condition", Expression: "request.time > 0", Description: "my description"},
+					},
+				},
+				Version: 3,
+			},
+			want: &cloudresourcemanager.Policy{
+				Etag: "asdasda123",
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Members: []string{"user:12312@google.com", "serviceAccount:123123@prod.google.com"},
+						Role:    "roles/viewer",
+					},
+					{
+						Members: []string{"serviceAccount:123123@prod.google.com"},
+						Role:    "roles/editor",
+					},
+				},
+				Version: 3,
+			},
+		},
+		{
+			name: "success_no_match_condition",
+			iam: &assetinventory.AssetIAM{
+				ResourceID:   "123",
+				ResourceType: assetinventory.Folder,
+				Role:         "roles/editor",
+				Member:       "user:12312@google.com",
+				Condition:    &assetinventory.IAMCondition{Title: "my-condition", Expression: "request.time > 0", Description: "my description"},
+			},
+			policy: &cloudresourcemanager.Policy{
+				Etag: "asdasda123",
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Members: []string{"user:12312@google.com", "serviceAccount:123123@prod.google.com"},
+						Role:    "roles/viewer",
+					},
+					{
+						Members: []string{"user:12312@google.com", "serviceAccount:123123@prod.google.com"},
+						Role:    "roles/editor",
+					},
+				},
+				Version: 3,
+			},
+			want: &cloudresourcemanager.Policy{
+				Etag: "asdasda123",
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Members: []string{"user:12312@google.com", "serviceAccount:123123@prod.google.com"},
+						Role:    "roles/viewer",
+					},
+					{
+						Members: []string{"user:12312@google.com", "serviceAccount:123123@prod.google.com"},
+						Role:    "roles/editor",
+					},
+				},
+				Version: 3,
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Run test.
+			got := removeFromPolicy(tc.policy, tc.iam)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Process(%+v) got diff (-want, +got): %v", tc.name, diff)
+			}
+		})
+	}
+}

--- a/pkg/terraform/parser/parser.go
+++ b/pkg/terraform/parser/parser.go
@@ -31,8 +31,10 @@ const (
 	// This shouldn't happen but it is theoretically possible especially if there is a race condition between
 	// fetching the projects & folders and querying for terraform state.
 	UnknownParentID = "UNKNOWN_PARENT_ID"
+
 	// UnknownParentType is used when we cannot find an asset parent. See UnknownParentID.
 	UnknownParentType = "UNKNOWN_PARENT_TYPE"
+
 	// Default max size for a terraform statefile is 512 MB.
 	defaultTerraformStateFileSizeLimit = 512 * 1024 * 1024 // 512 MB
 )
@@ -61,8 +63,10 @@ type TerraformState struct {
 type Terraform interface {
 	// SetAssets sets the assets to use for GCP asset lookup.
 	SetAssets(gcpFolders, gcpProjects map[string]*assetinventory.HierarchyNode)
+
 	// StateFileURIs returns the URIs of terraform state files located in the given GCS buckets.
 	StateFileURIs(ctx context.Context, gcsBuckets []string) ([]string, error)
+
 	// ProcessStates returns the IAM permissions stored in the given state files.
 	ProcessStates(ctx context.Context, gcsUris []string) ([]*assetinventory.AssetIAM, error)
 }

--- a/pkg/terraform/parser/parser.go
+++ b/pkg/terraform/parser/parser.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/abcxyz/guardian/pkg/assetinventory"
-	"github.com/abcxyz/guardian/pkg/iam"
 	"github.com/abcxyz/guardian/pkg/storage"
 )
 
@@ -65,7 +64,7 @@ type Terraform interface {
 	// StateFileURIs returns the URIs of terraform state files located in the given GCS buckets.
 	StateFileURIs(ctx context.Context, gcsBuckets []string) ([]string, error)
 	// ProcessStates returns the IAM permissions stored in the given state files.
-	ProcessStates(ctx context.Context, gcsUris []string) ([]*iam.AssetIAM, error)
+	ProcessStates(ctx context.Context, gcsUris []string) ([]*assetinventory.AssetIAM, error)
 }
 
 type TerraformParser struct {
@@ -115,8 +114,8 @@ func (p *TerraformParser) StateFileURIs(ctx context.Context, gcsBuckets []string
 }
 
 // ProcessStates finds all IAM in memberships, bindings, or policies in the given terraform state files.
-func (p *TerraformParser) ProcessStates(ctx context.Context, gcsUris []string) ([]*iam.AssetIAM, error) {
-	var iams []*iam.AssetIAM
+func (p *TerraformParser) ProcessStates(ctx context.Context, gcsUris []string) ([]*assetinventory.AssetIAM, error) {
+	var iams []*assetinventory.AssetIAM
 	for _, uri := range gcsUris {
 		var state TerraformState
 		bucket, name, err := storage.SplitObjectURI(uri)
@@ -137,8 +136,8 @@ func (p *TerraformParser) ProcessStates(ctx context.Context, gcsUris []string) (
 	return iams, nil
 }
 
-func (p *TerraformParser) parseTerraformStateIAM(state TerraformState) []*iam.AssetIAM {
-	var iams []*iam.AssetIAM
+func (p *TerraformParser) parseTerraformStateIAM(state TerraformState) []*assetinventory.AssetIAM {
+	var iams []*assetinventory.AssetIAM
 	for _, r := range state.Resources {
 		if strings.Contains(r.Type, "google_organization_iam_binding") {
 			iams = append(iams, p.parseIAMBindingForOrg(r.Instances)...)
@@ -159,11 +158,11 @@ func (p *TerraformParser) parseTerraformStateIAM(state TerraformState) []*iam.As
 	return iams
 }
 
-func (p *TerraformParser) parseIAMBindingForOrg(instances []ResourceInstance) []*iam.AssetIAM {
-	var iams []*iam.AssetIAM
+func (p *TerraformParser) parseIAMBindingForOrg(instances []ResourceInstance) []*assetinventory.AssetIAM {
+	var iams []*assetinventory.AssetIAM
 	for _, i := range instances {
 		for _, m := range i.Attributes.Members {
-			iams = append(iams, &iam.AssetIAM{
+			iams = append(iams, &assetinventory.AssetIAM{
 				Member:       m,
 				Role:         i.Attributes.Role,
 				ResourceID:   p.OrganizationID,
@@ -174,13 +173,13 @@ func (p *TerraformParser) parseIAMBindingForOrg(instances []ResourceInstance) []
 	return iams
 }
 
-func (p *TerraformParser) parseIAMBindingForFolder(instances []ResourceInstance) []*iam.AssetIAM {
-	var iams []*iam.AssetIAM
+func (p *TerraformParser) parseIAMBindingForFolder(instances []ResourceInstance) []*assetinventory.AssetIAM {
+	var iams []*assetinventory.AssetIAM
 	for _, i := range instances {
 		for _, m := range i.Attributes.Members {
 			folderID := strings.TrimPrefix(i.Attributes.Folder, "folders/")
 			parentID, parentType := p.maybeFindGCPAssetIDAndType(folderID)
-			iams = append(iams, &iam.AssetIAM{
+			iams = append(iams, &assetinventory.AssetIAM{
 				Member:       m,
 				Role:         i.Attributes.Role,
 				ResourceID:   parentID,
@@ -191,12 +190,12 @@ func (p *TerraformParser) parseIAMBindingForFolder(instances []ResourceInstance)
 	return iams
 }
 
-func (p *TerraformParser) parseIAMBindingForProject(instances []ResourceInstance) []*iam.AssetIAM {
-	var iams []*iam.AssetIAM
+func (p *TerraformParser) parseIAMBindingForProject(instances []ResourceInstance) []*assetinventory.AssetIAM {
+	var iams []*assetinventory.AssetIAM
 	for _, i := range instances {
 		for _, m := range i.Attributes.Members {
 			parentID, parentType := p.maybeFindGCPAssetIDAndType(i.Attributes.Project)
-			iams = append(iams, &iam.AssetIAM{
+			iams = append(iams, &assetinventory.AssetIAM{
 				Member:       m,
 				Role:         i.Attributes.Role,
 				ResourceID:   parentID,
@@ -207,10 +206,10 @@ func (p *TerraformParser) parseIAMBindingForProject(instances []ResourceInstance
 	return iams
 }
 
-func (p *TerraformParser) parseIAMMemberForOrg(instances []ResourceInstance) []*iam.AssetIAM {
-	iams := make([]*iam.AssetIAM, len(instances))
+func (p *TerraformParser) parseIAMMemberForOrg(instances []ResourceInstance) []*assetinventory.AssetIAM {
+	iams := make([]*assetinventory.AssetIAM, len(instances))
 	for x, i := range instances {
-		iams[x] = &iam.AssetIAM{
+		iams[x] = &assetinventory.AssetIAM{
 			Member:       i.Attributes.Member,
 			Role:         i.Attributes.Role,
 			ResourceID:   p.OrganizationID,
@@ -220,12 +219,12 @@ func (p *TerraformParser) parseIAMMemberForOrg(instances []ResourceInstance) []*
 	return iams
 }
 
-func (p *TerraformParser) parseIAMMemberForFolder(instances []ResourceInstance) []*iam.AssetIAM {
-	iams := make([]*iam.AssetIAM, len(instances))
+func (p *TerraformParser) parseIAMMemberForFolder(instances []ResourceInstance) []*assetinventory.AssetIAM {
+	iams := make([]*assetinventory.AssetIAM, len(instances))
 	for x, i := range instances {
 		folderID := strings.TrimPrefix(i.Attributes.Folder, "folders/")
 		parentID, parentType := p.maybeFindGCPAssetIDAndType(folderID)
-		iams[x] = &iam.AssetIAM{
+		iams[x] = &assetinventory.AssetIAM{
 			Member:       i.Attributes.Member,
 			Role:         i.Attributes.Role,
 			ResourceID:   parentID,
@@ -235,11 +234,11 @@ func (p *TerraformParser) parseIAMMemberForFolder(instances []ResourceInstance) 
 	return iams
 }
 
-func (p *TerraformParser) parseIAMMemberForProject(instances []ResourceInstance) []*iam.AssetIAM {
-	iams := make([]*iam.AssetIAM, len(instances))
+func (p *TerraformParser) parseIAMMemberForProject(instances []ResourceInstance) []*assetinventory.AssetIAM {
+	iams := make([]*assetinventory.AssetIAM, len(instances))
 	for x, i := range instances {
 		parentID, parentType := p.maybeFindGCPAssetIDAndType(i.Attributes.Project)
-		iams[x] = &iam.AssetIAM{
+		iams[x] = &assetinventory.AssetIAM{
 			Member:       i.Attributes.Member,
 			Role:         i.Attributes.Role,
 			ResourceID:   parentID,

--- a/pkg/terraform/parser/parser_test.go
+++ b/pkg/terraform/parser/parser_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/abcxyz/guardian/pkg/assetinventory"
-	"github.com/abcxyz/guardian/pkg/iam"
 	"github.com/abcxyz/guardian/pkg/storage"
 	"github.com/google/go-cmp/cmp"
 )
@@ -107,7 +106,7 @@ func TestParser_ProcessStates(t *testing.T) {
 		name                   string
 		terraformStatefilename string
 		gcsURIs                []string
-		want                   []*iam.AssetIAM
+		want                   []*assetinventory.AssetIAM
 		wantErr                string
 		knownFolders           map[string]*assetinventory.HierarchyNode
 		knownProjects          map[string]*assetinventory.HierarchyNode
@@ -115,7 +114,7 @@ func TestParser_ProcessStates(t *testing.T) {
 		{
 			name:                   "success",
 			terraformStatefilename: "testdata/test_valid.tfstate",
-			want: []*iam.AssetIAM{
+			want: []*assetinventory.AssetIAM{
 				{
 					ResourceID:   "1231231",
 					ResourceType: "Organization",
@@ -154,7 +153,7 @@ func TestParser_ProcessStates(t *testing.T) {
 		{
 			name:                   "success_no_known_assets",
 			terraformStatefilename: "testdata/test_valid.tfstate",
-			want: []*iam.AssetIAM{
+			want: []*assetinventory.AssetIAM{
 				{
 					ResourceID:   "1231231",
 					ResourceType: "Organization",


### PR DESCRIPTION
Fixes https://github.com/abcxyz/guardian/issues/145

I've manually tested this by running against X's org which had outdated AOD requests and it successfully deleted all expired IAM.
```
GUARDIAN_LOG_LEVEL=debug go run ./cmd/guardian iam-cleanup --scope=organizations/XXXXXXXX --iam-query="policy:abcxyz-aod-expiry"
```