### PR TITLE
fix: ignore deleted dirs for git diff

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -18,8 +18,9 @@ package git
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -88,7 +89,7 @@ func parseSortedDiffDirsAbs(ctx context.Context, stdout string) ([]string, error
 			dir := filepath.Dir(line)
 
 			path, err := util.PathEvalAbs(dir)
-			if err != nil && os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -64,7 +65,7 @@ func (g *GitClient) DiffDirsAbs(ctx context.Context, sourceRef, destRef string) 
 		Stderr:     &stderr,
 		WorkingDir: g.workingDir,
 		Command:    "git",
-		Args:       []string{"diff", fmt.Sprintf("%s..%s", sourceRef, destRef), "--name-only", "--diff-filter=d"},
+		Args:       []string{"diff", fmt.Sprintf("%s..%s", sourceRef, destRef), "--name-only"},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to run git diff command: %w\n\n%s", err, stderr.String())
@@ -87,6 +88,10 @@ func parseSortedDiffDirsAbs(ctx context.Context, stdout string) ([]string, error
 			dir := filepath.Dir(line)
 
 			path, err := util.PathEvalAbs(dir)
+			if err != nil && os.IsNotExist(err) {
+				continue
+			}
+
 			if err != nil {
 				return nil, fmt.Errorf("failed to get absolute path for directory %s: %w", dir, err)
 			}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -50,6 +50,18 @@ testdata/third/test.txt`,
 			},
 		},
 		{
+			name: "ignores_missing_dir",
+			value: `testdata/first/test.txt
+testdata/second/test.txt
+testdata/third/test.txt
+testdata/fourth/test.txt`,
+			exp: []string{
+				path.Join(cwd, "testdata/first"),
+				path.Join(cwd, "testdata/second"),
+				path.Join(cwd, "testdata/third"),
+			},
+		},
+		{
 			name:  "carriage_return_and_newline",
 			value: "testdata/first/test.txt\r\ntestdata/third/test.txt\r\ntestdata/second/test.txt",
 			exp: []string{
@@ -64,11 +76,6 @@ testdata/third/test.txt`,
 testdata/second
 testdata/third`,
 			exp: []string{path.Join(cwd, "testdata")},
-		},
-		{
-			name:  "returns_error",
-			value: "testdata/does_not_exist/test.txt",
-			err:   "failed to get absolute path for directory testdata/does_not_exist",
 		},
 		{
 			name:  "handles_empty",

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -58,12 +58,12 @@ func ChildPath(base, target string) (string, error) {
 func PathEvalAbs(path string) (string, error) {
 	sym, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve symlinks for path: %w", err)
+		return "", err //nolint:wrapcheck // Want passthrough
 	}
 
 	abs, err := filepath.Abs(sym)
 	if err != nil {
-		return "", fmt.Errorf("failed to compute absolute path: %w", err)
+		return "", err //nolint:wrapcheck // Want passthrough
 	}
 
 	return abs, nil

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"os"
 	"testing"
 
 	"github.com/abcxyz/pkg/testutil"
@@ -83,11 +84,48 @@ func TestChildPath(t *testing.T) {
 func TestPathEvalAbs(t *testing.T) {
 	t.Parallel()
 
-	dir, err := PathEvalAbs(".")
+	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if dir == "" {
-		t.Errorf("expected dir to be defined")
+
+	cases := []struct {
+		name string
+		dir  string
+		exp  string
+		err  string
+	}{
+		{
+			name: "success",
+			dir:  ".",
+			exp:  cwd,
+		},
+		{
+			name: "empty",
+			dir:  "",
+			exp:  cwd,
+		},
+		{
+			name: "missing_dir",
+			dir:  "./not_a_real_dir",
+			err:  "lstat not_a_real_dir: no such file or directory",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir, err := PathEvalAbs(tc.dir)
+			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
+				t.Errorf(diff)
+			}
+
+			if got, want := dir, tc.exp; got != want {
+				t.Errorf("expected %s to be %s", got, want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The previous fix didn't account for only deleting a single file, which would still require the directory to be plan/applied.

In this solution, if a whole directory is deleted, and the directory cannot be found, it will be ignored.