### PR TITLE
Simplify `plan` and `apply` commands

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -175,7 +175,7 @@ jobs:
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
         run: |-
-          guardian plan run \
+          guardian plan \
           -github-owner="${GITHUB_OWNER_NAME}" \
           -github-repo="${GITHUB_REPO_NAME}" \
           -github-token="${REPO_TOKEN}" \
@@ -279,7 +279,7 @@ jobs:
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
         run: |-
-          guardian apply run \
+          guardian apply \
           -github-owner="${GITHUB_OWNER_NAME}" \
           -github-repo="${GITHUB_REPO_NAME}" \
           -github-token="${REPO_TOKEN}" \

--- a/cmd/guardian/main.go
+++ b/cmd/guardian/main.go
@@ -67,26 +67,10 @@ var rootCmd = func() cli.Command {
 				}
 			},
 			"plan": func() cli.Command {
-				return &cli.RootCommand{
-					Name:        "plan",
-					Description: "Perform operations related to Terraform planning",
-					Commands: map[string]cli.CommandFactory{
-						"run": func() cli.Command {
-							return &plan.PlanRunCommand{}
-						},
-					},
-				}
+				return &plan.PlanCommand{}
 			},
 			"apply": func() cli.Command {
-				return &cli.RootCommand{
-					Name:        "apply",
-					Description: "Perform operations related to Terraform apply",
-					Commands: map[string]cli.CommandFactory{
-						"run": func() cli.Command {
-							return &apply.ApplyRunCommand{}
-						},
-					},
-				}
+				return &apply.ApplyCommand{}
 			},
 			"iam": func() cli.Command {
 				return &cli.RootCommand{

--- a/pkg/commands/apply/apply.go
+++ b/pkg/commands/apply/apply.go
@@ -50,8 +50,7 @@ type RunResult struct {
 	commentDetails string
 }
 
-// ApplyCommand is a subcommand of apply and implements the cli.Command interface.
-// It performs terraform apply on the given working directory.
+// ApplyCommand performs terraform apply on the given working directory.
 type ApplyCommand struct {
 	cli.BaseCommand
 

--- a/pkg/commands/apply/apply_test.go
+++ b/pkg/commands/apply/apply_test.go
@@ -251,7 +251,7 @@ func TestApply_Process(t *testing.T) {
 				},
 			}
 
-			c := &ApplyRunCommand{
+			c := &ApplyCommand{
 				cfg: tc.config,
 
 				directory:    tc.directory,

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -65,7 +65,7 @@ func TestAfterParse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			c := &PlanRunCommand{}
+			c := &PlanCommand{}
 
 			f := c.Flags()
 			err := f.Parse(tc.args)
@@ -326,7 +326,7 @@ func TestPlan_Process(t *testing.T) {
 			gitHubClient := &github.MockGitHubClient{}
 			storageClient := &storage.MockStorageClient{}
 
-			c := &PlanRunCommand{
+			c := &PlanCommand{
 				cfg: tc.config,
 
 				directory:    tc.directory,
@@ -378,14 +378,14 @@ func TestGetMessageBody(t *testing.T) {
 	bigMessage := messageOverLimit()
 	cases := []struct {
 		name      string
-		cmd       *PlanRunCommand
+		cmd       *PlanCommand
 		result    *RunResult
 		resultErr error
 		want      string
 	}{
 		{
 			name: "result_success",
-			cmd: &PlanRunCommand{
+			cmd: &PlanCommand{
 				childPath:    "foo",
 				gitHubLogURL: "http://github.com/logs",
 			},
@@ -398,7 +398,7 @@ func TestGetMessageBody(t *testing.T) {
 		},
 		{
 			name: "result_error",
-			cmd: &PlanRunCommand{
+			cmd: &PlanCommand{
 				childPath:    "foo",
 				gitHubLogURL: "http://github.com/logs",
 			},
@@ -411,7 +411,7 @@ func TestGetMessageBody(t *testing.T) {
 		},
 		{
 			name: "result_no_changes",
-			cmd: &PlanRunCommand{
+			cmd: &PlanCommand{
 				childPath:    "foo",
 				gitHubLogURL: "http://github.com/logs",
 			},
@@ -424,7 +424,7 @@ func TestGetMessageBody(t *testing.T) {
 		},
 		{
 			name: "result_success_over_limit",
-			cmd: &PlanRunCommand{
+			cmd: &PlanCommand{
 				childPath:    "foo",
 				gitHubLogURL: "http://github.com/logs",
 			},


### PR DESCRIPTION
* `guardian plan run $ARGS` -> `guardian plan $ARGS`
* `guardian apply run $ARGS` -> `guardian apply $ARGS`
* Refactored names of structs and files for `plan` and `apply` commands to reflect the removal of `run` subcommand.