### PR TITLE
feat: create run command to replicate guardian admin functionality

### DIFF
--- a/cmd/guardian/main.go
+++ b/cmd/guardian/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/abcxyz/guardian/pkg/commands/iamcleanup"
 	"github.com/abcxyz/guardian/pkg/commands/initialize"
 	"github.com/abcxyz/guardian/pkg/commands/plan"
+	"github.com/abcxyz/guardian/pkg/commands/run"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 )
@@ -93,6 +94,9 @@ var rootCmd = func() cli.Command {
 						},
 					},
 				}
+			},
+			"run": func() cli.Command {
+				return &run.RunCommand{}
 			},
 		},
 	}

--- a/pkg/commands/initialize/config.go
+++ b/pkg/commands/initialize/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plan
+package initialize
 
 import (
 	"errors"
@@ -21,30 +21,19 @@ import (
 	"github.com/sethvargo/go-githubactions"
 )
 
-// Config defines the of configuration required for running the plan action.
+// Config defines the of configuration required for running Guardian in GitHub workflows.
 type Config struct {
 	// GitHub context values
-	ServerURL  string // this value is used to generate URLs for creating links in pull request comments
-	RunID      int64
-	RunAttempt int64
+	Actor string
 }
 
-// MapGitHubContext maps values from the GitHub context to the PlanConfig.
+// MapGitHubContext maps values from the GitHub context to the Config.
 func (c *Config) MapGitHubContext(context *githubactions.GitHubContext) error {
 	var merr error
-	c.ServerURL = context.ServerURL
-	if c.ServerURL == "" {
-		merr = errors.Join(merr, fmt.Errorf("GITHUB_SERVER_URL is required"))
-	}
 
-	c.RunID = context.RunID
-	if c.RunID == 0 {
-		merr = errors.Join(merr, fmt.Errorf("GITHUB_RUN_ID is required"))
-	}
-
-	c.RunAttempt = context.RunAttempt
-	if c.RunAttempt == 0 {
-		merr = errors.Join(merr, fmt.Errorf("GITHUB_RUN_ATTEMPT is required"))
+	c.Actor = context.Actor
+	if c.Actor == "" {
+		merr = errors.Join(merr, fmt.Errorf("GITHUB_ACTOR is required"))
 	}
 
 	return merr

--- a/pkg/commands/initialize/config_test.go
+++ b/pkg/commands/initialize/config_test.go
@@ -43,6 +43,7 @@ func TestConfig_MapGitHubContext(t *testing.T) {
 		{
 			name:          "error",
 			githubContext: &githubactions.GitHubContext{},
+			exp:           &Config{},
 			err:           "GITHUB_ACTOR is required",
 		},
 	}
@@ -53,18 +54,17 @@ func TestConfig_MapGitHubContext(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			c := &Config{}
+			var c Config
 
 			err := c.MapGitHubContext(tc.githubContext)
 			if err != nil || tc.err != "" {
 				if diff := testutil.DiffErrString(err, tc.err); diff != "" {
 					t.Fatal(diff)
 				}
-				return
 			}
 
-			if diff := cmp.Diff(c, tc.exp); diff != "" {
-				t.Errorf("got %#v, want %#v, diff (-got, +want): %v", c, tc.exp, diff)
+			if diff := cmp.Diff(&c, tc.exp); diff != "" {
+				t.Errorf("got %#v, want %#v, diff (-got, +want): %v", &c, tc.exp, diff)
 			}
 		})
 	}

--- a/pkg/commands/initialize/config_test.go
+++ b/pkg/commands/initialize/config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plan
+package initialize
 
 import (
 	"testing"
@@ -34,20 +34,16 @@ func TestConfig_MapGitHubContext(t *testing.T) {
 		{
 			name: "success",
 			githubContext: &githubactions.GitHubContext{
-				ServerURL:  "https://github.com",
-				RunID:      int64(100),
-				RunAttempt: int64(1),
+				Actor: "actor",
 			},
 			exp: &Config{
-				ServerURL:  "https://github.com",
-				RunID:      int64(100),
-				RunAttempt: int64(1),
+				Actor: "actor",
 			},
 		},
 		{
 			name:          "error",
 			githubContext: &githubactions.GitHubContext{},
-			err:           "GITHUB_SERVER_URL is required\nGITHUB_RUN_ID is required\nGITHUB_RUN_ATTEMPT is required",
+			err:           "GITHUB_ACTOR is required",
 		},
 	}
 

--- a/pkg/commands/plan/config.go
+++ b/pkg/commands/plan/config.go
@@ -38,12 +38,12 @@ func (c *Config) MapGitHubContext(context *githubactions.GitHubContext) error {
 	}
 
 	c.RunID = context.RunID
-	if c.RunID == 0 {
+	if c.RunID <= 0 {
 		merr = errors.Join(merr, fmt.Errorf("GITHUB_RUN_ID is required"))
 	}
 
 	c.RunAttempt = context.RunAttempt
-	if c.RunAttempt == 0 {
+	if c.RunAttempt <= 0 {
 		merr = errors.Join(merr, fmt.Errorf("GITHUB_RUN_ATTEMPT is required"))
 	}
 

--- a/pkg/commands/plan/config_test.go
+++ b/pkg/commands/plan/config_test.go
@@ -47,6 +47,7 @@ func TestConfig_MapGitHubContext(t *testing.T) {
 		{
 			name:          "error",
 			githubContext: &githubactions.GitHubContext{},
+			exp:           &Config{},
 			err:           "GITHUB_SERVER_URL is required\nGITHUB_RUN_ID is required\nGITHUB_RUN_ATTEMPT is required",
 		},
 	}
@@ -57,18 +58,17 @@ func TestConfig_MapGitHubContext(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			c := &Config{}
+			var c Config
 
 			err := c.MapGitHubContext(tc.githubContext)
 			if err != nil || tc.err != "" {
 				if diff := testutil.DiffErrString(err, tc.err); diff != "" {
 					t.Fatal(diff)
 				}
-				return
 			}
 
-			if diff := cmp.Diff(c, tc.exp); diff != "" {
-				t.Errorf("got %#v, want %#v, diff (-got, +want): %v", c, tc.exp, diff)
+			if diff := cmp.Diff(&c, tc.exp); diff != "" {
+				t.Errorf("got %#v, want %#v, diff (-got, +want): %v", &c, tc.exp, diff)
 			}
 		})
 	}

--- a/pkg/commands/plan/plan_run.go
+++ b/pkg/commands/plan/plan_run.go
@@ -213,7 +213,7 @@ func (c *PlanRunCommand) Process(ctx context.Context) error {
 	}
 
 	c.Outf("Running Terraform commands")
-	result, err := c.handleTerraformPlan(ctx)
+	result, err := c.terraformPlan(ctx)
 	if err != nil {
 		merr = errors.Join(merr, fmt.Errorf("failed to run Guardian plan: %w", err))
 	}
@@ -314,9 +314,9 @@ func (c *PlanRunCommand) updateResultCommentForActions(ctx context.Context, star
 	return nil
 }
 
-// handleTerraformPlan runs the required Terraform commands for a full run of
+// terraformPlan runs the required Terraform commands for a full run of
 // a Guardian plan using the Terraform CLI.
-func (c *PlanRunCommand) handleTerraformPlan(ctx context.Context) (*RunResult, error) {
+func (c *PlanRunCommand) terraformPlan(ctx context.Context) (*RunResult, error) {
 	var stdout, stderr strings.Builder
 	multiStdout := io.MultiWriter(c.Stdout(), &stdout)
 	multiStderr := io.MultiWriter(c.Stderr(), &stderr)
@@ -400,7 +400,7 @@ func (c *PlanRunCommand) handleTerraformPlan(ctx context.Context) (*RunResult, e
 	bucketObjectPath := fmt.Sprintf("guardian-plans/%s/%s/%d/%s", c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.flagPullRequestNumber, planFilePath)
 	c.Outf("Uploading plan file to gs://%s/%s", c.flagBucketName, bucketObjectPath)
 
-	if err := c.handleUploadGuardianPlan(ctx, bucketObjectPath, planData, planExitCode); err != nil {
+	if err := c.uploadGuardianPlan(ctx, bucketObjectPath, planData, planExitCode); err != nil {
 		return &RunResult{hasChanges: hasChanges}, fmt.Errorf("failed to upload plan data: %w", err)
 	}
 
@@ -425,8 +425,8 @@ func (c *PlanRunCommand) withActionsOutGroup(msg string, fn func() error) error 
 	return fn()
 }
 
-// handleUploadGuardianPlan uploads the Guardian plan binary to the configured Guardian storage bucket.
-func (c *PlanRunCommand) handleUploadGuardianPlan(ctx context.Context, path string, data []byte, exitCode int) error {
+// uploadGuardianPlan uploads the Guardian plan binary to the configured Guardian storage bucket.
+func (c *PlanRunCommand) uploadGuardianPlan(ctx context.Context, path string, data []byte, exitCode int) error {
 	metadata := make(map[string]string)
 	metadata["plan_exit_code"] = strconv.Itoa(exitCode)
 

--- a/pkg/commands/run/run.go
+++ b/pkg/commands/run/run.go
@@ -1,0 +1,198 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/abcxyz/guardian/pkg/flags"
+	"github.com/abcxyz/guardian/pkg/terraform"
+	"github.com/abcxyz/guardian/pkg/util"
+	"github.com/abcxyz/pkg/cli"
+	"github.com/sethvargo/go-githubactions"
+	"golang.org/x/exp/slices"
+)
+
+var _ cli.Command = (*RunCommand)(nil)
+
+type RunCommand struct {
+	cli.BaseCommand
+
+	directory string
+	childPath string
+
+	flags.GitHubFlags
+	flags.RetryFlags
+
+	flagAllowedTerraformCommands []string
+	flagTerraformCommand         string
+	flagTerraformArgs            []string
+	flagAllowLockfileChanges     bool
+	flagLockTimeout              time.Duration
+
+	actions         *githubactions.Action
+	terraformClient terraform.Terraform
+}
+
+func (c *RunCommand) Desc() string {
+	return `Run a Terraform command for a directory`
+}
+
+func (c *RunCommand) Help() string {
+	return `
+Usage: {{ COMMAND }} [options] <directory>
+
+  Run a Terraform command for a directory.
+`
+}
+
+func (c *RunCommand) Flags() *cli.FlagSet {
+	set := c.NewFlagSet()
+
+	c.GitHubFlags.Register(set)
+	c.RetryFlags.Register(set)
+
+	f := set.NewSection("COMMAND OPTIONS")
+
+	f.StringSliceVar(&cli.StringSliceVar{
+		Name:    "allowed-terraform-commands",
+		Target:  &c.flagAllowedTerraformCommands,
+		Example: "plan,apply,destroy",
+		Usage:   "The list of allowed Terraform commands to be run. Defaults to all commands.",
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "terraform-command",
+		Target:  &c.flagTerraformCommand,
+		Example: "plan",
+		Usage:   "The Terraform CLI command to run.",
+	})
+
+	f.StringSliceVar(&cli.StringSliceVar{
+		Name:    "terraform-args",
+		Target:  &c.flagTerraformArgs,
+		Example: "-no-color,-input=false",
+		Usage:   "The list arguments to provide to the Terraform CLI command.",
+	})
+
+	f.BoolVar(&cli.BoolVar{
+		Name:    "allow-lockfile-changes",
+		Target:  &c.flagAllowLockfileChanges,
+		Example: "true",
+		Usage:   "Allow modification of the Terraform lockfile.",
+	})
+
+	f.DurationVar(&cli.DurationVar{
+		Name:    "lock-timeout",
+		Target:  &c.flagLockTimeout,
+		Default: 10 * time.Minute,
+		Example: "10m",
+		Usage:   "The duration Terraform should wait to obtain a lock when running commands that modify state.",
+	})
+
+	return set
+}
+
+func (c *RunCommand) Run(ctx context.Context, args []string) error {
+	f := c.Flags()
+	if err := f.Parse(args); err != nil {
+		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+
+	parsedArgs := f.Args()
+	if len(parsedArgs) != 1 {
+		return flag.ErrHelp
+	}
+
+	dirAbs, err := util.PathEvalAbs(parsedArgs[0])
+	if err != nil {
+		return fmt.Errorf("failed to absolute path for directory: %w", err)
+	}
+	c.directory = dirAbs
+
+	cwd, err := c.WorkingDir()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	childPath, err := util.ChildPath(cwd, c.directory)
+	if err != nil {
+		return fmt.Errorf("failed to get child path for current working directory: %w", err)
+	}
+	c.childPath = childPath
+
+	c.actions = githubactions.New(githubactions.WithWriter(c.Stdout()))
+	c.terraformClient = terraform.NewTerraformClient(c.directory)
+
+	return c.Process(ctx)
+}
+
+// Process handles the main logic for the Guardian admin run process.
+func (c *RunCommand) Process(ctx context.Context) error {
+	var merr error
+
+	c.Outf("Starting Guardian run")
+
+	if len(c.flagAllowedTerraformCommands) > 0 && !slices.Contains(c.flagAllowedTerraformCommands, c.flagTerraformCommand) {
+		sort.Strings(c.flagAllowedTerraformCommands)
+		return fmt.Errorf("%s is not an allowed Terraform command.\n\nAllowed commands are %q", c.flagTerraformCommand, c.flagAllowedTerraformCommands)
+	}
+
+	if _, ok := terraform.InitRequiredCommands[c.flagTerraformCommand]; ok {
+		c.Outf("Running Terraform init")
+
+		lockfileMode := "none"
+		if !c.flagAllowLockfileChanges {
+			lockfileMode = "readonly"
+		}
+
+		if err := c.withActionsOutGroup("Initializing Terraform", func() error {
+			_, err := c.terraformClient.Init(ctx, c.Stdout(), c.Stderr(), &terraform.InitOptions{
+				Input:       util.Ptr(false),
+				Lockfile:    util.Ptr(lockfileMode),
+				LockTimeout: util.Ptr(c.flagLockTimeout.String()),
+			})
+			return err //nolint:wrapcheck // Want passthrough
+		}); err != nil {
+			return fmt.Errorf("failed to initialize: %w", err)
+		}
+	}
+
+	if err := c.withActionsOutGroup("Running Terraform command", func() error {
+		_, err := c.terraformClient.Run(ctx, c.Stdout(), c.Stderr(), c.flagTerraformCommand, c.flagTerraformArgs...)
+		return err //nolint:wrapcheck // Want passthrough
+	}); err != nil {
+		return fmt.Errorf("failed to run command: %w", err)
+	}
+
+	return merr
+}
+
+// withActionsOutGroup runs a function and ensures it is wrapped in GitHub actions
+// grouping syntax. If this is not in an action, output is printed without grouping syntax.
+func (c *RunCommand) withActionsOutGroup(msg string, fn func() error) error {
+	if c.GitHubFlags.FlagIsGitHubActions {
+		c.actions.Group(msg)
+		defer c.actions.EndGroup()
+	} else {
+		c.Outf(msg)
+	}
+
+	return fn()
+}

--- a/pkg/commands/run/run.go
+++ b/pkg/commands/run/run.go
@@ -73,7 +73,7 @@ func (c *RunCommand) Flags() *cli.FlagSet {
 	f.StringSliceVar(&cli.StringSliceVar{
 		Name:    "allowed-terraform-commands",
 		Target:  &c.flagAllowedTerraformCommands,
-		Example: "plan,apply,destroy",
+		Example: "plan, apply, destroy",
 		Usage:   "The list of allowed Terraform commands to be run. Defaults to all commands.",
 	})
 
@@ -81,7 +81,7 @@ func (c *RunCommand) Flags() *cli.FlagSet {
 		Name:    "terraform-command",
 		Target:  &c.flagTerraformCommand,
 		Example: "plan",
-		Usage:   "The Terraform CLI command to run.",
+		Usage:   "The Terraform command to run.",
 	})
 
 	f.StringSliceVar(&cli.StringSliceVar{

--- a/pkg/commands/run/run_test.go
+++ b/pkg/commands/run/run_test.go
@@ -17,7 +17,7 @@ package run
 import (
 	"context"
 	"fmt"
-	"os"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -117,7 +117,7 @@ func TestPlan_Process(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			actions := githubactions.New(githubactions.WithWriter(os.Stdout))
+			actions := githubactions.New(githubactions.WithWriter(io.Discard))
 
 			c := &RunCommand{
 				directory: "testdir",

--- a/pkg/commands/run/run_test.go
+++ b/pkg/commands/run/run_test.go
@@ -1,0 +1,155 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/abcxyz/guardian/pkg/flags"
+	"github.com/abcxyz/guardian/pkg/terraform"
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/testutil"
+	"github.com/sethvargo/go-githubactions"
+)
+
+var terraformMock = &terraform.MockTerraformClient{
+	RunResponse: &terraform.MockTerraformResponse{
+		Stdout:   "terraform run success",
+		ExitCode: 0,
+	},
+}
+
+var terraformErrorMock = &terraform.MockTerraformClient{
+	RunResponse: &terraform.MockTerraformResponse{
+		Stdout:   "terraform run output",
+		Stderr:   "terraform run failed",
+		ExitCode: 1,
+		Err:      fmt.Errorf("failed to run terraform run"),
+	},
+}
+
+func TestPlan_Process(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
+
+	cases := []struct {
+		name                         string
+		directory                    string
+		flagIsGitHubActions          bool
+		flagGitHubOwner              string
+		flagGitHubRepo               string
+		flagAllowedTerraformCommands []string
+		flagTerraformCommand         string
+		flagTerraformArgs            []string
+		flagAllowLockfileChanges     bool
+		flagLockTimeout              time.Duration
+		terraformClient              *terraform.MockTerraformClient
+		err                          string
+		expStdout                    string
+		expStderr                    string
+	}{
+		{
+			name:                         "success",
+			directory:                    "testdata",
+			flagIsGitHubActions:          true,
+			flagGitHubOwner:              "owner",
+			flagGitHubRepo:               "repo",
+			flagAllowedTerraformCommands: []string{},
+			flagTerraformCommand:         "apply",
+			flagTerraformArgs:            []string{"-no-color", "-input=false"},
+			flagAllowLockfileChanges:     true,
+			flagLockTimeout:              10 * time.Minute,
+			terraformClient:              terraformMock,
+		},
+		{
+			name:                         "retricts_allowed_commands",
+			directory:                    "testdata",
+			flagIsGitHubActions:          true,
+			flagGitHubOwner:              "owner",
+			flagGitHubRepo:               "repo",
+			flagAllowedTerraformCommands: []string{"plan"},
+			flagTerraformCommand:         "apply",
+			flagTerraformArgs:            []string{"-no-color", "-input=false"},
+			flagAllowLockfileChanges:     true,
+			flagLockTimeout:              10 * time.Minute,
+			terraformClient:              terraformMock,
+			err:                          "apply is not an allowed Terraform command.\n\nAllowed commands are [\"plan\"]",
+		},
+		{
+			name:                         "handles_errors",
+			directory:                    "testdata",
+			flagIsGitHubActions:          true,
+			flagGitHubOwner:              "owner",
+			flagGitHubRepo:               "repo",
+			flagAllowedTerraformCommands: []string{},
+			flagTerraformCommand:         "apply",
+			flagTerraformArgs:            []string{"-no-color", "-input=false"},
+			flagAllowLockfileChanges:     true,
+			flagLockTimeout:              10 * time.Minute,
+			terraformClient:              terraformErrorMock,
+			expStdout:                    "terraform run output",
+			expStderr:                    "terraform run failed",
+			err:                          "failed to run command: failed to run terraform run",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actions := githubactions.New(githubactions.WithWriter(os.Stdout))
+
+			c := &RunCommand{
+				directory: "testdir",
+				childPath: "testdir",
+
+				flagAllowedTerraformCommands: tc.flagAllowedTerraformCommands,
+				flagTerraformCommand:         tc.flagTerraformCommand,
+				flagTerraformArgs:            tc.flagTerraformArgs,
+				flagAllowLockfileChanges:     tc.flagAllowLockfileChanges,
+				flagLockTimeout:              tc.flagLockTimeout,
+				GitHubFlags: flags.GitHubFlags{
+					FlagIsGitHubActions: tc.flagIsGitHubActions,
+					FlagGitHubOwner:     tc.flagGitHubOwner,
+					FlagGitHubRepo:      tc.flagGitHubRepo,
+				},
+				actions:         actions,
+				terraformClient: tc.terraformClient,
+			}
+
+			_, stdout, stderr := c.Pipe()
+
+			err := c.Process(ctx)
+			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
+				t.Errorf(diff)
+			}
+
+			if got, want := strings.TrimSpace(stdout.String()), strings.TrimSpace(tc.expStdout); !strings.Contains(got, want) {
+				t.Errorf("expected stdout\n\n%s\n\nto contain\n\n%s\n\n", got, want)
+			}
+			if got, want := strings.TrimSpace(stderr.String()), strings.TrimSpace(tc.expStderr); !strings.Contains(got, want) {
+				t.Errorf("expected stderr\n\n%s\n\nto contain\n\n%s\n\n", got, want)
+			}
+		})
+	}
+}

--- a/pkg/github/github_mock.go
+++ b/pkg/github/github_mock.go
@@ -39,6 +39,8 @@ type MockGitHubClient struct {
 	UpdateIssueCommentsErr error
 	DeleteIssueCommentsErr error
 	ListIssueCommentsErr   error
+	RepoPermissionLevelErr error
+	RepoPermissionLevel    string
 }
 
 func (m *MockGitHubClient) ListIssues(ctx context.Context, owner, repo string, opts *github.IssueListByRepoOptions) ([]*Issue, error) {
@@ -143,4 +145,19 @@ func (m *MockGitHubClient) ListIssueComments(ctx context.Context, owner, repo st
 	}
 
 	return &IssueCommentResponse{}, nil
+}
+
+func (m *MockGitHubClient) RepoUserPermissionLevel(ctx context.Context, owner, repo, user string) (string, error) {
+	m.reqMu.Lock()
+	defer m.reqMu.Unlock()
+	m.Reqs = append(m.Reqs, &Request{
+		Name:   "RepoUserPermissionLevel",
+		Params: []any{owner, repo, user},
+	})
+
+	if m.RepoPermissionLevelErr != nil {
+		return "", m.RepoPermissionLevelErr
+	}
+
+	return m.RepoPermissionLevel, nil
 }

--- a/pkg/terraform/terraform_mock.go
+++ b/pkg/terraform/terraform_mock.go
@@ -35,6 +35,7 @@ type MockTerraformClient struct {
 	PlanResponse     *MockTerraformResponse
 	ApplyResponse    *MockTerraformResponse
 	ShowResponse     *MockTerraformResponse
+	RunResponse      *MockTerraformResponse
 }
 
 func (m *MockTerraformClient) Init(ctx context.Context, stdout, stderr io.Writer, opts *InitOptions) (int, error) {
@@ -83,10 +84,10 @@ func (m *MockTerraformClient) Show(ctx context.Context, stdout, stderr io.Writer
 }
 
 func (m *MockTerraformClient) Run(ctx context.Context, stdout, stderr io.Writer, subcommand string, args ...string) (int, error) {
-	if m.ShowResponse != nil {
-		stdout.Write([]byte(m.ShowResponse.Stdout))
-		stderr.Write([]byte(m.ShowResponse.Stderr))
-		return m.ShowResponse.ExitCode, m.ShowResponse.Err
+	if m.RunResponse != nil {
+		stdout.Write([]byte(m.RunResponse.Stdout))
+		stderr.Write([]byte(m.RunResponse.Stderr))
+		return m.RunResponse.ExitCode, m.RunResponse.Err
 	}
 	return 0, nil
 }


### PR DESCRIPTION
Closes #152 

Adds new functionality to the init command to validate github actor permission levels for the repository. This is useful when a repository administrator wants to create a more powerful workflow that can run sensitive commands to administer terraform, but wants to restrict it to repo admins or specific repo permission levels.

Adds a new run command that can run arbitrary terraform sub commands. This also adds the ability to restrict which commands are allowed to be run. This is useful when running in a github workflow for workflow_dispatch so repository admins can create a workflow that can only run a subset of commands for users to administer failures.

NOTE: all of this works and is secure because the workflow is run from main, so only administrators can create workflows and modify and merge with approval
