### PR TITLE
feat: migrate plan-status to go

### DIFF
--- a/pkg/commands/plan/plan_run.go
+++ b/pkg/commands/plan/plan_run.go
@@ -121,6 +121,26 @@ func (c *PlanRunCommand) Flags() *cli.FlagSet {
 		Usage:   "The duration Terraform should wait to obtain a lock when running commands that modify state.",
 	})
 
+	set.AfterParse(func(existingErr error) (merr error) {
+		if c.GitHubFlags.FlagGitHubOwner == "" {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: github-owner is required"))
+		}
+
+		if c.GitHubFlags.FlagGitHubRepo == "" {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: github-repo is required"))
+		}
+
+		if c.flagPullRequestNumber <= 0 {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: pull-request-number is required"))
+		}
+
+		if c.flagBucketName == "" {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: bucket-name is required"))
+		}
+
+		return merr
+	})
+
 	return set
 }
 

--- a/pkg/commands/plan/plan_run_test.go
+++ b/pkg/commands/plan/plan_run_test.go
@@ -32,6 +32,48 @@ import (
 	"github.com/sethvargo/go-githubactions"
 )
 
+func TestAfterParse(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		err  string
+	}{
+		{
+			name: "validate_github_flags",
+			args: []string{"-pull-request-number=1", "-bucket-name=my-bucket"},
+			err:  "missing flag: github-owner is required\nmissing flag: github-repo is required",
+		},
+		{
+			name: "validate_pull_request_number",
+			args: []string{"-github-owner=owner", "-github-repo=repo", "-bucket-name=my-bucket"},
+			err:  "missing flag: pull-request-number is required",
+		},
+		{
+			name: "validate_bucket_name",
+			args: []string{"-github-owner=owner", "-github-repo=repo", "-pull-request-number=1"},
+			err:  "missing flag: bucket-name is required",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &PlanRunCommand{}
+
+			f := c.Flags()
+			err := f.Parse(tc.args)
+			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}
+
 var terraformNoDiffMock = &terraform.MockTerraformClient{
 	InitResponse: &terraform.MockTerraformResponse{
 		Stdout:   "terraform init success",

--- a/pkg/commands/workflows/config.go
+++ b/pkg/commands/workflows/config.go
@@ -21,14 +21,46 @@ import (
 	"github.com/sethvargo/go-githubactions"
 )
 
-// Config defines the of configuration required for running Guardian in GitHub workflows.
-type Config struct {
+// PlanStatusCommentsConfig defines the of configuration required for running the plan status comments
+// command for GitHub workflows.
+type PlanStatusCommentsConfig struct {
+	// GitHub context values
+	ServerURL  string // this value is used to generate URLs for creating links in pull request comments
+	RunID      int64
+	RunAttempt int64
+}
+
+// MapGitHubContext maps values from the GitHub context.
+func (c *PlanStatusCommentsConfig) MapGitHubContext(context *githubactions.GitHubContext) error {
+	var merr error
+
+	c.ServerURL = context.ServerURL
+	if c.ServerURL == "" {
+		merr = errors.Join(merr, fmt.Errorf("GITHUB_SERVER_URL is required"))
+	}
+
+	c.RunID = context.RunID
+	if c.RunID <= 0 {
+		merr = errors.Join(merr, fmt.Errorf("GITHUB_RUN_ID is required"))
+	}
+
+	c.RunAttempt = context.RunAttempt
+	if c.RunAttempt <= 0 {
+		merr = errors.Join(merr, fmt.Errorf("GITHUB_RUN_ATTEMPT is required"))
+	}
+
+	return merr
+}
+
+// ValidatePermissionsConfig defines the of configuration required for running the
+// validate permissions command for GitHub workflows.
+type ValidatePermissionsConfig struct {
 	// GitHub context values
 	Actor string
 }
 
-// MapGitHubContext maps values from the GitHub context to the Config.
-func (c *Config) MapGitHubContext(context *githubactions.GitHubContext) error {
+// MapGitHubContext maps values from the GitHub context.
+func (c *ValidatePermissionsConfig) MapGitHubContext(context *githubactions.GitHubContext) error {
 	var merr error
 
 	c.Actor = context.Actor

--- a/pkg/commands/workflows/config_test.go
+++ b/pkg/commands/workflows/config_test.go
@@ -22,13 +22,65 @@ import (
 	"github.com/sethvargo/go-githubactions"
 )
 
-func TestConfig_MapGitHubContext(t *testing.T) {
+func TestPlanStatusCommentsConfig_MapGitHubContext(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name          string
 		githubContext *githubactions.GitHubContext
-		exp           *Config
+		exp           *PlanStatusCommentsConfig
+		err           string
+	}{
+		{
+			name: "success",
+			githubContext: &githubactions.GitHubContext{
+				ServerURL:  "https://github.com",
+				RunID:      1,
+				RunAttempt: 1,
+			},
+			exp: &PlanStatusCommentsConfig{
+				ServerURL:  "https://github.com",
+				RunID:      1,
+				RunAttempt: 1,
+			},
+		},
+		{
+			name:          "error",
+			githubContext: &githubactions.GitHubContext{},
+			exp:           &PlanStatusCommentsConfig{},
+			err:           "GITHUB_SERVER_URL is required\nGITHUB_RUN_ID is required\nGITHUB_RUN_ATTEMPT is required",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c PlanStatusCommentsConfig
+
+			err := c.MapGitHubContext(tc.githubContext)
+			if err != nil || tc.err != "" {
+				if diff := testutil.DiffErrString(err, tc.err); diff != "" {
+					t.Fatal(diff)
+				}
+			}
+
+			if diff := cmp.Diff(&c, tc.exp); diff != "" {
+				t.Errorf("got %#v, want %#v, diff (-got, +want): %v", &c, tc.exp, diff)
+			}
+		})
+	}
+}
+
+func TestValidatePermissionsConfig_MapGitHubContext(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		githubContext *githubactions.GitHubContext
+		exp           *ValidatePermissionsConfig
 		err           string
 	}{
 		{
@@ -36,14 +88,14 @@ func TestConfig_MapGitHubContext(t *testing.T) {
 			githubContext: &githubactions.GitHubContext{
 				Actor: "actor",
 			},
-			exp: &Config{
+			exp: &ValidatePermissionsConfig{
 				Actor: "actor",
 			},
 		},
 		{
 			name:          "error",
 			githubContext: &githubactions.GitHubContext{},
-			exp:           &Config{},
+			exp:           &ValidatePermissionsConfig{},
 			err:           "GITHUB_ACTOR is required",
 		},
 	}
@@ -54,7 +106,7 @@ func TestConfig_MapGitHubContext(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			var c Config
+			var c ValidatePermissionsConfig
 
 			err := c.MapGitHubContext(tc.githubContext)
 			if err != nil || tc.err != "" {

--- a/pkg/commands/workflows/plan_status_comments.go
+++ b/pkg/commands/workflows/plan_status_comments.go
@@ -1,0 +1,225 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package provides worklow helper functionality for Guardian.
+package workflows
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/abcxyz/guardian/pkg/commands/plan"
+	"github.com/abcxyz/guardian/pkg/flags"
+	"github.com/abcxyz/guardian/pkg/github"
+	"github.com/abcxyz/pkg/cli"
+	"github.com/abcxyz/pkg/logging"
+	"github.com/sethvargo/go-githubactions"
+	"golang.org/x/exp/slices"
+)
+
+var _ cli.Command = (*PlanStatusCommentsCommand)(nil)
+
+type PlanStatusCommentsCommand struct {
+	cli.BaseCommand
+
+	cfg *PlanStatusCommentsConfig
+
+	gitHubLogURL string
+
+	flags.GitHubFlags
+	flags.RetryFlags
+
+	flagPullRequestNumber int
+	flagInitResult        string
+	flagPlanResult        string
+
+	actions      *githubactions.Action
+	gitHubClient github.GitHub
+}
+
+func (c *PlanStatusCommentsCommand) Desc() string {
+	return `Remove previous Guardian plan comments from a pull request`
+}
+
+func (c *PlanStatusCommentsCommand) Help() string {
+	return `
+Usage: {{ COMMAND }} [options] <pull_request_number>
+
+	Remove previous Guardian plan comments from a pull request.
+`
+}
+
+func (c *PlanStatusCommentsCommand) Flags() *cli.FlagSet {
+	set := c.NewFlagSet()
+
+	c.GitHubFlags.Register(set)
+	c.RetryFlags.Register(set)
+
+	f := set.NewSection("COMMAND OPTIONS")
+
+	f.IntVar(&cli.IntVar{
+		Name:    "pull-request-number",
+		Target:  &c.flagPullRequestNumber,
+		Example: "100",
+		Usage:   "The GitHub pull request number to remove plan comments from.",
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "init-result",
+		Target:  &c.flagInitResult,
+		Example: "success",
+		Usage:   "The Guardian init job result status.",
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "plan-result",
+		Target:  &c.flagPlanResult,
+		Example: "failure",
+		Usage:   "The Guardian plan job result status.",
+	})
+
+	set.AfterParse(func(existingErr error) (merr error) {
+		if c.GitHubFlags.FlagGitHubOwner == "" {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: github-owner is required"))
+		}
+
+		if c.GitHubFlags.FlagGitHubRepo == "" {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: github-repo is required"))
+		}
+
+		if c.flagPullRequestNumber <= 0 {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: pull-request-number is required"))
+		}
+
+		if c.flagInitResult == "" {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: init-result is required"))
+		}
+
+		if c.flagPlanResult == "" {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: plan-result is required"))
+		}
+
+		return merr
+	})
+
+	return set
+}
+
+func (c *PlanStatusCommentsCommand) Run(ctx context.Context, args []string) error {
+	logger := logging.FromContext(ctx)
+
+	f := c.Flags()
+	if err := f.Parse(args); err != nil {
+		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+
+	parsedArgs := f.Args()
+	if len(parsedArgs) > 0 {
+		return flag.ErrHelp
+	}
+
+	c.actions = githubactions.New(githubactions.WithWriter(c.Stdout()))
+	actionsCtx, err := c.actions.Context()
+	if err != nil {
+		return fmt.Errorf("failed to load github context: %w", err)
+	}
+
+	c.cfg = &PlanStatusCommentsConfig{}
+	if err := c.cfg.MapGitHubContext(actionsCtx); err != nil {
+		return fmt.Errorf("failed to load github context: %w", err)
+	}
+	logger.DebugContext(ctx, "loaded configuration", "plan_status_comments_config", c.cfg)
+
+	c.gitHubClient = github.NewClient(
+		ctx,
+		c.GitHubFlags.FlagGitHubToken,
+		github.WithRetryInitialDelay(c.RetryFlags.FlagRetryInitialDelay),
+		github.WithRetryMaxAttempts(c.RetryFlags.FlagRetryMaxAttempts),
+		github.WithRetryMaxDelay(c.RetryFlags.FlagRetryMaxDelay),
+	)
+
+	return c.Process(ctx)
+}
+
+// Process handles the main logic for the Guardian remove plan comments process.
+func (c *PlanStatusCommentsCommand) Process(ctx context.Context) error {
+	logger := logging.FromContext(ctx).
+		With("github_owner", c.GitHubFlags.FlagGitHubOwner).
+		With("github_repo", c.GitHubFlags.FlagGitHubOwner).
+		With("init_result", c.flagInitResult).
+		With("plan_result", c.flagPlanResult)
+
+	logger.DebugContext(ctx, "determining plan status...")
+
+	c.gitHubLogURL = fmt.Sprintf("[[logs](%s/%s/%s/actions/runs/%d/attempts/%d)]", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, c.cfg.RunAttempt)
+	logger.DebugContext(ctx, "computed github log url", "github_log_url", c.gitHubLogURL)
+
+	// this case improves user experience, when the planning job does not have a plan diff
+	// there are no comments, this informs the user that the job ran successfully
+	if c.flagInitResult == "success" && c.flagPlanResult == "success" {
+		if _, err := c.gitHubClient.CreateIssueComment(
+			ctx,
+			c.GitHubFlags.FlagGitHubOwner,
+			c.GitHubFlags.FlagGitHubRepo,
+			c.flagPullRequestNumber,
+			fmt.Sprintf("%s 🟩 Plan completed successfully. %s", plan.CommentPrefix, c.gitHubLogURL),
+		); err != nil {
+			return fmt.Errorf("failed to create plan status comment: %w", err)
+		}
+
+		return nil
+	}
+
+	// this case does not require a comment because the planning job should
+	// have commented that there was a failure, for which directory
+	if c.flagInitResult == "failure" || c.flagPlanResult == "failure" {
+		return fmt.Errorf("init or plan has one or more failures")
+	}
+
+	// this case improves user experience, when no Terraform changes were submitted
+	// the plan job is skipped, this informs the user that the job ran successfully
+	// but no changes are needed
+	if c.flagInitResult == "success" && c.flagPlanResult == "skipped" {
+		if _, err := c.gitHubClient.CreateIssueComment(
+			ctx,
+			c.GitHubFlags.FlagGitHubOwner,
+			c.GitHubFlags.FlagGitHubRepo,
+			c.flagPullRequestNumber,
+			fmt.Sprintf("%s 🟦 No Terraform changes detect, planning skipped. %s", plan.CommentPrefix, c.gitHubLogURL),
+		); err != nil {
+			return fmt.Errorf("failed to create plan status comment: %w", err)
+		}
+
+		return nil
+	}
+
+	indeterminateStatuses := []string{"skipped", "cancelled"}
+	if slices.Contains(indeterminateStatuses, c.flagInitResult) || slices.Contains(indeterminateStatuses, c.flagPlanResult) {
+		if _, err := c.gitHubClient.CreateIssueComment(
+			ctx,
+			c.GitHubFlags.FlagGitHubOwner,
+			c.GitHubFlags.FlagGitHubRepo,
+			c.flagPullRequestNumber,
+			fmt.Sprintf("%s 🟨 Unable to determine plan status. %s", plan.CommentPrefix, c.gitHubLogURL),
+		); err != nil {
+			return fmt.Errorf("failed to create plan status comment: %w", err)
+		}
+
+		return fmt.Errorf("unable to determine plan status, init and/or plan was skipped or cancelled")
+	}
+
+	return nil
+}

--- a/pkg/commands/workflows/plan_status_comments_test.go
+++ b/pkg/commands/workflows/plan_status_comments_test.go
@@ -17,18 +17,19 @@ package workflows
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
-	"github.com/abcxyz/guardian/pkg/commands/plan"
 	"github.com/abcxyz/guardian/pkg/flags"
 	"github.com/abcxyz/guardian/pkg/github"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
+	"github.com/sethvargo/go-githubactions"
 )
 
-func TestRemovePlanCommentsAfterParse(t *testing.T) {
+func TestPlanStatusCommentsAfterParse(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -38,13 +39,23 @@ func TestRemovePlanCommentsAfterParse(t *testing.T) {
 	}{
 		{
 			name: "validate_github_flags",
-			args: []string{"-pull-request-number=1"},
+			args: []string{"-pull-request-number=1", "-init-result=success", "-plan-result=success"},
 			err:  "missing flag: github-owner is required\nmissing flag: github-repo is required",
 		},
 		{
 			name: "validate_pull_request_number",
-			args: []string{"-github-owner=owner", "-github-repo=repo"},
+			args: []string{"-github-owner=owner", "-github-repo=repo", "-init-result=success", "-plan-result=success"},
 			err:  "missing flag: pull-request-number is required",
+		},
+		{
+			name: "validate_init_result",
+			args: []string{"-github-owner=owner", "-github-repo=repo", "-pull-request-number=1", "-plan-result=success"},
+			err:  "missing flag: init-result is required",
+		},
+		{
+			name: "validate_plan_result",
+			args: []string{"-github-owner=owner", "-github-repo=repo", "-pull-request-number=1", "-init-result=success"},
+			err:  "missing flag: plan-result is required",
 		},
 	}
 
@@ -54,7 +65,7 @@ func TestRemovePlanCommentsAfterParse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			c := &RemovePlanCommentsCommand{}
+			c := &PlanStatusCommentsCommand{}
 
 			f := c.Flags()
 			err := f.Parse(tc.args)
@@ -65,10 +76,16 @@ func TestRemovePlanCommentsAfterParse(t *testing.T) {
 	}
 }
 
-func TestRemovePlanCommentsProcess(t *testing.T) {
+func TestPlanStatusCommentsProcess(t *testing.T) {
 	t.Parallel()
 
 	ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
+
+	defaultConfig := &PlanStatusCommentsConfig{
+		ServerURL:  "https://github.com",
+		RunID:      int64(100),
+		RunAttempt: int64(1),
+	}
 
 	cases := []struct {
 		name                  string
@@ -77,6 +94,8 @@ func TestRemovePlanCommentsProcess(t *testing.T) {
 		flagGitHubOwner       string
 		flagGitHubRepo        string
 		flagPullRequestNumber int
+		flagInitResult        string
+		flagPlanResult        string
 		gitHubClient          *github.MockGitHubClient
 		err                   string
 		expGitHubClientReqs   []*github.Request
@@ -89,27 +108,49 @@ func TestRemovePlanCommentsProcess(t *testing.T) {
 			flagGitHubOwner:       "owner",
 			flagGitHubRepo:        "repo",
 			flagPullRequestNumber: 1,
-			gitHubClient: &github.MockGitHubClient{
-				ListIssueCommentResponse: &github.IssueCommentResponse{
-					Comments: []*github.IssueComment{
-						{
-							ID:   1,
-							Body: plan.CommentPrefix + " comment message",
-						},
-					},
-				},
-			},
+			flagInitResult:        "success",
+			flagPlanResult:        "success",
+			gitHubClient:          &github.MockGitHubClient{},
 			expGitHubClientReqs: []*github.Request{
 				{
-					Name:   "ListIssueComments",
-					Params: []any{"owner", "repo", 1},
-				},
-				{
-					Name:   "DeleteIssueComment",
-					Params: []any{"owner", "repo", int64(1)},
+					Name:   "CreateIssueComment",
+					Params: []any{"owner", "repo", 1, "**`🔱 Guardian 🔱 PLAN`** - 🟩 Plan completed successfully. [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
 				},
 			},
 			err:       "",
+			expStdout: "",
+			expStderr: "",
+		},
+		{
+			name:                  "failure",
+			flagIsGitHubActions:   true,
+			flagGitHubOwner:       "owner",
+			flagGitHubRepo:        "repo",
+			flagPullRequestNumber: 2,
+			flagInitResult:        "failure",
+			flagPlanResult:        "failure",
+			gitHubClient:          &github.MockGitHubClient{},
+			expGitHubClientReqs:   nil,
+			err:                   "init or plan has one or more failures",
+			expStdout:             "",
+			expStderr:             "",
+		},
+		{
+			name:                  "indeterminate",
+			flagIsGitHubActions:   true,
+			flagGitHubOwner:       "owner",
+			flagGitHubRepo:        "repo",
+			flagPullRequestNumber: 3,
+			flagInitResult:        "cancelled",
+			flagPlanResult:        "skipped",
+			gitHubClient:          &github.MockGitHubClient{},
+			expGitHubClientReqs: []*github.Request{
+				{
+					Name:   "CreateIssueComment",
+					Params: []any{"owner", "repo", 3, "**`🔱 Guardian 🔱 PLAN`** - 🟨 Unable to determine plan status. [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
+				},
+			},
+			err:       "unable to determine plan status, init and/or plan was skipped or cancelled",
 			expStdout: "",
 			expStderr: "",
 		},
@@ -118,17 +159,19 @@ func TestRemovePlanCommentsProcess(t *testing.T) {
 			flagIsGitHubActions:   true,
 			flagGitHubOwner:       "owner",
 			flagGitHubRepo:        "repo",
-			flagPullRequestNumber: 2,
+			flagPullRequestNumber: 4,
+			flagInitResult:        "success",
+			flagPlanResult:        "success",
 			gitHubClient: &github.MockGitHubClient{
-				ListIssueCommentsErr: fmt.Errorf("error getting comments"),
+				CreateIssueCommentsErr: fmt.Errorf("error creating comment"),
 			},
 			expGitHubClientReqs: []*github.Request{
 				{
-					Name:   "ListIssueComments",
-					Params: []any{"owner", "repo", 2},
+					Name:   "CreateIssueComment",
+					Params: []any{"owner", "repo", 4, "**`🔱 Guardian 🔱 PLAN`** - 🟩 Plan completed successfully. [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
 				},
 			},
-			err:       "failed to list comments: error getting comments",
+			err:       "failed to create plan status comment: error creating comment",
 			expStdout: "",
 			expStderr: "",
 		},
@@ -140,13 +183,20 @@ func TestRemovePlanCommentsProcess(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			c := &RemovePlanCommentsCommand{
+			actions := githubactions.New(githubactions.WithWriter(os.Stdout))
+
+			c := &PlanStatusCommentsCommand{
+				cfg: defaultConfig,
+
 				GitHubFlags: flags.GitHubFlags{
 					FlagIsGitHubActions: tc.flagIsGitHubActions,
 					FlagGitHubOwner:     tc.flagGitHubOwner,
 					FlagGitHubRepo:      tc.flagGitHubRepo,
 				},
 				flagPullRequestNumber: tc.flagPullRequestNumber,
+				flagInitResult:        tc.flagInitResult,
+				flagPlanResult:        tc.flagPlanResult,
+				actions:               actions,
 				gitHubClient:          tc.gitHubClient,
 			}
 

--- a/pkg/commands/workflows/remove_plan_comments.go
+++ b/pkg/commands/workflows/remove_plan_comments.go
@@ -17,6 +17,7 @@ package workflows
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"strings"
@@ -67,6 +68,22 @@ func (c *RemovePlanCommentsCommand) Flags() *cli.FlagSet {
 		Target:  &c.flagPullRequestNumber,
 		Example: "100",
 		Usage:   "The GitHub pull request number to remove plan comments from.",
+	})
+
+	set.AfterParse(func(existingErr error) (merr error) {
+		if c.GitHubFlags.FlagGitHubOwner == "" {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: github-owner is required"))
+		}
+
+		if c.GitHubFlags.FlagGitHubRepo == "" {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: github-repo is required"))
+		}
+
+		if c.flagPullRequestNumber <= 0 {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: pull-request-number is required"))
+		}
+
+		return merr
 	})
 
 	return set

--- a/pkg/commands/workflows/validate_permissions_test.go
+++ b/pkg/commands/workflows/validate_permissions_test.go
@@ -28,6 +28,38 @@ import (
 	"github.com/sethvargo/go-githubactions"
 )
 
+func TestValidatePermissionsAfterParse(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		err  string
+	}{
+		{
+			name: "validate_github_flags",
+			args: []string{},
+			err:  "missing flag: github-owner is required\nmissing flag: github-repo is required",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &ValidatePermissionsCommand{}
+
+			f := c.Flags()
+			err := f.Parse(tc.args)
+			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}
+
 func TestValidatePermissionsProcess(t *testing.T) {
 	t.Parallel()
 
@@ -35,7 +67,7 @@ func TestValidatePermissionsProcess(t *testing.T) {
 
 	cases := []struct {
 		name                   string
-		config                 *Config
+		config                 *ValidatePermissionsConfig
 		flagIsGitHubActions    bool
 		flagGitHubOwner        string
 		flagGitHubRepo         string
@@ -47,7 +79,7 @@ func TestValidatePermissionsProcess(t *testing.T) {
 	}{
 		{
 			name:                   "allowed",
-			config:                 &Config{Actor: "testuser"},
+			config:                 &ValidatePermissionsConfig{Actor: "testuser"},
 			flagIsGitHubActions:    true,
 			flagGitHubOwner:        "owner",
 			flagGitHubRepo:         "repo",
@@ -64,7 +96,7 @@ func TestValidatePermissionsProcess(t *testing.T) {
 		},
 		{
 			name:                   "denied",
-			config:                 &Config{Actor: "testuser"},
+			config:                 &ValidatePermissionsConfig{Actor: "testuser"},
 			flagIsGitHubActions:    true,
 			flagGitHubOwner:        "owner",
 			flagGitHubRepo:         "repo",


### PR DESCRIPTION
Migrate the existing plan-status action to the workflows command. This command is used by a github workflow as a post status job. The users can configured required status checks to ensure this check is required because when using a matrix strategy, the plan job has dynamic names and makes it impossible to have required status checks for all possible directories.

This change also cleans up required flags for several commands and adds tests for them.