### PR TITLE
feat: update statefile drift to check all repos and buckets

### DIFF
--- a/pkg/commands/drift/github.go
+++ b/pkg/commands/drift/github.go
@@ -50,7 +50,7 @@ func (s *GitHubDriftIssueService) CreateOrUpdateIssue(ctx context.Context, assig
 
 	var issueNumber int
 	if len(issues) == 0 {
-		issue, err := s.gh.CreateIssue(ctx, s.owner, s.repo, issueTitle, issueBody, assignees, labels)
+		issue, err := s.gh.CreateIssue(ctx, s.owner, s.repo, s.issueTitle, s.issueBody, assignees, labels)
 		if err != nil {
 			return fmt.Errorf("failed to create GitHub issue for %s/%s with assignees %s and labels %s: %w", s.owner, s.repo, assignees, labels, err)
 		}

--- a/pkg/commands/drift/github.go
+++ b/pkg/commands/drift/github.go
@@ -23,14 +23,14 @@ import (
 )
 
 type GitHubDriftIssueService struct {
-	gh         *github.GitHubClient
+	gh         github.GitHub
 	owner      string
 	repo       string
 	issueTitle string
 	issueBody  string
 }
 
-func NewGitHubDriftIssueService(gh *github.GitHubClient, owner, repo, issueTitle, issueBody string) *GitHubDriftIssueService {
+func NewGitHubDriftIssueService(gh github.GitHub, owner, repo, issueTitle, issueBody string) *GitHubDriftIssueService {
 	return &GitHubDriftIssueService{gh, owner, repo, issueTitle, issueBody}
 }
 

--- a/pkg/commands/drift/statefiles/statefiles.go
+++ b/pkg/commands/drift/statefiles/statefiles.go
@@ -199,7 +199,9 @@ func (c *DriftStatefilesCommand) Process(ctx context.Context) error {
 	}
 
 	for _, r := range repositoriesWithTerraform {
-		c.gitClient.CloneRepository(ctx, c.GitHubFlags.FlagGitHubToken, r.Owner, r.Name)
+		if err = c.gitClient.CloneRepository(ctx, c.GitHubFlags.FlagGitHubToken, r.Owner, r.Name); err != nil {
+			return fmt.Errorf("failed to clone repository: %w", err)
+		}
 	}
 
 	// Determine expected statefiles from checked out repositories.

--- a/pkg/commands/drift/statefiles/statefiles.go
+++ b/pkg/commands/drift/statefiles/statefiles.go
@@ -65,7 +65,6 @@ type DriftStatefilesCommand struct {
 	driftflags.DriftIssueFlags
 
 	flagOrganizationID                string
-	flagGitHubRepoQuery               string
 	flagGCSBucketQuery                string
 	flagDetectGCSBucketsFromTerraform bool
 	flagTerraformRepoTopics           []string
@@ -106,13 +105,6 @@ func (c *DriftStatefilesCommand) Flags() *cli.FlagSet {
 		Target:  &c.flagOrganizationID,
 		Example: "123435456456",
 		Usage:   `The Google Cloud organization ID for which to detect drift.`,
-	})
-
-	f.StringVar(&cli.StringVar{
-		Name:    "github-repo-query",
-		Target:  &c.flagGitHubRepoQuery,
-		Example: "labels.terraform:*",
-		Usage:   `The label to use to find GCS buckets with Terraform statefiles.`,
 	})
 
 	f.StringVar(&cli.StringVar{

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -90,7 +90,7 @@ func (g *GitClient) CloneRepository(ctx context.Context, githubToken, owner, rep
 		Stderr:     &stderr,
 		WorkingDir: g.workingDir,
 		Command:    "git",
-		Args:       []string{"clone", fmt.Sprintf("https://%s@github.com/%s/%s.git", githubToken, owner, repo)},
+		Args:       []string{"clone", fmt.Sprintf("https://%s@github.com/%s/%s.git", githubToken, owner, repo), "--single-branch", "--no-tags"},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to run git clone command: %w\n\n%s", err, stderr.String())

--- a/pkg/git/git_mock.go
+++ b/pkg/git/git_mock.go
@@ -22,9 +22,15 @@ import (
 type MockGitClient struct {
 	DiffResp []string
 	DiffErr  error
+	CloneErr error
 }
 
 // DiffDirsAbs runs a git diff between two revisions and returns the list of directories with changes.
 func (m *MockGitClient) DiffDirsAbs(ctx context.Context, baseRef, headRef string) ([]string, error) {
 	return m.DiffResp, m.DiffErr
+}
+
+// CloneRepository clones the repository to the workingDir.
+func (m *MockGitClient) CloneRepository(ctx context.Context, githubToken, owner, repo string) error {
+	return m.CloneErr
 }

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -88,7 +88,7 @@ const (
 
 // GitHub provides the minimum interface for sending requests to the GitHub API.
 type GitHub interface {
-	//  ListRepositories all repositories and returns details about the repositories.
+	//  ListRepositories lists all repositories and returns details about the repositories.
 	ListRepositories(ctx context.Context, owner string, opts *github.RepositoryListByOrgOptions) ([]*Repository, error)
 
 	// ListIssues lists all issues and returns their numbers in a repository matching the given criteria.
@@ -158,7 +158,7 @@ func NewClient(ctx context.Context, token string, opts ...Option) *GitHubClient 
 	return g
 }
 
-// ListRepositories all repositories and returns details about the repositories.
+// ListRepositories lists all repositories and returns details about the repositories.
 func (g *GitHubClient) ListRepositories(ctx context.Context, owner string, opts *github.RepositoryListByOrgOptions) ([]*Repository, error) {
 	pageStart := func(i *int) bool { return i == nil }
 	pageEnd := func(i *int) bool { return *i == 0 }

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -182,7 +182,7 @@ func (g *GitHubClient) ListRepositories(ctx context.Context, owner string, opts 
 					return retry.RetryableError(err)
 				}
 
-				return fmt.Errorf("failed to list issues: %w", err)
+				return fmt.Errorf("failed to list repositories: %w", err)
 			}
 
 			for _, r := range repos {
@@ -197,7 +197,7 @@ func (g *GitHubClient) ListRepositories(ctx context.Context, owner string, opts 
 			page = &resp.NextPage
 			return nil
 		}); err != nil {
-			return nil, fmt.Errorf("failed to list issues after retries: %w", err)
+			return nil, fmt.Errorf("failed to list repositories after retries: %w", err)
 		}
 	}
 

--- a/pkg/github/github_mock.go
+++ b/pkg/github/github_mock.go
@@ -32,6 +32,7 @@ type MockGitHubClient struct {
 	reqMu sync.Mutex
 	Reqs  []*Request
 
+	ListRepositoriesErr          error
 	ListIssuesErr                error
 	CreateIssueErr               error
 	CloseIssueErr                error
@@ -43,6 +44,20 @@ type MockGitHubClient struct {
 	ListPullRequestsForCommitErr error
 	RepoPermissionLevelErr       error
 	RepoPermissionLevel          string
+}
+
+func (m *MockGitHubClient) ListRepositories(ctx context.Context, owner string, opts *github.RepositoryListByOrgOptions) ([]*Repository, error) {
+	m.reqMu.Lock()
+	defer m.reqMu.Unlock()
+	m.Reqs = append(m.Reqs, &Request{
+		Name:   "ListRepositories",
+		Params: []any{owner, opts},
+	})
+
+	if m.ListRepositoriesErr != nil {
+		return nil, m.ListRepositoriesErr
+	}
+	return []*Repository{}, nil
 }
 
 func (m *MockGitHubClient) ListIssues(ctx context.Context, owner, repo string, opts *github.IssueListByRepoOptions) ([]*Issue, error) {


### PR DESCRIPTION
These change updates statefile drift so that it 

* Clones all github repositories that have a given set of topics (e.g. terraform, guardian) - this will be limited by the github token passed - so if you only have access to 1 repo you will only get 1 repo.
* (noop) Determines all expected statefile locations in gcs using the method already used
* Fetches all gcs buckets - this will be limited by the access that you/your SA has.
* (noop) Determines all actual statefile locations in gcs using the method already used

To support environments that don't have elevated github permissions I introduced a new flag called `detect-gcs-buckets-from-terraform` that will not rely on fetching GCS buckets from the asset inventory API. Instead it will parse them from the terraform configuration (this is how it used to behave before this change).