### PR TITLE
fix drift-workflows abc.template

### DIFF
--- a/abc.templates/drift-workflows/spec.yaml
+++ b/abc.templates/drift-workflows/spec.yaml
@@ -56,16 +56,16 @@ steps:
         - to_replace: 'REPLACE_GUARDIAN_VERSION_TAG'
           with: '{{._git_tag}}'
 
-        # TODO: once https://github.com/abcxyz/abc/pull/423 is available, switch to a rule requiring a '_git_tag' value
-        - desc: 'Print warning if rendered without git tag'
-          action: 'print'
-          if: '_git_tag == ""'
-          params:
-            message: |-
-              #
-              # WARNING ##############################
-              #
-              # The template was rendered without a valid git tag. For best compatibility, we recommended
-              # re-rendering this template using one of the latest tags at https://github.com/abcxyz/guardian/tags.
-              #
-              ########################################
+  # TODO: once https://github.com/abcxyz/abc/pull/423 is available, switch to a rule requiring a '_git_tag' value
+  - desc: 'Print warning if rendered without git tag'
+    action: 'print'
+    if: '_git_tag == ""'
+    params:
+      message: |-
+        #
+        # WARNING ##############################
+        #
+        # The template was rendered without a valid git tag. For best compatibility, we recommended
+        # re-rendering this template using one of the latest tags at https://github.com/abcxyz/guardian/tags.
+        #
+        ########################################


### PR DESCRIPTION
This fixes the indentation of the spec file used for rendering drift-workflows

Fixes #293 