### PR TITLE
Remove unneeded guardian.env.yml

### DIFF
--- a/guardian.env.yml
+++ b/guardian.env.yml
@@ -1,6 +1,0 @@
-- dirs:
-    - './*'
-  variables:
-    GUARDIAN_WIF_PROVIDER: 'projects/1098665030124/locations/global/workloadIdentityPools/guardian-automation/providers/guardian-ci-i'
-    GUARDIAN_WIF_SERVICE_ACCOUNT: 'guardian-automation-bot@ghg-guardian-ci-i-6ad437.iam.gserviceaccount.com'
-    GUARDIAN_BUCKET_NAME: 'guardian-ci-i-guardian-state-c79e1f4759'


### PR DESCRIPTION
`guardian.env.yml` is no longer needed as these environemnt variables are now set directly by the `.github/workflows/integration.yml` workflow, and it is now the only workflow that needs these environment variables.