### PR TITLE
Switch `drift statefiles` to use `-dir` flag

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -268,7 +268,7 @@ Each line in your `.driftignore` file can contain one of the following
 
 Run the drift detection for terraform statefiles in a directory.
 
-Usage: guardian drift statefiles [options] <directory>
+Usage: guardian drift statefiles [options]
 
 ### Prerequisites
 
@@ -286,6 +286,7 @@ The actor that runs this command must have:
 
 Also supports [GitHub Options](#github-options) and [Retry Options](#retry-options).
 
+* **-dir** - The directory to use to determine Terraform entrypoints. Defaults to the current working directory.
 * **-detect-gcs-buckets-from-terraform** - Whether or not to use the terraform
   backend configs to determine gcs buckets. The default value is "false".
 * **-gcs-bucket-query="labels.terraform:*"** - The label to use to find GCS

--- a/pkg/commands/apply/apply.go
+++ b/pkg/commands/apply/apply.go
@@ -88,7 +88,7 @@ func (c *ApplyCommand) Desc() string {
 // information.
 func (c *ApplyCommand) Help() string {
 	return `
-Usage: {{ COMMAND }} [options] <directory>
+Usage: {{ COMMAND }} [options]
 
 	Run Terraform apply for a directory.
 `

--- a/pkg/commands/entrypoints/entrypoints.go
+++ b/pkg/commands/entrypoints/entrypoints.go
@@ -75,7 +75,7 @@ func (c *EntrypointsCommand) Desc() string {
 
 func (c *EntrypointsCommand) Help() string {
 	return `
-Usage: {{ COMMAND }} [options] <directory>
+Usage: {{ COMMAND }} [options]
 
 	Determine the entrypoint directories to run Guardian commands.
 `

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -82,7 +82,7 @@ func (c *PlanCommand) Desc() string {
 
 func (c *PlanCommand) Help() string {
 	return `
-Usage: {{ COMMAND }} [options] <directory>
+Usage: {{ COMMAND }} [options]
 
   Run Terraform plan for a directory.
 `

--- a/pkg/commands/run/run.go
+++ b/pkg/commands/run/run.go
@@ -58,7 +58,7 @@ func (c *RunCommand) Desc() string {
 
 func (c *RunCommand) Help() string {
 	return `
-Usage: {{ COMMAND }} [options] <directory>
+Usage: {{ COMMAND }} [options]
 
   Run a Terraform command for a directory.
 `

--- a/pkg/commands/workflows/plan_status_comments.go
+++ b/pkg/commands/workflows/plan_status_comments.go
@@ -56,7 +56,7 @@ func (c *PlanStatusCommentCommand) Desc() string {
 
 func (c *PlanStatusCommentCommand) Help() string {
 	return `
-Usage: {{ COMMAND }} [options] <pull_request_number>
+Usage: {{ COMMAND }} [options]
 
 	Remove previous Guardian plan comments from a pull request.
 `

--- a/pkg/commands/workflows/remove_comments.go
+++ b/pkg/commands/workflows/remove_comments.go
@@ -65,7 +65,7 @@ func (c *RemoveGuardianCommentsCommand) Desc() string {
 
 func (c *RemoveGuardianCommentsCommand) Help() string {
 	return `
-Usage: {{ COMMAND }} [options] <pull_request_number>
+Usage: {{ COMMAND }} [options]
 
 	Remove previous Guardian comments from a pull request.
 `


### PR DESCRIPTION
* Switched to using the `-dir` flag for the `drift statefiles` command to make it consistent with other commands.
* Cleaned up 'Usage' strings that implied a different of method of input for directory or pull request number for various commands.