### PR TITLE
fix(plan): run handles non action environments, init add skip changes

### DIFF
--- a/.github/workflows/test-admin.yml
+++ b/.github/workflows/test-admin.yml
@@ -39,7 +39,7 @@ permissions:
 
 # only one admin should run at a time
 concurrency:
-  group: '${{ github.workflow_ref }}'
+  group: '${{ github.workflow }}'
 
 jobs:
   init:

--- a/.github/workflows/test-apply.yml
+++ b/.github/workflows/test-apply.yml
@@ -26,7 +26,7 @@ permissions:
 
 # only one apply should run at a time
 concurrency:
-  group: '${{ github.workflow_ref }}'
+  group: '${{ github.workflow }}'
 
 jobs:
   init:

--- a/pkg/commands/plan/plan_init.go
+++ b/pkg/commands/plan/plan_init.go
@@ -158,7 +158,7 @@ func (c *PlanInitCommand) Run(ctx context.Context, args []string) error {
 // Process handles the main logic for the Guardian init process.
 func (c *PlanInitCommand) Process(ctx context.Context) error {
 	logger := logging.FromContext(ctx).
-		Named("init.process").
+		Named("plan_init.process").
 		With("github_owner", c.GitHubFlags.FlagGitHubOwner).
 		With("github_repo", c.GitHubFlags.FlagGitHubOwner).
 		With("pull_request_number", c.flagPullRequestNumber)


### PR DESCRIPTION
- Plan run now handles correct output formatting for non-actions
- Added `-skip-detect-changes` flag for plan init, this is useful for running a for the entire entrypoint universe.