### PR TITLE
Fix bug where formatting error does not display

### DIFF
--- a/terraform/project1/main.tf
+++ b/terraform/project1/main.tf
@@ -3,3 +3,5 @@ terraform {
 }
 
 resource "null_resource" "empty" {}
+
+invalid

--- a/terraform/project1/main.tf
+++ b/terraform/project1/main.tf
@@ -3,5 +3,3 @@ terraform {
 }
 
 resource "null_resource" "empty" {}
-
-invalid


### PR DESCRIPTION
 * Fixed a bug where `terraform fmt` can respond with a non-zero
    exit code but still write its ouput to `stdout` instead of `stderr`.
    Fix checks `stderr` first for output and if that is empty it falls
    back to `stdout` for determining the output.
    
closes #258
