### PR TITLE
feat: add a flag to optionally fail if `plan` finds a diff

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -97,7 +97,7 @@ Also supports [GitHub Options](#github-options) and [Retry Options](#retry-optio
   and commit-sha can be given.
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
-* **-pull-request-number="100"** The GitHub pull request number associated with this
+* **-pull-request-number="100"** - The GitHub pull request number associated with this
   apply. Only one of pull-request-number and commit-sha can be given. The default value is "0".
 
 ## Plan
@@ -124,8 +124,12 @@ Also supports [GitHub Options](#github-options) and [Retry Options](#retry-optio
 * **-bucket-name="my-guardian-state-bucket"** - The Google Cloud Storage bucket name to store Guardian plan files.
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
-* **-pull-request-number="100"** The GitHub pull request number associated with this
+* **-pull-request-number="100"** - The GitHub pull request number associated with this
   plan. Only one of pull-request-number and commit-sha can be given. The default value is "0".
+* **-fail-on-diff** - Returns an exit code of 2 to the OS if `terraform plan` returns a plan with
+any changes. This can be useful to run occasionally to detect if your cloud resources match their
+intended state on the `.tf` files. This doesn't detect spurious extra resources that were created
+outside of terraform.
 
 ## Run
 

--- a/cmd/guardian/main.go
+++ b/cmd/guardian/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -31,6 +32,7 @@ import (
 	"github.com/abcxyz/guardian/pkg/commands/plan"
 	"github.com/abcxyz/guardian/pkg/commands/run"
 	"github.com/abcxyz/guardian/pkg/commands/workflows"
+	"github.com/abcxyz/guardian/pkg/util"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 )
@@ -112,8 +114,22 @@ func main() {
 
 	if err := realMain(ctx); err != nil {
 		done()
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+
+		// On error, the exit code is 1 unless otherwise requested.
+		exitCode := 1
+
+		// In the special case where there's an ExitCodeErr, use that code.
+		var exitErr *util.ExitCodeError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.Code
+			err = exitErr.Unwrap()
+		}
+
+		if err != nil { // Could be nil if the ExitCodeErr wasn't wrapping anything
+			fmt.Fprintln(os.Stderr, err.Error())
+		}
+
+		os.Exit(exitCode)
 	}
 }
 

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -162,6 +162,7 @@ func TestPlan_Process(t *testing.T) {
 	cases := []struct {
 		name                     string
 		directory                string
+		flagFailOnDiff           bool
 		flagIsGitHubActions      bool
 		flagGitHubOwner          string
 		flagGitHubRepo           string
@@ -315,6 +316,41 @@ func TestPlan_Process(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                     "flag_fail_on_diff",
+			directory:                "testdata",
+			flagFailOnDiff:           true,
+			flagIsGitHubActions:      true,
+			flagGitHubOwner:          "owner",
+			flagGitHubRepo:           "repo",
+			flagPullRequestNumber:    1,
+			flagBucketName:           "my-bucket-name",
+			flagAllowLockfileChanges: true,
+			flagLockTimeout:          10 * time.Minute,
+			config:                   defaultConfig,
+			terraformClient:          terraformDiffMock,
+			err:                      "exit code 2: <nil>", // users won't actually see this message, since the error will be unwrapped in main()
+			expGitHubClientReqs: []*github.Request{
+				{
+					Name:   "CreateIssueComment",
+					Params: []any{"owner", "repo", int(1), "**`🔱 Guardian 🔱 PLAN`** - 🟨 Running for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
+				},
+				{
+					Name:   "UpdateIssueComment",
+					Params: []any{"owner", "repo", int64(1), "**`🔱 Guardian 🔱 PLAN`** - 🟩 Successful for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform show success with diff\n```\n</details>"},
+				},
+			},
+			expStorageClientReqs: []*storage.Request{
+				{
+					Name: "UploadObject",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/1/testdata/test-tfplan.binary",
+						"this is a plan binary",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -342,6 +378,7 @@ func TestPlan_Process(t *testing.T) {
 				childPath:    tc.directory,
 				planFilename: "test-tfplan.binary",
 
+				flagFailOnDiff:           tc.flagFailOnDiff,
 				flagPullRequestNumber:    tc.flagPullRequestNumber,
 				flagBucketName:           tc.flagBucketName,
 				flagAllowLockfileChanges: tc.flagAllowLockfileChanges,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -88,3 +88,23 @@ func PathEvalAbs(path string) (string, error) {
 
 	return abs, nil
 }
+
+// ExitCodeErr is an implementation of the error interface that contains an
+// command exit status. This is intended to be returned from a Run() function
+// when a command wants to return a specific error code to the OS.
+type ExitCodeError struct {
+	Code int
+
+	// Err may be nil if nothing went wrong, but we still want to exit with a
+	// nonzero status
+	Err error
+}
+
+func (e *ExitCodeError) Error() string {
+	// The CLI user should never see this, it's unwrapped in main().
+	return fmt.Sprintf("exit code %d: %v", e.Code, e.Err)
+}
+
+func (e *ExitCodeError) Unwrap() error {
+	return e.Err
+}


### PR DESCRIPTION
Fixes #325. This helps avoid a situation where a terraform codebase accumulates lots of technical debt. The command `guardian plan -fail-on-diff` can be run in a cron job. As soon as cloud resources differ from their declared desired state in terraform (due to, say, some scoundrel clicking in the cloud console), then you'll know shortly thereafter instead of silently diverging for some unknown amount of time.