### PR TITLE
Inject custom user-agent headers

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -39,6 +39,9 @@ var (
 
 	// HumanVersion is the compiled version.
 	HumanVersion = Name + " " + Version + " (" + Commit + ", " + OSArch + ")"
+
+	// UserAgent is the HTTP user agent string.
+	UserAgent = Name + "/" + Version + "(+https://github.com/abcxyz/guardian)"
 )
 
 func valueOrFallback(val string, fn func() string) string {

--- a/pkg/commands/drift/command.go
+++ b/pkg/commands/drift/command.go
@@ -130,7 +130,7 @@ func (c *DetectIamDriftCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("unexpected arguments: %q", args)
 	}
 
-	logger.DebugContext(ctx, "Running IAM Drift Detection...",
+	logger.DebugContext(ctx, "running IAM Drift Detection",
 		"name", version.Name,
 		"commit", version.Commit,
 		"version", version.Version)

--- a/pkg/commands/drift/drift.go
+++ b/pkg/commands/drift/drift.go
@@ -152,7 +152,8 @@ func (d *IAMDriftDetector) DetectDrift(
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine GCP IAM: %w", err)
 	}
-	logger.DebugContext(ctx, "Fetching terraform state from Buckets", "number_of_buckets", len(buckets))
+	logger.DebugContext(ctx, "fetching terraform state from buckets",
+		"number_of_buckets", len(buckets))
 	tfIAM, err := d.terraformStateIAM(ctx, buckets)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse IAM from Terraform State: %w", err)

--- a/pkg/commands/drift/driftignore.go
+++ b/pkg/commands/drift/driftignore.go
@@ -231,7 +231,9 @@ func driftignore(
 			} else if p, ok := projectsByName[a]; ok {
 				projects[p.ID] = struct{}{}
 			} else {
-				logger.WarnContext(ctx, "failed to identify ignored project %s", "project", a, "uri", line)
+				logger.WarnContext(ctx, "failed to identify ignored project",
+					"project", a,
+					"uri", line)
 			}
 		}
 
@@ -244,7 +246,9 @@ func driftignore(
 			} else if f, ok := foldersByName[a]; ok {
 				folders[f.ID] = struct{}{}
 			} else {
-				logger.WarnContext(ctx, "failed to identify ignored folder %s", "folder", a, "uri", line)
+				logger.WarnContext(ctx, "failed to identify ignored folder",
+					"folder", a,
+					"uri", line)
 			}
 		}
 

--- a/pkg/commands/iamcleanup/command.go
+++ b/pkg/commands/iamcleanup/command.go
@@ -111,7 +111,7 @@ func (c *IAMCleanupCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("unexpected arguments: %q", args)
 	}
 
-	logger.DebugContext(ctx, "Running IAM Cleanup...",
+	logger.DebugContext(ctx, "running IAM cleanup",
 		"name", version.Name,
 		"commit", version.Commit,
 		"version", version.Version)

--- a/pkg/commands/iamcleanup/iamcleanup.go
+++ b/pkg/commands/iamcleanup/iamcleanup.go
@@ -49,7 +49,10 @@ func (c *IAMCleaner) Do(
 		return fmt.Errorf("failed to get iam: %w", err)
 	}
 
-	logger.DebugContext(ctx, "got IAM", "number_of_iam_memberships", len(iams), "scope", scope, "query", iamQuery)
+	logger.DebugContext(ctx, "got IAM",
+		"number_of_iam_memberships", len(iams),
+		"scope", scope,
+		"query", iamQuery)
 
 	// We group by URI to confirm we only delete 1 ResourceID/Member combination at a single time.
 	// Multiple concurrent requests to delete IAM for a particular ResourceID/Member result in a conflict.
@@ -60,7 +63,8 @@ func (c *IAMCleaner) Do(
 		iamsToDelete = groupByURI(iams)
 	}
 
-	logger.DebugContext(ctx, "Cleaning up IAM", "number_of_iam_memberships_to_remove", countAll(iamsToDelete))
+	logger.DebugContext(ctx, "cleaning up IAM",
+		"number_of_iam_memberships_to_remove", countAll(iamsToDelete))
 
 	w := workerpool.New[*workerpool.Void](&workerpool.Config{
 		Concurrency: c.maxConcurrentRequests,
@@ -96,7 +100,8 @@ func (c *IAMCleaner) Do(
 		return fmt.Errorf("failed to execute IAM Removal tasks in parallel: %w", err)
 	}
 
-	logger.DebugContext(ctx, "Successfully deleted IAM", "number_of_iam_memberships_removed", len(iamsToDelete))
+	logger.DebugContext(ctx, "successfully deleted IAM",
+		"number_of_iam_memberships_removed", len(iamsToDelete))
 
 	return nil
 }
@@ -108,7 +113,8 @@ func filterByEvaluation(ctx context.Context, iams []*assetinventory.AssetIAM) []
 		passed, err := evaluateIAMConditionExpression(ctx, i.Condition.Expression)
 		if err != nil {
 			logger.WarnContext(ctx, "failed to parse expression (CEL) for IAM membership",
-				"membership", i, "error", err)
+				"membership", i,
+				"error", err)
 		} else if !*passed {
 			filteredResults = append(filteredResults, i)
 		}

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -226,7 +226,9 @@ func modules(ctx context.Context, rootDir string, skipUnresolvableModules bool) 
 			pth, err := util.PathEvalAbs(relativeModulePath)
 			if err != nil {
 				if skipUnresolvableModules {
-					logger.DebugContext(ctx, "Skipping unresolvable module", "module", relativeModulePath, "used_in_tf_file", absPath)
+					logger.DebugContext(ctx, "skipping unresolvable module",
+						"module", relativeModulePath,
+						"used_in_tf_file", absPath)
 					continue
 				}
 				return fmt.Errorf("failed to get absolute path for directory %s: %w", relativeModulePath, err)


### PR DESCRIPTION
This also sets us up for a future world where we can allow/deny specific environment variables from the parent process (such as forbidding users to override the path to a terraformrc file).