### PR TITLE
chore: indicate unknown parent in logs and issue

### DIFF
--- a/pkg/assetinventory/assetinventory.go
+++ b/pkg/assetinventory/assetinventory.go
@@ -37,6 +37,9 @@ const (
 	// Project Node Type.
 	Project = "Project"
 
+	// UnknownParent is used when we cannot find an asset parent. See UnknownParentID.
+	UnknownParent = "Unknown"
+
 	// OrganizationAssetType represent the org asset type used in the cloud resource manager api.
 	OrganizationAssetType = "cloudresourcemanager.googleapis.com/Organization"
 

--- a/pkg/commands/drift/drift.go
+++ b/pkg/commands/drift/drift.go
@@ -325,7 +325,9 @@ func (d *IAMDriftDetector) URI(i *assetinventory.AssetIAM) string {
 			resourceName = p.Name
 		}
 		return fmt.Sprintf("/organizations/%s/projects/%s/%s/%s", d.organizationID, resourceName, role, i.Member)
-	} else {
+	} else if i.ResourceType == assetinventory.Organization {
 		return fmt.Sprintf("/organizations/%s/%s/%s", d.organizationID, role, i.Member)
+	} else {
+		return fmt.Sprintf("unknownParent:/organizations/%s/%s/%s/%s/%s", d.organizationID, i.ResourceType, i.ResourceID, role, i.Member)
 	}
 }


### PR DESCRIPTION
When a parent project or folder cannot be identified we should indicate that