### PR TITLE
Make supplying Terraform directory consistent

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -183,7 +183,7 @@ jobs:
           -github-token="${REPO_TOKEN}" \
           -pull-request-number="${PULL_REQUEST_NUMBER}" \
           -bucket-name="${GUARDIAN_BUCKET_NAME}" \
-          "${DIRECTORY}"
+          -dir="${DIRECTORY}"
 
   plan_success:
     needs:
@@ -287,7 +287,7 @@ jobs:
           -github-token="${REPO_TOKEN}" \
           -pull-request-number="${PULL_REQUEST_NUMBER}" \
           -bucket-name="${GUARDIAN_BUCKET_NAME}" \
-          "${DIRECTORY}"
+          -dir="${DIRECTORY}"
 
       - name: 'Guardian Destroy'
         env:

--- a/pkg/commands/apply/apply.go
+++ b/pkg/commands/apply/apply.go
@@ -66,6 +66,7 @@ type ApplyCommand struct {
 	flags.GitHubFlags
 	flags.RetryFlags
 
+	flagDir                  string
 	flagBucketName           string
 	flagCommitSHA            string
 	flagPullRequestNumber    int
@@ -100,6 +101,13 @@ func (c *ApplyCommand) Flags() *cli.FlagSet {
 	c.RetryFlags.Register(set)
 
 	f := set.NewSection("COMMAND OPTIONS")
+
+	f.StringVar(&cli.StringVar{
+		Name:    "dir",
+		Target:  &c.flagDir,
+		Example: "-dir=terraform",
+		Usage:   "The location of the terraform directory",
+	})
 
 	f.IntVar(&cli.IntVar{
 		Name:    "pull-request-number",
@@ -148,12 +156,11 @@ func (c *ApplyCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to parse flags: %w", err)
 	}
 
-	parsedArgs := f.Args()
-	if len(parsedArgs) != 1 {
+	if c.flagDir == "" {
 		return flag.ErrHelp
 	}
 
-	dirAbs, err := util.PathEvalAbs(parsedArgs[0])
+	dirAbs, err := util.PathEvalAbs(c.flagDir)
 	if err != nil {
 		return fmt.Errorf("failed to absolute path for directory: %w", err)
 	}

--- a/pkg/commands/entrypoints/entrypoints.go
+++ b/pkg/commands/entrypoints/entrypoints.go
@@ -55,6 +55,7 @@ type EntrypointsCommand struct {
 	flags.GitHubFlags
 	flags.RetryFlags
 
+	flagDir                     string
 	flagPullRequestNumber       int
 	flagDestRef                 string
 	flagSourceRef               string
@@ -87,6 +88,13 @@ func (c *EntrypointsCommand) Flags() *cli.FlagSet {
 	c.RetryFlags.Register(set)
 
 	f := set.NewSection("COMMAND OPTIONS")
+
+	f.StringVar(&cli.StringVar{
+		Name:    "dir",
+		Target:  &c.flagDir,
+		Example: "-dir=terraform",
+		Usage:   "The location of the terraform directory",
+	})
 
 	f.IntVar(&cli.IntVar{
 		Name:    "pull-request-number",
@@ -165,13 +173,11 @@ func (c *EntrypointsCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to parse flags: %w", err)
 	}
 
-	parsedArgs := f.Args()
-
-	if len(parsedArgs) != 1 {
+	if c.flagDir == "" {
 		return flag.ErrHelp
 	}
 
-	dirAbs, err := util.PathEvalAbs(parsedArgs[0])
+	dirAbs, err := util.PathEvalAbs(c.flagDir)
 	if err != nil {
 		return fmt.Errorf("failed to absolute path for directory: %w", err)
 	}

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -64,6 +64,7 @@ type PlanCommand struct {
 	flags.GitHubFlags
 	flags.RetryFlags
 
+	flagDir                  string
 	flagBucketName           string
 	flagPullRequestNumber    int
 	flagAllowLockfileChanges bool
@@ -94,6 +95,13 @@ func (c *PlanCommand) Flags() *cli.FlagSet {
 	c.RetryFlags.Register(set)
 
 	f := set.NewSection("COMMAND OPTIONS")
+
+	f.StringVar(&cli.StringVar{
+		Name:    "dir",
+		Target:  &c.flagDir,
+		Example: "-dir=terraform",
+		Usage:   "The location of the terraform directory",
+	})
 
 	f.IntVar(&cli.IntVar{
 		Name:    "pull-request-number",
@@ -155,12 +163,11 @@ func (c *PlanCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to parse flags: %w", err)
 	}
 
-	parsedArgs := f.Args()
-	if len(parsedArgs) != 1 {
+	if c.flagDir == "" {
 		return flag.ErrHelp
 	}
 
-	dirAbs, err := util.PathEvalAbs(parsedArgs[0])
+	dirAbs, err := util.PathEvalAbs(c.flagDir)
 	if err != nil {
 		return fmt.Errorf("failed to absolute path for directory: %w", err)
 	}


### PR DESCRIPTION
The `run` command was recently changed to supply the Terraform directory via a `-dir` flag. The `plan`, `apply`, and `entrypoints` commands have been similarly updated so that supplying the Terraform directory is consistent across each of guardian's commands.