### PR TITLE
feat: designate which statefiles are empty in drift detection

### DIFF
--- a/pkg/commands/drift/statefiles/statefiles.go
+++ b/pkg/commands/drift/statefiles/statefiles.go
@@ -41,6 +41,7 @@ import (
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/sets"
+	"github.com/abcxyz/pkg/workerpool"
 )
 
 var _ cli.Command = (*DriftStatefilesCommand)(nil)
@@ -56,6 +57,8 @@ const (
         in your GCS bucket.
 
         Re-run drift detection manually once complete to verify all diffs are properly resolved.`
+	// maxConcurrentRequests is the maximum number of concurrent gcs reads to perform at once.
+	maxConcurrentRequests = 10
 )
 
 type DriftStatefilesCommand struct {
@@ -229,11 +232,20 @@ func (c *DriftStatefilesCommand) Process(ctx context.Context) error {
 	// Compare expected vs actual statefiles.
 	statefilesNotInRemote := sets.Subtract(expectedURIs, gotURIs)
 	statefilesNotInLocal := sets.Subtract(gotURIs, expectedURIs)
-	sort.Strings(statefilesNotInRemote)
-	sort.Strings(statefilesNotInLocal)
 
-	changesDetected := len(statefilesNotInRemote) > 0 || len(statefilesNotInLocal) > 0
-	m := driftMessage(statefilesNotInRemote, statefilesNotInLocal)
+	emptyStateFiles, err := c.emptyStateFiles(ctx, statefilesNotInLocal)
+	if err != nil {
+		return fmt.Errorf("failed to find empty statefiles: %w", err)
+	}
+
+	statefilesNotInLocalNotEmpty := sets.Subtract(statefilesNotInLocal, emptyStateFiles)
+
+	sort.Strings(statefilesNotInRemote)
+	sort.Strings(statefilesNotInLocalNotEmpty)
+	sort.Strings(emptyStateFiles)
+
+	changesDetected := len(statefilesNotInRemote) > 0 || len(statefilesNotInLocalNotEmpty) > 0 || len(emptyStateFiles) > 0
+	m := driftMessage(statefilesNotInRemote, statefilesNotInLocalNotEmpty, emptyStateFiles)
 	if changesDetected {
 		c.Outf(m)
 	}
@@ -353,6 +365,52 @@ func (c *DriftStatefilesCommand) actualStatefileUris(ctx context.Context, logger
 	return gotURIs, nil
 }
 
+func (c *DriftStatefilesCommand) emptyStateFiles(ctx context.Context, gcsURIs []string) ([]string, error) {
+	type Resource struct {
+		Empty bool
+		URI   string
+	}
+	w := workerpool.New[*Resource](&workerpool.Config{
+		Concurrency: maxConcurrentRequests,
+		StopOnError: true,
+	})
+	for _, u := range gcsURIs {
+		uri := u
+		if err := w.Do(ctx, func() (*Resource, error) {
+			empty, err := c.terraformParser.StateWithoutResources(ctx, uri)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get determine if state file URI has resources: %w", err)
+			}
+			return &Resource{*empty, uri}, nil
+		}); err != nil && !errors.Is(err, workerpool.ErrStopped) {
+			return nil, fmt.Errorf("failed to execute terraform resources task: %w", err)
+		}
+	}
+
+	results, err := w.Done(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute terraform resources tasks in parallel: %w", err)
+	}
+
+	var emptyStateFiles []string
+	errs := []error{}
+	for _, r := range results {
+		if err := r.Error; err != nil {
+			if !errors.Is(err, workerpool.ErrStopped) {
+				errs = append(errs, fmt.Errorf("failed to execute resource task: %w", err))
+			}
+			continue
+		}
+		if r.Value.Empty {
+			emptyStateFiles = append(emptyStateFiles, r.Value.URI)
+		}
+	}
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("failed to execute terraform resource tasks in parallel: %w", errors.Join(errs...))
+	}
+	return emptyStateFiles, nil
+}
+
 func Set(values []string) map[string]struct{} {
 	set := make(map[string]struct{})
 	for _, v := range values {
@@ -361,16 +419,22 @@ func Set(values []string) map[string]struct{} {
 	return set
 }
 
-func driftMessage(statefilesNotInRemote, statefilesNotInLocal []string) string {
+func driftMessage(statefilesNotInRemote, statefilesNotInLocal, emptyStatefilesNotInLocal []string) string {
 	var msg strings.Builder
 	if len(statefilesNotInRemote) > 0 {
 		msg.WriteString(fmt.Sprintf("Found state locally that are not in remote \n> %s", strings.Join(statefilesNotInRemote, "\n> ")))
-		if len(statefilesNotInLocal) > 0 {
+		if len(statefilesNotInLocal) > 0 || len(emptyStatefilesNotInLocal) > 0 {
 			msg.WriteString("\n\n")
 		}
 	}
 	if len(statefilesNotInLocal) > 0 {
 		msg.WriteString(fmt.Sprintf("Found statefiles in remote that are not in local \n> %s", strings.Join(statefilesNotInLocal, "\n> ")))
+		if len(emptyStatefilesNotInLocal) > 0 {
+			msg.WriteString("\n\n")
+		}
+	}
+	if len(emptyStatefilesNotInLocal) > 0 {
+		msg.WriteString(fmt.Sprintf("Found empty statefiles in remote that are not in local \n> %s", strings.Join(emptyStatefilesNotInLocal, "\n> ")))
 	}
 	return msg.String()
 }

--- a/pkg/terraform/parser/parser.go
+++ b/pkg/terraform/parser/parser.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/abcxyz/guardian/pkg/assetinventory"
 	"github.com/abcxyz/guardian/pkg/storage"
+	"github.com/abcxyz/guardian/pkg/util"
 	"github.com/abcxyz/pkg/logging"
 )
 
@@ -35,6 +36,9 @@ const (
 
 	// Default max size for a terraform statefile is 512 MB.
 	defaultTerraformStateFileSizeLimit = 512 * 1024 * 1024 // 512 MB
+
+	// noResourcesInStatefileSyntax can be used to determine if a statefile has any resources or not.
+	noResourcesInStatefileSyntax = "\"resources\": [],"
 )
 
 // ResourceInstances represents the JSON terraform state IAM instance.
@@ -67,6 +71,9 @@ type Terraform interface {
 
 	// ProcessStates returns the IAM permissions stored in the given state files.
 	ProcessStates(ctx context.Context, gcsUris []string) ([]*assetinventory.AssetIAM, error)
+
+	// StateWithoutResources determines if the given statefile at the uri contains any resources or not.
+	StateWithoutResources(ctx context.Context, uri string) (*bool, error)
 }
 
 type TerraformParser struct {
@@ -113,6 +120,26 @@ func (p *TerraformParser) StateFileURIs(ctx context.Context, gcsBuckets []string
 		gcsURIs = append(gcsURIs, allStateFiles...)
 	}
 	return gcsURIs, nil
+}
+
+// ProcessStates finds all IAM in memberships, bindings, or policies in the given terraform state files.
+func (p *TerraformParser) StateWithoutResources(ctx context.Context, uri string) (*bool, error) {
+	bucket, name, err := storage.SplitObjectURI(uri)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse GCS URI: %w", err)
+	}
+	r, err := p.GCS.DownloadObject(ctx, *bucket, *name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download gcs URI for terraform: %w", err)
+	}
+	defer r.Close()
+	lr := io.LimitReader(r, defaultTerraformStateFileSizeLimit)
+	data, err := io.ReadAll(lr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode terraform state: %w", err)
+	}
+	jsonContent := string(data)
+	return util.Ptr(strings.Contains(jsonContent, noResourcesInStatefileSyntax)), nil
 }
 
 // ProcessStates finds all IAM in memberships, bindings, or policies in the given terraform state files.


### PR DESCRIPTION
This enables statefiles drift detection to inform the user which statefiles that were found are actually empty (result of an init without an apply)

Example of new output:
```
Found state locally that are not in remote
> gs://terraform-abc123/terraform/a/default.tfstate
> gs://terraform-abc123/terraform/b/default.tfstate

Found statefiles in remote that are not in local           
> gs://terraform-abc123/terraform/c/default.tfstate
> gs://terraform-abc123/terraform/d/default.tfstate
                                                                                                                          
Found empty statefiles in remote that are not in local
> gs://terraform-abc123/terraform/e/default.tfstate
> gs://terraform-abc123/terraform/f/default.tfstate
```