### PR TITLE
chore: refactor terraform package to use a common run command

### DIFF
--- a/pkg/terraform/apply.go
+++ b/pkg/terraform/apply.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-
-	"github.com/abcxyz/guardian/pkg/child"
 )
 
 // ApplyOptions are the set of options for running a terraform apply.
@@ -35,9 +33,7 @@ type ApplyOptions struct {
 
 // applyArgsFromOptions generated the terrafrom apply arguments from the provided options.
 func applyArgsFromOptions(opts *ApplyOptions) []string {
-	args := make([]string, 0, 9) // 9 potential args to be added
-
-	args = append(args, "apply")
+	args := make([]string, 0, 7) // 7 potential args to be added
 
 	if opts == nil {
 		return args
@@ -76,11 +72,5 @@ func applyArgsFromOptions(opts *ApplyOptions) []string {
 
 // Apply runs the Terraform apply command.
 func (t *TerraformClient) Apply(ctx context.Context, stdout, stderr io.Writer, opts *ApplyOptions) (int, error) {
-	return child.Run(ctx, &child.RunConfig{ //nolint:wrapcheck
-		Stdout:     stdout,
-		Stderr:     stderr,
-		WorkingDir: t.workingDir,
-		Command:    "terraform",
-		Args:       applyArgsFromOptions(opts),
-	})
+	return t.Run(ctx, stdout, stderr, "apply", applyArgsFromOptions(opts)...)
 }

--- a/pkg/terraform/apply_test.go
+++ b/pkg/terraform/apply_test.go
@@ -41,7 +41,6 @@ func TestApplyArgsFromOptions(t *testing.T) {
 				NoColor:         util.Ptr(true),
 			},
 			exp: []string{
-				"apply",
 				"-auto-approve",
 				"-compact-warnings",
 				"-lock=true",
@@ -63,7 +62,6 @@ func TestApplyArgsFromOptions(t *testing.T) {
 				NoColor:         util.Ptr(false),
 			},
 			exp: []string{
-				"apply",
 				"-lock=false",
 				"-lock-timeout=10m",
 				"-input=false",
@@ -73,12 +71,12 @@ func TestApplyArgsFromOptions(t *testing.T) {
 		{
 			name: "empty",
 			opts: &ApplyOptions{},
-			exp:  []string{"apply"},
+			exp:  []string{},
 		},
 		{
 			name: "nil",
 			opts: nil,
-			exp:  []string{"apply"},
+			exp:  []string{},
 		},
 	}
 

--- a/pkg/terraform/init.go
+++ b/pkg/terraform/init.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-
-	"github.com/abcxyz/guardian/pkg/child"
 )
 
 // InitOptions are the set of options for running a terraform init.
@@ -34,9 +32,7 @@ type InitOptions struct {
 
 // initArgsFromOptions generated the terrafrom init arguments from the provided options.
 func initArgsFromOptions(opts *InitOptions) []string {
-	args := make([]string, 0, 7) // 7 potential args to be added
-
-	args = append(args, "init")
+	args := make([]string, 0, 6) // 6 potential args to be added
 
 	if opts == nil {
 		return args
@@ -71,11 +67,5 @@ func initArgsFromOptions(opts *InitOptions) []string {
 
 // Init runs the terraform init command.
 func (t *TerraformClient) Init(ctx context.Context, stdout, stderr io.Writer, opts *InitOptions) (int, error) {
-	return child.Run(ctx, &child.RunConfig{ //nolint:wrapcheck
-		Stdout:     stdout,
-		Stderr:     stderr,
-		WorkingDir: t.workingDir,
-		Command:    "terraform",
-		Args:       initArgsFromOptions(opts),
-	})
+	return t.Run(ctx, stdout, stderr, "init", initArgsFromOptions(opts)...)
 }

--- a/pkg/terraform/init_test.go
+++ b/pkg/terraform/init_test.go
@@ -40,7 +40,6 @@ func TestInitArgsFromOptions(t *testing.T) {
 				NoColor:     util.Ptr(true),
 			},
 			exp: []string{
-				"init",
 				"-backend=true",
 				"-input=true",
 				"-no-color",
@@ -60,7 +59,6 @@ func TestInitArgsFromOptions(t *testing.T) {
 				NoColor:     util.Ptr(false),
 			},
 			exp: []string{
-				"init",
 				"-backend=false",
 				"-input=false",
 				"-lock=false",
@@ -71,12 +69,12 @@ func TestInitArgsFromOptions(t *testing.T) {
 		{
 			name: "empty",
 			opts: &InitOptions{},
-			exp:  []string{"init"},
+			exp:  []string{},
 		},
 		{
 			name: "nil",
 			opts: nil,
-			exp:  []string{"init"},
+			exp:  []string{},
 		},
 	}
 

--- a/pkg/terraform/plan.go
+++ b/pkg/terraform/plan.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-
-	"github.com/abcxyz/guardian/pkg/child"
 )
 
 // PlanOptions are the set of options for running a terraform plan.
@@ -36,8 +34,6 @@ type PlanOptions struct {
 // planArgsFromOptions generated the terrafrom plan arguments from the provided options.
 func planArgsFromOptions(opts *PlanOptions) []string {
 	args := make([]string, 0, 7) // 7 potential args to be added
-
-	args = append(args, "plan")
 
 	if opts == nil {
 		return args
@@ -76,11 +72,5 @@ func planArgsFromOptions(opts *PlanOptions) []string {
 
 // Plan runs the Terraform plan command.
 func (t *TerraformClient) Plan(ctx context.Context, stdout, stderr io.Writer, opts *PlanOptions) (int, error) {
-	return child.Run(ctx, &child.RunConfig{ //nolint:wrapcheck
-		Stdout:     stdout,
-		Stderr:     stderr,
-		WorkingDir: t.workingDir,
-		Command:    "terraform",
-		Args:       planArgsFromOptions(opts),
-	})
+	return t.Run(ctx, stdout, stderr, "plan", planArgsFromOptions(opts)...)
 }

--- a/pkg/terraform/plan_test.go
+++ b/pkg/terraform/plan_test.go
@@ -41,7 +41,6 @@ func TestPlanArgsFromOptions(t *testing.T) {
 				Out:              util.Ptr("outfile"),
 			},
 			exp: []string{
-				"plan",
 				"-compact-warnings",
 				"-detailed-exitcode",
 				"-no-color",
@@ -63,7 +62,6 @@ func TestPlanArgsFromOptions(t *testing.T) {
 				Out:              util.Ptr("outfile"),
 			},
 			exp: []string{
-				"plan",
 				"-input=false",
 				"-lock=false",
 				"-lock-timeout=10m",
@@ -73,12 +71,12 @@ func TestPlanArgsFromOptions(t *testing.T) {
 		{
 			name: "empty",
 			opts: &PlanOptions{},
-			exp:  []string{"plan"},
+			exp:  []string{},
 		},
 		{
 			name: "nil",
 			opts: nil,
-			exp:  []string{"plan"},
+			exp:  []string{},
 		},
 	}
 

--- a/pkg/terraform/run.go
+++ b/pkg/terraform/run.go
@@ -1,0 +1,39 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terraform
+
+import (
+	"context"
+	"io"
+
+	"github.com/abcxyz/guardian/pkg/child"
+)
+
+// Run runs a Terraform command.
+func (t *TerraformClient) Run(ctx context.Context, stdout, stderr io.Writer, subcommand string, args ...string) (int, error) {
+	runArgs := []string{subcommand}
+
+	if len(args) > 0 {
+		runArgs = append(runArgs, args...)
+	}
+
+	return child.Run(ctx, &child.RunConfig{ //nolint:wrapcheck
+		Stdout:     stdout,
+		Stderr:     stderr,
+		WorkingDir: t.workingDir,
+		Command:    "terraform",
+		Args:       runArgs,
+	})
+}

--- a/pkg/terraform/show.go
+++ b/pkg/terraform/show.go
@@ -17,8 +17,6 @@ package terraform
 import (
 	"context"
 	"io"
-
-	"github.com/abcxyz/guardian/pkg/child"
 )
 
 // ShowOptions are the set of options for running a terraform show.
@@ -30,9 +28,7 @@ type ShowOptions struct {
 
 // showArgsFromOptions generated the terrafrom show arguments from the provided options.
 func showArgsFromOptions(opts *ShowOptions) []string {
-	args := make([]string, 0, 4) // 4 potential args to be added
-
-	args = append(args, "show")
+	args := make([]string, 0, 3) // 3 potential args to be added
 
 	if opts == nil {
 		return args
@@ -55,11 +51,5 @@ func showArgsFromOptions(opts *ShowOptions) []string {
 
 // Show runs the Terraform show command.
 func (t *TerraformClient) Show(ctx context.Context, stdout, stderr io.Writer, opts *ShowOptions) (int, error) {
-	return child.Run(ctx, &child.RunConfig{ //nolint:wrapcheck
-		Stdout:     stdout,
-		Stderr:     stderr,
-		WorkingDir: t.workingDir,
-		Command:    "terraform",
-		Args:       showArgsFromOptions(opts),
-	})
+	return t.Run(ctx, stdout, stderr, "show", showArgsFromOptions(opts)...)
 }

--- a/pkg/terraform/show_test.go
+++ b/pkg/terraform/show_test.go
@@ -37,7 +37,6 @@ func TestShowArgsFromOptions(t *testing.T) {
 				JSON:    util.Ptr(true),
 			},
 			exp: []string{
-				"show",
 				"-no-color",
 				"-json",
 				"filename",
@@ -50,17 +49,17 @@ func TestShowArgsFromOptions(t *testing.T) {
 				NoColor: util.Ptr(false),
 				JSON:    util.Ptr(false),
 			},
-			exp: []string{"show", "filename"},
+			exp: []string{"filename"},
 		},
 		{
 			name: "empty",
 			opts: &ShowOptions{},
-			exp:  []string{"show"},
+			exp:  []string{},
 		},
 		{
 			name: "nil",
 			opts: nil,
-			exp:  []string{"show"},
+			exp:  []string{},
 		},
 	}
 

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -45,6 +45,26 @@ var (
 			`((\-(\/\+)*)|(\+(\/\-)*)|(!))`) // match characters to swap whitespace for git diff (+, +/-, -, -/+, !)
 )
 
+// InitRequiredCommands are the Terraform commands that
+// require terraform init to be run first.
+var InitRequiredCommands = map[string]struct{}{
+	"validate":  {},
+	"plan":      {},
+	"apply":     {},
+	"destroy":   {},
+	"console":   {},
+	"graph":     {},
+	"import":    {},
+	"output":    {},
+	"providers": {},
+	"refresh":   {},
+	"show":      {},
+	"state":     {},
+	"taint":     {},
+	"untaint":   {},
+	"workspace": {},
+}
+
 var _ Terraform = (*TerraformClient)(nil)
 
 // Terraform is the interface for working with the Terraform CLI.
@@ -63,6 +83,9 @@ type Terraform interface {
 
 	// Show runs the terraform show command.
 	Show(context.Context, io.Writer, io.Writer, *ShowOptions) (int, error)
+
+	// Run runs a terraform command.
+	Run(context.Context, io.Writer, io.Writer, string, ...string) (int, error)
 }
 
 // TerraformClient implements the Terraform interface.

--- a/pkg/terraform/terraform_mock.go
+++ b/pkg/terraform/terraform_mock.go
@@ -81,3 +81,12 @@ func (m *MockTerraformClient) Show(ctx context.Context, stdout, stderr io.Writer
 	}
 	return 0, nil
 }
+
+func (m *MockTerraformClient) Run(ctx context.Context, stdout, stderr io.Writer, subcommand string, args ...string) (int, error) {
+	if m.ShowResponse != nil {
+		stdout.Write([]byte(m.ShowResponse.Stdout))
+		stderr.Write([]byte(m.ShowResponse.Stderr))
+		return m.ShowResponse.ExitCode, m.ShowResponse.Err
+	}
+	return 0, nil
+}

--- a/pkg/terraform/validate.go
+++ b/pkg/terraform/validate.go
@@ -17,8 +17,6 @@ package terraform
 import (
 	"context"
 	"io"
-
-	"github.com/abcxyz/guardian/pkg/child"
 )
 
 // ValidateOptions are the set of options for running a terraform validate.
@@ -29,9 +27,7 @@ type ValidateOptions struct {
 
 // validateArgsFromOptions generated the terrafrom validate arguments from the provided options.
 func validateArgsFromOptions(opts *ValidateOptions) []string {
-	args := make([]string, 0, 3) // 3 potential args to be added
-
-	args = append(args, "validate")
+	args := make([]string, 0, 2) // 2 potential args to be added
 
 	if opts == nil {
 		return args
@@ -50,11 +46,5 @@ func validateArgsFromOptions(opts *ValidateOptions) []string {
 
 // Validate runs the terraform validate command.
 func (t *TerraformClient) Validate(ctx context.Context, stdout, stderr io.Writer, opts *ValidateOptions) (int, error) {
-	return child.Run(ctx, &child.RunConfig{ //nolint:wrapcheck
-		Stdout:     stdout,
-		Stderr:     stderr,
-		WorkingDir: t.workingDir,
-		Command:    "terraform",
-		Args:       validateArgsFromOptions(opts),
-	})
+	return t.Run(ctx, stdout, stderr, "validate", validateArgsFromOptions(opts)...)
 }

--- a/pkg/terraform/validate_test.go
+++ b/pkg/terraform/validate_test.go
@@ -36,7 +36,6 @@ func TestValidateArgsFromOptions(t *testing.T) {
 				JSON:    util.Ptr(true),
 			},
 			exp: []string{
-				"validate",
 				"-no-color",
 				"-json",
 			},
@@ -47,17 +46,17 @@ func TestValidateArgsFromOptions(t *testing.T) {
 				NoColor: util.Ptr(false),
 				JSON:    util.Ptr(false),
 			},
-			exp: []string{"validate"},
+			exp: []string{},
 		},
 		{
 			name: "empty",
 			opts: &ValidateOptions{},
-			exp:  []string{"validate"},
+			exp:  []string{},
 		},
 		{
 			name: "nil",
 			opts: nil,
-			exp:  []string{"validate"},
+			exp:  []string{},
 		},
 	}
 


### PR DESCRIPTION
This will allow for a future commands that can execute supplied terraform commands. The idea is to enable the ability to create admin or helper workflows that can run a limited set of terraform commands for administering terraform from github workflows.

Examples:
- I want to run terraform force-unlock to remove the lock from a failed run
- I want to run terraform apply again to fix the previous failed run
- I want to list the outputs for a given module