### PR TITLE
fix: always upload plan regardless of changes for apply to read

### DIFF
--- a/pkg/commands/plan/plan_run.go
+++ b/pkg/commands/plan/plan_run.go
@@ -337,10 +337,6 @@ func (c *PlanRunCommand) handleTerraformPlan(ctx context.Context) (*RunResult, e
 		return &RunResult{commentDetails: stderr.String()}, fmt.Errorf("failed to plan: %w", err)
 	}
 
-	if !hasChanges {
-		return &RunResult{hasChanges: hasChanges}, nil
-	}
-
 	c.actions.Group("Formatting plan output")
 
 	_, err = c.terraformClient.Show(ctx, multiStdout, multiStderr, &terraform.ShowOptions{File: util.Ptr(c.planFilename), NoColor: util.Ptr(true)})

--- a/pkg/commands/plan/plan_run_test.go
+++ b/pkg/commands/plan/plan_run_test.go
@@ -164,6 +164,16 @@ func TestPlan_Process(t *testing.T) {
 					Params: []any{"owner", "repo", int64(1), "**`🔱 Guardian 🔱 PLAN`** - 🟦 No changes for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
 				},
 			},
+			expStorageClientReqs: []*storage.Request{
+				{
+					Name: "UploadObject",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/2/testdata/test-tfplan.binary",
+						"this is a plan binary",
+					},
+				},
+			},
 		},
 		{
 			name:                     "handles_error",


### PR DESCRIPTION
Apply reads the plan file and metadata to determine if it should apply, we should always upload the plan file even if no changes.