### PR TITLE
fix: parsing of members attribute with non google provider resources

### DIFF
--- a/pkg/terraform/parser/parser.go
+++ b/pkg/terraform/parser/parser.go
@@ -43,12 +43,12 @@ const (
 // ResourceInstances represents the JSON terraform state IAM instance.
 type ResourceInstance struct {
 	Attributes struct {
-		ID      string   `json:"id"`
-		Members []string `json:"members,omitempty"`
-		Member  string   `json:"member,omitempty"`
-		Folder  string   `json:"folder,omitempty"`
-		Project string   `json:"project,omitempty"`
-		Role    string   `json:"role,omitempty"`
+		ID      string        `json:"id"`
+		Members []interface{} `json:"members,omitempty"`
+		Member  string        `json:"member,omitempty"`
+		Folder  string        `json:"folder,omitempty"`
+		Project string        `json:"project,omitempty"`
+		Role    string        `json:"role,omitempty"`
 	}
 }
 
@@ -191,7 +191,7 @@ func (p *TerraformParser) parseIAMBindingForOrg(ctx context.Context, instances [
 	for _, i := range instances {
 		for _, m := range i.Attributes.Members {
 			iams = append(iams, &assetinventory.AssetIAM{
-				Member:       m,
+				Member:       m.(string),
 				Role:         i.Attributes.Role,
 				ResourceID:   p.OrganizationID,
 				ResourceType: assetinventory.Organization,
@@ -212,7 +212,7 @@ func (p *TerraformParser) parseIAMBindingForFolder(ctx context.Context, instance
 				logger.WarnContext(ctx, "failed to locate GCP folder - is this folder deleted?", "folder", folderID)
 			}
 			iams = append(iams, &assetinventory.AssetIAM{
-				Member:       m,
+				Member:       m.(string),
 				Role:         i.Attributes.Role,
 				ResourceID:   parentID,
 				ResourceType: parentType,
@@ -232,7 +232,7 @@ func (p *TerraformParser) parseIAMBindingForProject(ctx context.Context, instanc
 				logger.WarnContext(ctx, "failed to locate GCP project - is this project deleted?", "project", i.Attributes.Project)
 			}
 			iams = append(iams, &assetinventory.AssetIAM{
-				Member:       m,
+				Member:       m.(string),
 				Role:         i.Attributes.Role,
 				ResourceID:   parentID,
 				ResourceType: parentType,

--- a/testdata/test_valid.tfstate
+++ b/testdata/test_valid.tfstate
@@ -7,6 +7,32 @@
     "resources": [
         {
             "mode": "managed",
+            "type": "github_team_members",
+            "name": "default",
+            "provider": "provider[\"registry.terraform.io/integrations/github\"]",
+            "instances": [
+                {
+                    "index_key": 0,
+                    "schema_version": 0,
+                    "attributes": {
+                        "id": "1231231",
+                        "members": [
+                            {
+                                "username": "user1"
+                            },
+                            {
+                                "username": "user2"
+                            }
+                        ],
+                        "team_id": "1231231"
+                    },
+                    "sensitive_attributes": [],
+                    "private": "bnVsbA=="
+                }
+            ]
+        },
+        {
+            "mode": "managed",
             "type": "google_organization_iam_binding",
             "name": "org_roles",
             "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",


### PR DESCRIPTION
When using detect drift, I had this error:
> failed to parse IAM from Terraform State: failed to execute terraform IAM tasks in parallel: failed to parse terraform states: failed to decode terraform state: json: cannot unmarshal object into Go struct field .resources.instances.Attributes.members of type string

It turns out guardian downloaded and parsed a terraform state file including a `github_team_members` resource from the github provider, that has a `members` field, whose value is not an array of string, but an array of object.

Not sure the fix provided is the best way to handle this, but at least, test passes.
We could probably filter resources by provider field, but it would probably mean creating our json decoder.