### PR TITLE
fix: drift detection parsing issue

### DIFF
--- a/pkg/terraform/parser/parser.go
+++ b/pkg/terraform/parser/parser.go
@@ -178,11 +178,11 @@ func (p *TerraformParser) parseTerraformStateIAM(ctx context.Context, state Terr
 	var iams []*assetinventory.AssetIAM
 	for _, r := range state.Resources {
 		targetResources := map[string]struct{}{
-			"google_organization_iam_binding": {},
 			"google_folder_iam_binding":       {},
-			"google_project_iam_binding":      {},
-			"google_organization_iam_member":  {},
 			"google_folder_iam_member":        {},
+			"google_organization_iam_binding": {},
+			"google_organization_iam_member":  {},
+			"google_project_iam_binding":      {},
 			"google_project_iam_member":       {},
 		}
 

--- a/testdata/test_valid.tfstate
+++ b/testdata/test_valid.tfstate
@@ -1,81 +1,127 @@
 {
-    "version": 4,
-    "terraform_version": "1.3.6",
-    "serial": 13,
-    "lineage": "7a1905bb-b49d-a48f-73e0-9d1c7b7d03d1",
-    "outputs": {},
-    "resources": [
+  "version": 4,
+  "terraform_version": "1.3.6",
+  "serial": 13,
+  "lineage": "7a1905bb-b49d-a48f-73e0-9d1c7b7d03d1",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "github_team_members",
+      "name": "default",
+      "provider": "provider[\"registry.terraform.io/integrations/github\"]",
+      "instances": [
         {
-            "mode": "managed",
-            "type": "google_organization_iam_binding",
-            "name": "org_roles",
-            "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
-            "instances": [
-                {
-                    "index_key": "roles/browser",
-                    "schema_version": 0,
-                    "attributes": {
-                        "condition": [],
-                        "etag": "BwX/MpDNkGs=",
-                        "id": "874171298815/roles/browser",
-                        "members": [
-                            "group:my-group@google.com",
-                            "serviceAccount:my-service-account@my-project.iam.gserviceaccount.com",
-                            "user:dcreey@google.com"
-                        ],
-                        "org_id": "1231231",
-                        "role": "roles/browser"
-                    },
-                    "sensitive_attributes": [],
-                    "private": "bnVsbA==",
-                    "dependencies": [
-                        "data.terraform_remote_state.remote_state"
-                    ]
-                }
-            ]
-        },
-        {
-            "mode": "managed",
-            "type": "google_folder_iam_member",
-            "name": "folder_member",
-            "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
-            "instances": [
-                {
-                    "schema_version": 0,
-                    "attributes": {
-                        "condition": [],
-                        "etag": "BwX+r+r0nXg=",
-                        "folder": "folders/123123123123",
-                        "id": "folders/123123123123/roles/viewer/group:my-group@google.com",
-                        "member": "group:my-group@google.com",
-                        "role": "roles/viewer"
-                    },
-                    "sensitive_attributes": [],
-                    "private": "bnVsbA=="
-                }
-            ]
-        },
-        {
-            "mode": "managed",
-            "type": "google_project_iam_member",
-            "name": "compute_admin",
-            "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
-            "instances": [
-                {
-                    "schema_version": 0,
-                    "attributes": {
-                        "condition": [],
-                        "etag": "BwX9ZwfhdP4=",
-                        "id": "my-project/roles/compute.admin/serviceAccount:my-service-account@my-project.iam.gserviceaccount.com",
-                        "member": "serviceAccount:my-service-account@my-project.iam.gserviceaccount.com",
-                        "project": "my-project",
-                        "role": "roles/compute.admin"
-                    },
-                    "sensitive_attributes": [],
-                    "private": "bnVsbA=="
-                }
-            ]
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "1231231",
+            "members": [
+              {
+                "username": "user1"
+              },
+              {
+                "username": "user2"
+              }
+            ],
+            "team_id": "1231231"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
         }
-    ],
-    "check_results": null
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "fake_resource",
+      "name": "default",
+      "provider": "provider[\"registry.terraform.io/fake/provider\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "34234",
+            "members": {
+              "usernames": "user1, user2, user3"
+            },
+            "member": ["test", "test", "test"],
+            "team_id": "1231231"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_organization_iam_binding",
+      "name": "org_roles",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "index_key": "roles/browser",
+          "schema_version": 0,
+          "attributes": {
+            "condition": [],
+            "etag": "BwX/MpDNkGs=",
+            "id": "874171298815/roles/browser",
+            "members": [
+              "group:my-group@google.com",
+              "serviceAccount:my-service-account@my-project.iam.gserviceaccount.com",
+              "user:dcreey@google.com"
+            ],
+            "org_id": "1231231",
+            "role": "roles/browser"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": ["data.terraform_remote_state.remote_state"]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_folder_iam_member",
+      "name": "folder_member",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "condition": [],
+            "etag": "BwX+r+r0nXg=",
+            "folder": "folders/123123123123",
+            "id": "folders/123123123123/roles/viewer/group:my-group@google.com",
+            "member": "group:my-group@google.com",
+            "role": "roles/viewer"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_project_iam_member",
+      "name": "compute_admin",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "condition": [],
+            "etag": "BwX9ZwfhdP4=",
+            "id": "my-project/roles/compute.admin/serviceAccount:my-service-account@my-project.iam.gserviceaccount.com",
+            "member": "serviceAccount:my-service-account@my-project.iam.gserviceaccount.com",
+            "project": "my-project",
+            "role": "roles/compute.admin"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    }
+  ],
+  "check_results": null
 }


### PR DESCRIPTION
This fixes an issue where parsing the Terraform statefile would error during drift detection. See #317 for more details.
