### PR TITLE
fix: guardian apply plan file path

### DIFF
--- a/pkg/commands/apply/apply_run_test.go
+++ b/pkg/commands/apply/apply_run_test.go
@@ -255,7 +255,7 @@ func TestApply_Process(t *testing.T) {
 
 				directory:    tc.directory,
 				childPath:    tc.directory,
-				planFilename: "test-tfplan.binary",
+				planFileName: "test-tfplan.binary",
 
 				flagCommitSHA:            tc.flagCommitSHA,
 				flagPullRequestNumber:    tc.flagPullRequestNumber,


### PR DESCRIPTION
- Terraform apply needs the full path to the plan file in the temp dir
- Renamed `planFilename` -> `planFileName`