### PR TITLE
chore: refactor the part of init into entrypoints

### DIFF
--- a/cmd/guardian/main.go
+++ b/cmd/guardian/main.go
@@ -26,8 +26,8 @@ import (
 	"github.com/abcxyz/guardian/pkg/commands/apply"
 	"github.com/abcxyz/guardian/pkg/commands/drift"
 	"github.com/abcxyz/guardian/pkg/commands/drift/statefiles"
+	"github.com/abcxyz/guardian/pkg/commands/entrypoints"
 	"github.com/abcxyz/guardian/pkg/commands/iamcleanup"
-	"github.com/abcxyz/guardian/pkg/commands/initialize"
 	"github.com/abcxyz/guardian/pkg/commands/plan"
 	"github.com/abcxyz/guardian/pkg/commands/run"
 	"github.com/abcxyz/pkg/cli"
@@ -45,8 +45,8 @@ var rootCmd = func() cli.Command {
 		Name:    "guardian",
 		Version: version.HumanVersion,
 		Commands: map[string]cli.CommandFactory{
-			"init": func() cli.Command {
-				return &initialize.InitCommand{}
+			"entrypoints": func() cli.Command {
+				return &entrypoints.EntrypointsCommand{}
 			},
 			"plan": func() cli.Command {
 				return &cli.RootCommand{

--- a/pkg/commands/entrypoints/entrypoints.go
+++ b/pkg/commands/entrypoints/entrypoints.go
@@ -1,0 +1,251 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package entrypoints provides the functionality to determine the entrypoints for Guardian.
+package entrypoints
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/abcxyz/guardian/pkg/flags"
+	"github.com/abcxyz/guardian/pkg/git"
+	"github.com/abcxyz/guardian/pkg/terraform"
+	"github.com/abcxyz/guardian/pkg/util"
+	"github.com/abcxyz/pkg/cli"
+	"github.com/abcxyz/pkg/logging"
+	"golang.org/x/exp/maps"
+)
+
+var _ cli.Command = (*EntrypointsCommand)(nil)
+
+// allowedFormats are the allowed format flags for this command.
+var allowedFormats = map[string]struct{}{
+	"json": {},
+	"text": {},
+}
+
+type EntrypointsCommand struct {
+	cli.BaseCommand
+
+	directory string
+
+	flags.GitHubFlags
+	flags.RetryFlags
+
+	flagPullRequestNumber       int
+	flagDestRef                 string
+	flagSourceRef               string
+	flagSkipDetectChanges       bool
+	flagFormat                  string
+	flagFailUnresolvableModules bool
+
+	gitClient git.Git
+}
+
+func (c *EntrypointsCommand) Desc() string {
+	return `Determine the entrypoint directories to run Guardian commands`
+}
+
+func (c *EntrypointsCommand) Help() string {
+	return `
+Usage: {{ COMMAND }} [options] <directory>
+
+	Determine the entrypoint directories to run Guardian commands.
+`
+}
+
+func (c *EntrypointsCommand) Flags() *cli.FlagSet {
+	set := c.NewFlagSet()
+
+	c.GitHubFlags.Register(set)
+	c.RetryFlags.Register(set)
+
+	f := set.NewSection("COMMAND OPTIONS")
+
+	f.IntVar(&cli.IntVar{
+		Name:    "pull-request-number",
+		Target:  &c.flagPullRequestNumber,
+		Example: "100",
+		Usage:   "The GitHub pull request number associated with this plan run.",
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "dest-ref",
+		Target:  &c.flagDestRef,
+		Example: "ref-name",
+		Usage:   "The destination GitHub ref name for finding file changes.",
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "source-ref",
+		Target:  &c.flagSourceRef,
+		Example: "ref-name",
+		Usage:   "The source GitHub ref name for finding file changes.",
+	})
+
+	f.BoolVar(&cli.BoolVar{
+		Name:   "skip-detect-changes",
+		Target: &c.flagSkipDetectChanges,
+		Usage:  "Skip detecting file changes and run for all entrypoint directories.",
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:   "format",
+		Target: &c.flagFormat,
+		Usage:  fmt.Sprintf("The format to print the output directories. The supported formats are: %s.", strings.Join(maps.Keys(allowedFormats), ", ")),
+	})
+
+	f.BoolVar(&cli.BoolVar{
+		Name:    "fail-unresolvable-modules",
+		Target:  &c.flagFailUnresolvableModules,
+		Usage:   `Whether or not to error if a module cannot be resolved.`,
+		Default: false,
+	})
+
+	return set
+}
+
+func (c *EntrypointsCommand) Run(ctx context.Context, args []string) error {
+	f := c.Flags()
+	if err := f.Parse(args); err != nil {
+		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+
+	parsedArgs := f.Args()
+
+	if len(parsedArgs) != 1 {
+		return flag.ErrHelp
+	}
+
+	dirAbs, err := util.PathEvalAbs(parsedArgs[0])
+	if err != nil {
+		return fmt.Errorf("failed to absolute path for directory: %w", err)
+	}
+	c.directory = dirAbs
+
+	c.gitClient = git.NewGitClient(c.directory)
+
+	return c.Process(ctx)
+}
+
+// Process handles the main logic for the Guardian init process.
+func (c *EntrypointsCommand) Process(ctx context.Context) error {
+	logger := logging.FromContext(ctx).
+		With("github_owner", c.GitHubFlags.FlagGitHubOwner).
+		With("github_repo", c.GitHubFlags.FlagGitHubOwner).
+		With("pull_request_number", c.flagPullRequestNumber)
+
+	logger.DebugContext(ctx, "Starting Guardian init")
+
+	if c.flagFormat == "" {
+		c.flagFormat = "text"
+	}
+
+	if _, ok := allowedFormats[c.flagFormat]; !ok {
+		return fmt.Errorf("invalid format flag: %s (supported formats are: %s)", c.flagFormat, strings.Join(maps.Keys(allowedFormats), ", "))
+	}
+
+	logger.DebugContext(ctx, "finding entrypoint directories")
+
+	entrypoints, err := terraform.GetEntrypointDirectories(c.directory)
+	if err != nil {
+		return fmt.Errorf("failed to find terraform directories: %w", err)
+	}
+
+	entrypointDirs := make([]string, 0, len(entrypoints))
+	for _, e := range entrypoints {
+		entrypointDirs = append(entrypointDirs, e.Path)
+	}
+
+	logger.DebugContext(ctx, "terraform entrypoint directories", "entrypoint_dirs", entrypoints)
+
+	if !c.flagSkipDetectChanges {
+		logger.DebugContext(ctx, "finding git diff directories")
+
+		diffDirs, err := c.gitClient.DiffDirsAbs(ctx, c.flagDestRef, c.flagSourceRef)
+		if err != nil {
+			return fmt.Errorf("failed to find git diff directories: %w", err)
+		}
+		logger.DebugContext(ctx, "git diff directories", "directories", diffDirs)
+
+		moduleUsageGraph, err := terraform.ModuleUsage(ctx, c.directory, !c.flagFailUnresolvableModules)
+		if err != nil {
+			return fmt.Errorf("failed to get module usage for %s: %w", c.directory, err)
+		}
+
+		modifiedEntrypoints := make(map[string]struct{})
+
+		for _, changedFile := range diffDirs {
+			if entrypoints, ok := moduleUsageGraph.ModulesToEntrypoints[changedFile]; ok {
+				for entrypoint := range entrypoints {
+					modifiedEntrypoints[entrypoint] = struct{}{}
+				}
+			}
+			if _, ok := moduleUsageGraph.EntrypointToModules[changedFile]; ok {
+				modifiedEntrypoints[changedFile] = struct{}{}
+			}
+		}
+
+		files := maps.Keys(modifiedEntrypoints)
+		sort.Strings(files)
+
+		entrypointDirs = files
+	}
+
+	logger.DebugContext(ctx, "target directories", "target_directories", entrypointDirs)
+
+	if err := c.writeOutput(entrypointDirs); err != nil {
+		return fmt.Errorf("failed to write output: %w", err)
+	}
+
+	return nil
+}
+
+// writeOutput writes the command output.
+func (c *EntrypointsCommand) writeOutput(dirs []string) error {
+	cwd, err := c.WorkingDir()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	// convert to child path for output
+	// using absolute path creates an ugly github workflow name
+	for k, dir := range dirs {
+		childPath, err := util.ChildPath(cwd, dir)
+		if err != nil {
+			return fmt.Errorf("failed to get child path for: %w", err)
+		}
+		dirs[k] = childPath
+	}
+
+	switch v := strings.TrimSpace(strings.ToLower(c.flagFormat)); v {
+	case "json":
+		if err := json.NewEncoder(c.Stdout()).Encode(dirs); err != nil {
+			return fmt.Errorf("failed to create json string: %w", err)
+		}
+	case "text":
+		for _, dir := range dirs {
+			c.Outf("%s", dir)
+		}
+	default:
+		return fmt.Errorf("invalid format flag: %s (supported formats are: %s)", c.flagFormat, strings.Join(maps.Keys(allowedFormats), ", "))
+	}
+
+	return nil
+}

--- a/pkg/commands/entrypoints/entrypoints_test.go
+++ b/pkg/commands/entrypoints/entrypoints_test.go
@@ -1,0 +1,176 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entrypoints
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/abcxyz/guardian/pkg/flags"
+	"github.com/abcxyz/guardian/pkg/git"
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/testutil"
+)
+
+func TestEntrypointsProcess(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name                  string
+		directory             string
+		flagIsGitHubActions   bool
+		flagGitHubOwner       string
+		flagGitHubRepo        string
+		flagPullRequestNumber int
+		flagDestRef           string
+		flagSourceRef         string
+		flagSkipDetectChanges bool
+		flagFormat            string
+		gitClient             *git.MockGitClient
+		err                   string
+		expStdout             string
+		expStderr             string
+	}{
+		{
+			name:                  "success",
+			directory:             "testdata",
+			flagIsGitHubActions:   true,
+			flagGitHubOwner:       "owner",
+			flagGitHubRepo:        "repo",
+			flagPullRequestNumber: 1,
+			flagDestRef:           "main",
+			flagSourceRef:         "ldap/feature",
+			gitClient: &git.MockGitClient{
+				DiffResp: []string{
+					path.Join(cwd, "testdata/backends/project1"),
+					path.Join(cwd, "testdata/backends/project2"),
+				},
+			},
+			expStdout: "testdata/backends/project1\ntestdata/backends/project2",
+		},
+		{
+			name:                  "returns_json",
+			directory:             "testdata",
+			flagFormat:            "json",
+			flagIsGitHubActions:   true,
+			flagGitHubOwner:       "owner",
+			flagGitHubRepo:        "repo",
+			flagPullRequestNumber: 3,
+			flagDestRef:           "main",
+			flagSourceRef:         "ldap/feature",
+			gitClient: &git.MockGitClient{
+				DiffResp: []string{
+					path.Join(cwd, "testdata/backends/project1"),
+					path.Join(cwd, "testdata/backends/project2"),
+				},
+			},
+			expStdout: "[\"testdata/backends/project1\",\"testdata/backends/project2\"]",
+		},
+		{
+			name:                  "invalid_format",
+			directory:             "testdata",
+			flagIsGitHubActions:   true,
+			flagGitHubOwner:       "owner",
+			flagGitHubRepo:        "repo",
+			flagPullRequestNumber: 3,
+			flagDestRef:           "main",
+			flagSourceRef:         "ldap/feature",
+			flagFormat:            "yaml",
+			gitClient: &git.MockGitClient{
+				DiffResp: []string{
+					path.Join(cwd, "testdata/backends/project1"),
+					path.Join(cwd, "testdata/backends/project2"),
+				},
+			},
+			err: "invalid format flag: yaml",
+		},
+		{
+			name:                  "skips_detect_changes",
+			directory:             "testdata",
+			flagIsGitHubActions:   true,
+			flagGitHubOwner:       "owner",
+			flagGitHubRepo:        "repo",
+			flagPullRequestNumber: 1,
+			flagDestRef:           "main",
+			flagSourceRef:         "ldap/feature",
+			flagSkipDetectChanges: true,
+			gitClient:             &git.MockGitClient{},
+			expStdout:             "testdata/backends/project1\ntestdata/backends/project2",
+		},
+		{
+			name:                  "errors",
+			directory:             "testdata",
+			flagIsGitHubActions:   true,
+			flagGitHubOwner:       "owner",
+			flagGitHubRepo:        "repo",
+			flagPullRequestNumber: 2,
+			flagDestRef:           "main",
+			flagSourceRef:         "ldap/feature",
+			gitClient: &git.MockGitClient{
+				DiffErr: fmt.Errorf("failed to run git diff"),
+			},
+			err: "failed to find git diff directories: failed to run git diff",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &EntrypointsCommand{
+				directory: tc.directory,
+
+				flagPullRequestNumber: tc.flagPullRequestNumber,
+				flagFormat:            tc.flagFormat,
+				flagDestRef:           tc.flagDestRef,
+				flagSourceRef:         tc.flagSourceRef,
+				flagSkipDetectChanges: tc.flagSkipDetectChanges,
+				GitHubFlags: flags.GitHubFlags{
+					FlagIsGitHubActions: tc.flagIsGitHubActions,
+					FlagGitHubOwner:     tc.flagGitHubOwner,
+					FlagGitHubRepo:      tc.flagGitHubRepo,
+				},
+				gitClient: tc.gitClient,
+			}
+
+			_, stdout, stderr := c.Pipe()
+
+			err := c.Process(ctx)
+			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
+				t.Errorf(diff)
+			}
+
+			if got, want := strings.TrimSpace(stdout.String()), strings.TrimSpace(tc.expStdout); !strings.Contains(got, want) {
+				t.Errorf("expected stdout\n\n%s\n\nto contain\n\n%s\n\n", got, want)
+			}
+			if got, want := strings.TrimSpace(stderr.String()), strings.TrimSpace(tc.expStderr); !strings.Contains(got, want) {
+				t.Errorf("expected stderr\n\n%s\n\nto contain\n\n%s\n\n", got, want)
+			}
+		})
+	}
+}

--- a/pkg/commands/entrypoints/testdata/backends/project1/main.tf
+++ b/pkg/commands/entrypoints/testdata/backends/project1/main.tf
@@ -1,0 +1,17 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  backend "local" {}
+}

--- a/pkg/commands/entrypoints/testdata/backends/project2/main.tf
+++ b/pkg/commands/entrypoints/testdata/backends/project2/main.tf
@@ -1,0 +1,17 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  backend "local" {}
+}

--- a/pkg/commands/entrypoints/testdata/no-backends/project1/main.tf
+++ b/pkg/commands/entrypoints/testdata/no-backends/project1/main.tf
@@ -1,0 +1,15 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {}

--- a/pkg/commands/entrypoints/testdata/no-backends/project2/main.tf
+++ b/pkg/commands/entrypoints/testdata/no-backends/project2/main.tf
@@ -1,0 +1,15 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {}


### PR DESCRIPTION
The command `initialize` seems to being doing too much and is confusing. It currently mixes core logic (finding entrypoints) with GitHub specific logic (deleting PR comments, required permissions, etc).

This PR is one of multiple PRs that will split this logic apart.

In this PR, the logic related to determining the Guardian entrypoints is moved to its own command. The follow up PRs will create a new command for handling GitHub specific logic.