### PR TITLE
fix: handle bucket not found error

### DIFF
--- a/pkg/commands/drift/statefiles/statefiles.go
+++ b/pkg/commands/drift/statefiles/statefiles.go
@@ -235,15 +235,16 @@ func (c *DriftStatefilesCommand) Process(ctx context.Context) error {
 		With("github_repo", c.GitHubFlags.FlagGitHubOwner)
 
 	logger.DebugContext(ctx, "starting Guardian drift statefiles")
-	if err := c.cloneAllGitHubRepositories(ctx, logger); err != nil {
-		return fmt.Errorf("failed to clone github repositories: %w", err)
-	}
+	// if err := c.cloneAllGitHubRepositories(ctx, logger); err != nil {
+	// 	return fmt.Errorf("failed to clone github repositories: %w", err)
+	// }
 
+	expectedURIs := []string{}
 	logger.DebugContext(ctx, "finding expected statefile uris")
-	expectedURIs, err := c.expectedStatefileUris(ctx, logger)
-	if err != nil {
-		return fmt.Errorf("failed to determine expected state file URIs: %w", err)
-	}
+	// expectedURIs, err := c.expectedStatefileUris(ctx, logger)
+	// if err != nil {
+	// 	return fmt.Errorf("failed to determine expected state file URIs: %w", err)
+	// }
 
 	logger.DebugContext(ctx, "finding actual statefile uris")
 	gotURIs, err := c.actualStatefileUris(ctx, logger, expectedURIs)

--- a/pkg/commands/drift/statefiles/statefiles.go
+++ b/pkg/commands/drift/statefiles/statefiles.go
@@ -235,16 +235,15 @@ func (c *DriftStatefilesCommand) Process(ctx context.Context) error {
 		With("github_repo", c.GitHubFlags.FlagGitHubOwner)
 
 	logger.DebugContext(ctx, "starting Guardian drift statefiles")
-	// if err := c.cloneAllGitHubRepositories(ctx, logger); err != nil {
-	// 	return fmt.Errorf("failed to clone github repositories: %w", err)
-	// }
+	if err := c.cloneAllGitHubRepositories(ctx, logger); err != nil {
+		return fmt.Errorf("failed to clone github repositories: %w", err)
+	}
 
-	expectedURIs := []string{}
 	logger.DebugContext(ctx, "finding expected statefile uris")
-	// expectedURIs, err := c.expectedStatefileUris(ctx, logger)
-	// if err != nil {
-	// 	return fmt.Errorf("failed to determine expected state file URIs: %w", err)
-	// }
+	expectedURIs, err := c.expectedStatefileUris(ctx, logger)
+	if err != nil {
+		return fmt.Errorf("failed to determine expected state file URIs: %w", err)
+	}
 
 	logger.DebugContext(ctx, "finding actual statefile uris")
 	gotURIs, err := c.actualStatefileUris(ctx, logger, expectedURIs)


### PR DESCRIPTION
I am seeing a [failure](https://github.com/theteamatx/x-refinery-org/actions/runs/9500936795/job/26185227984) caused by running `guardian drift statefiles` when asset inventory returns a gcs bucket that is in a recently deleted project. We should check whether a bucket exists and skip ones that don't exist.