### PR TITLE
Add base `GitHubActionCommand`

### DIFF
--- a/pkg/commands/actions/actions.go
+++ b/pkg/commands/actions/actions.go
@@ -1,0 +1,43 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package actions provide the support for creating cli commands that run in GitHub actions.
+package actions
+
+import (
+	"github.com/sethvargo/go-githubactions"
+
+	"github.com/abcxyz/guardian/pkg/flags"
+	"github.com/abcxyz/pkg/cli"
+)
+
+type GitHubActionCommand struct {
+	cli.BaseCommand
+
+	flags.GitHubFlags
+
+	Action *githubactions.Action
+}
+
+// WithActionsOutGroup runs a function and ensures it is wrapped in GitHub actions
+// grouping syntax. If this is not in an action, output is printed without grouping syntax.
+func (c *GitHubActionCommand) WithActionsOutGroup(msg string, fn func() error) error {
+	if c.FlagIsGitHubActions {
+		c.Action.Group(msg)
+		defer c.Action.EndGroup()
+	} else {
+		c.Outf(msg)
+	}
+	return fn()
+}

--- a/pkg/commands/actions/actions_test.go
+++ b/pkg/commands/actions/actions_test.go
@@ -1,0 +1,126 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sethvargo/go-githubactions"
+
+	"github.com/abcxyz/guardian/pkg/flags"
+	"github.com/abcxyz/pkg/testutil"
+)
+
+func TestWithActionsOutGroup(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name                string
+		flagIsGitHubActions bool
+		actionout           *strings.Builder
+		stdout              *strings.Builder
+		msg                 string
+		testFunc            func() error
+		wantActionOut       string
+		wantStdOut          string
+		wantErr             string
+	}{
+		{
+			name:                "action_disabled_error_pass_through",
+			flagIsGitHubActions: false,
+			actionout:           &strings.Builder{},
+			stdout:              &strings.Builder{},
+			msg:                 "MyActionGroup",
+			testFunc: func() error {
+				return fmt.Errorf("testFunc error")
+			},
+			wantActionOut: "",
+			wantStdOut:    "MyActionGroup\n",
+			wantErr:       "testFunc error",
+		},
+		{
+			name:                "action_disabled_error_pass_nil",
+			flagIsGitHubActions: false,
+			actionout:           &strings.Builder{},
+			stdout:              &strings.Builder{},
+			msg:                 "MyActionGroup",
+			testFunc: func() error {
+				return nil
+			},
+			wantActionOut: "",
+			wantStdOut:    "MyActionGroup\n",
+			wantErr:       "",
+		},
+		{
+			name:                "action_enabled_error_pass_through",
+			flagIsGitHubActions: true,
+			actionout:           &strings.Builder{},
+			stdout:              &strings.Builder{},
+			msg:                 "MyActionGroup",
+			testFunc: func() error {
+				return fmt.Errorf("testFunc error")
+			},
+			wantActionOut: "::group::MyActionGroup\n::endgroup::\n",
+			wantStdOut:    "",
+			wantErr:       "testFunc error",
+		},
+		{
+			name:                "action_enabled_error_pass_nil",
+			flagIsGitHubActions: true,
+			actionout:           &strings.Builder{},
+			stdout:              &strings.Builder{},
+			msg:                 "MyActionGroup",
+			testFunc: func() error {
+				return nil
+			},
+			wantActionOut: "::group::MyActionGroup\n::endgroup::\n",
+			wantStdOut:    "",
+			wantErr:       "",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			action := githubactions.New(githubactions.WithWriter(tc.actionout))
+
+			cmd := &GitHubActionCommand{
+				GitHubFlags: flags.GitHubFlags{
+					FlagIsGitHubActions: tc.flagIsGitHubActions,
+				},
+				Action: action,
+			}
+
+			cmd.SetStdout(tc.stdout)
+
+			gotErr := cmd.WithActionsOutGroup(tc.msg, tc.testFunc)
+			if diff := testutil.DiffErrString(gotErr, tc.wantErr); diff != "" {
+				t.Errorf("unexpected result (-got, +want):\n%s", diff)
+			}
+			gotStdOut := tc.stdout.String()
+			if diff := cmp.Diff(gotStdOut, tc.wantStdOut); diff != "" {
+				t.Errorf("unexpected result (-got, +want):\n%s", diff)
+			}
+			gotActionOut := tc.actionout.String()
+			if diff := cmp.Diff(gotActionOut, tc.wantActionOut); diff != "" {
+				t.Errorf("unexpected result (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/commands/apply/apply_test.go
+++ b/pkg/commands/apply/apply_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sethvargo/go-githubactions"
 
+	"github.com/abcxyz/guardian/pkg/commands/actions"
 	"github.com/abcxyz/guardian/pkg/flags"
 	"github.com/abcxyz/guardian/pkg/github"
 	"github.com/abcxyz/guardian/pkg/storage"
@@ -243,7 +244,7 @@ func TestApply_Process(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			actions := githubactions.New(githubactions.WithWriter(os.Stdout))
+			action := githubactions.New(githubactions.WithWriter(os.Stdout))
 			gitHubClient := &github.MockGitHubClient{}
 			storageClient := &storage.MockStorageClient{
 				Metadata: map[string]string{
@@ -252,6 +253,14 @@ func TestApply_Process(t *testing.T) {
 			}
 
 			c := &ApplyCommand{
+				GitHubActionCommand: actions.GitHubActionCommand{
+					GitHubFlags: flags.GitHubFlags{
+						FlagIsGitHubActions: tc.flagIsGitHubActions,
+						FlagGitHubOwner:     tc.flagGitHubOwner,
+						FlagGitHubRepo:      tc.flagGitHubRepo,
+					},
+					Action: action,
+				},
 				cfg: tc.config,
 
 				directory:    tc.directory,
@@ -263,15 +272,9 @@ func TestApply_Process(t *testing.T) {
 				flagBucketName:           tc.flagBucketName,
 				flagAllowLockfileChanges: tc.flagAllowLockfileChanges,
 				flagLockTimeout:          tc.flagLockTimeout,
-				GitHubFlags: flags.GitHubFlags{
-					FlagIsGitHubActions: tc.flagIsGitHubActions,
-					FlagGitHubOwner:     tc.flagGitHubOwner,
-					FlagGitHubRepo:      tc.flagGitHubRepo,
-				},
-				actions:         actions,
-				gitHubClient:    gitHubClient,
-				storageClient:   storageClient,
-				terraformClient: tc.terraformClient,
+				gitHubClient:             gitHubClient,
+				storageClient:            storageClient,
+				terraformClient:          tc.terraformClient,
 			}
 
 			_, stdout, stderr := c.Pipe()

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sethvargo/go-githubactions"
 
+	"github.com/abcxyz/guardian/pkg/commands/actions"
 	"github.com/abcxyz/guardian/pkg/flags"
 	"github.com/abcxyz/guardian/pkg/github"
 	"github.com/abcxyz/guardian/pkg/storage"
@@ -322,11 +323,19 @@ func TestPlan_Process(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			actions := githubactions.New(githubactions.WithWriter(os.Stdout))
+			action := githubactions.New(githubactions.WithWriter(os.Stdout))
 			gitHubClient := &github.MockGitHubClient{}
 			storageClient := &storage.MockStorageClient{}
 
 			c := &PlanCommand{
+				GitHubActionCommand: actions.GitHubActionCommand{
+					GitHubFlags: flags.GitHubFlags{
+						FlagIsGitHubActions: tc.flagIsGitHubActions,
+						FlagGitHubOwner:     tc.flagGitHubOwner,
+						FlagGitHubRepo:      tc.flagGitHubRepo,
+					},
+					Action: action,
+				},
 				cfg: tc.config,
 
 				directory:    tc.directory,
@@ -337,15 +346,9 @@ func TestPlan_Process(t *testing.T) {
 				flagBucketName:           tc.flagBucketName,
 				flagAllowLockfileChanges: tc.flagAllowLockfileChanges,
 				flagLockTimeout:          tc.flagLockTimeout,
-				GitHubFlags: flags.GitHubFlags{
-					FlagIsGitHubActions: tc.flagIsGitHubActions,
-					FlagGitHubOwner:     tc.flagGitHubOwner,
-					FlagGitHubRepo:      tc.flagGitHubRepo,
-				},
-				actions:         actions,
-				gitHubClient:    gitHubClient,
-				storageClient:   storageClient,
-				terraformClient: tc.terraformClient,
+				gitHubClient:             gitHubClient,
+				storageClient:            storageClient,
+				terraformClient:          tc.terraformClient,
 			}
 
 			_, stdout, stderr := c.Pipe()

--- a/pkg/commands/run/run_test.go
+++ b/pkg/commands/run/run_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/sethvargo/go-githubactions"
 
+	"github.com/abcxyz/guardian/pkg/commands/actions"
 	"github.com/abcxyz/guardian/pkg/flags"
 	"github.com/abcxyz/guardian/pkg/terraform"
 	"github.com/abcxyz/pkg/logging"
@@ -118,9 +119,17 @@ func TestPlan_Process(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			actions := githubactions.New(githubactions.WithWriter(io.Discard))
+			action := githubactions.New(githubactions.WithWriter(io.Discard))
 
 			c := &RunCommand{
+				GitHubActionCommand: actions.GitHubActionCommand{
+					GitHubFlags: flags.GitHubFlags{
+						FlagIsGitHubActions: tc.flagIsGitHubActions,
+						FlagGitHubOwner:     tc.flagGitHubOwner,
+						FlagGitHubRepo:      tc.flagGitHubRepo,
+					},
+					Action: action,
+				},
 				directory: "testdir",
 				childPath: "testdir",
 
@@ -129,13 +138,7 @@ func TestPlan_Process(t *testing.T) {
 				terraformArgs:                tc.flagTerraformArgs,
 				flagAllowLockfileChanges:     tc.flagAllowLockfileChanges,
 				flagLockTimeout:              tc.flagLockTimeout,
-				GitHubFlags: flags.GitHubFlags{
-					FlagIsGitHubActions: tc.flagIsGitHubActions,
-					FlagGitHubOwner:     tc.flagGitHubOwner,
-					FlagGitHubRepo:      tc.flagGitHubRepo,
-				},
-				actions:         actions,
-				terraformClient: tc.terraformClient,
+				terraformClient:              tc.terraformClient,
 			}
 
 			_, stdout, stderr := c.Pipe()


### PR DESCRIPTION
* Created a base `GitHubActionCommand` that implements the `WithActionsOutGroup` method. Any command that wants this functionality can simply embed this struct.
* Refactored `PlanCommand`, `ApplyCommand`, and `RunCommand` to use the new `GitHubActionCommand`.

closes #185