### PR TITLE
Use the head.sha instead of head.ref

### DIFF
--- a/.github/actions/directories/action.yml
+++ b/.github/actions/directories/action.yml
@@ -74,8 +74,8 @@ runs:
       shell: 'bash'
       env:
         TERRAFORM_DIRECTORY: '${{ inputs.terraform_directory }}'
-        HEAD_REF: 'origin/${{ github.event.pull_request.head.ref }}'
-        BASE_REF: 'origin/${{ github.event.pull_request.base.ref }}'
+        HEAD_REF: 'origin/${{ github.event.pull_request.head.sha }}'
+        BASE_REF: 'origin/${{ github.event.pull_request.base.sha }}'
       run: |-
         # Get all terraform file directores that contain a backend config
         BACKEND_DIRS=$(find $TERRAFORM_DIRECTORY -name "*.tf" | xargs awk '/backend ".*" {/ && ! /#[[:space:]]*backend ".*" {/ { print FILENAME }' | xargs dirname | sed 's|[\.?][/]*||g' | sort | uniq)

--- a/.github/actions/directories/action.yml
+++ b/.github/actions/directories/action.yml
@@ -74,8 +74,8 @@ runs:
       shell: 'bash'
       env:
         TERRAFORM_DIRECTORY: '${{ inputs.terraform_directory }}'
-        HEAD_REF: 'origin/${{ github.event.pull_request.head.sha }}'
-        BASE_REF: 'origin/${{ github.event.pull_request.base.sha }}'
+        HEAD_REF: '${{ github.event.pull_request.head.sha }}'
+        BASE_REF: '${{ github.event.pull_request.base.sha }}'
       run: |-
         # Get all terraform file directores that contain a backend config
         BACKEND_DIRS=$(find $TERRAFORM_DIRECTORY -name "*.tf" | xargs awk '/backend ".*" {/ && ! /#[[:space:]]*backend ".*" {/ { print FILENAME }' | xargs dirname | sed 's|[\.?][/]*||g' | sort | uniq)

--- a/.github/workflows/test-plan.yml
+++ b/.github/workflows/test-plan.yml
@@ -91,7 +91,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744' # ratchet:actions/checkout@v3
         with:
-          ref: '${{ github.event.pull_request.head.ref }}'
+          ref: '${{ github.event.pull_request.head.sha }}'
 
       - name: 'Setup Go'
         uses: 'actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568' # ratchet:actions/setup-go@v3

--- a/abc.templates/default-workflows/contents/guardian-plan.yml
+++ b/abc.templates/default-workflows/contents/guardian-plan.yml
@@ -51,7 +51,7 @@ jobs:
         uses: 'actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9' # ratchet:actions/checkout@v3
         with:
           fetch-depth: 0 # get everything so we can use git diff
-          ref: '${{ github.event.pull_request.head.ref }}'
+          ref: '${{ github.event.pull_request.head.sha }}'
 
       - name: 'Guardian Directories'
         id: 'dirs'
@@ -79,7 +79,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9' # ratchet:actions/checkout@v3
         with:
-          ref: '${{ github.event.pull_request.head.ref }}'
+          ref: '${{ github.event.pull_request.head.sha }}'
 
       - name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033' # ratchet:google-github-actions/auth@v1

--- a/examples/guardian-plan.yml
+++ b/examples/guardian-plan.yml
@@ -42,7 +42,7 @@ jobs:
         uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
         with:
           fetch-depth: 0 # get everything so we can use git diff
-          ref: '${{ github.event.pull_request.head.ref }}'
+          ref: '${{ github.event.pull_request.head.sha }}'
 
       - name: 'Guardian Directories'
         id: 'dirs'
@@ -69,7 +69,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3
         with:
-          ref: '${{ github.event.pull_request.head.ref }}'
+          ref: '${{ github.event.pull_request.head.sha }}'
 
       # required to upload terraform plan files to cloud storage
       - name: 'Authenticate to Google Cloud'


### PR DESCRIPTION
Using `head.ref`/`base.ref` can lead to race conditions where the branch (ref) is modified after a workflow is started which results in either the wrong revision to be checked out or fails when the branch is deleted.