### PR TITLE
Use CAI to fetch IAM policies in IAM detect-drift

### DIFF
--- a/pkg/assetinventory/assetinventory.go
+++ b/pkg/assetinventory/assetinventory.go
@@ -138,7 +138,7 @@ type AssetInventory interface {
 	HierarchyAssets(ctx context.Context, organizationID, assetType string) ([]*HierarchyNode, error)
 
 	// IAM returns all IAM that matches the given query.
-	IAM(ctx context.Context, opts IAMOptions) ([]*AssetIAM, error)
+	IAM(ctx context.Context, opts *IAMOptions) ([]*AssetIAM, error)
 }
 
 // AssetInventoryClient exposes GCP Asset Inventory functionality.
@@ -165,7 +165,7 @@ type IAMOptions struct {
 }
 
 // IAM returns all IAM that matches the given query.
-func (c *AssetInventoryClient) IAM(ctx context.Context, opts IAMOptions) ([]*AssetIAM, error) {
+func (c *AssetInventoryClient) IAM(ctx context.Context, opts *IAMOptions) ([]*AssetIAM, error) {
 	// gcloud asset search-all-iam-policies \
 	// --query="$QUERY"
 	// --scope="$SCOPE"

--- a/pkg/assetinventory/assetinventory.go
+++ b/pkg/assetinventory/assetinventory.go
@@ -138,7 +138,7 @@ type AssetInventory interface {
 	HierarchyAssets(ctx context.Context, organizationID, assetType string) ([]*HierarchyNode, error)
 
 	// IAM returns all IAM that matches the given query.
-	IAM(ctx context.Context, scope, query string) ([]*AssetIAM, error)
+	IAM(ctx context.Context, scope, query string, assetTypes []string) ([]*AssetIAM, error)
 }
 
 // AssetInventoryClient exposes GCP Asset Inventory functionality.
@@ -159,13 +159,14 @@ func NewClient(ctx context.Context) (*AssetInventoryClient, error) {
 }
 
 // IAM returns all IAM that matches the given query.
-func (c *AssetInventoryClient) IAM(ctx context.Context, scope, query string) ([]*AssetIAM, error) {
+func (c *AssetInventoryClient) IAM(ctx context.Context, scope, query string, assetTypes []string) ([]*AssetIAM, error) {
 	// gcloud asset search-all-iam-policies \
 	// --query="$QUERY"
 	// --scope="$SCOPE"
 	req := &assetpb.SearchAllIamPoliciesRequest{
-		Scope: scope,
-		Query: query,
+		Scope:      scope,
+		Query:      query,
+		AssetTypes: assetTypes,
 	}
 	it := c.assetClient.SearchAllIamPolicies(ctx, req)
 	var results []*AssetIAM

--- a/pkg/assetinventory/assetinventory.go
+++ b/pkg/assetinventory/assetinventory.go
@@ -138,7 +138,7 @@ type AssetInventory interface {
 	HierarchyAssets(ctx context.Context, organizationID, assetType string) ([]*HierarchyNode, error)
 
 	// IAM returns all IAM that matches the given query.
-	IAM(ctx context.Context, scope, query string, assetTypes []string) ([]*AssetIAM, error)
+	IAM(ctx context.Context, opts IAMOptions) ([]*AssetIAM, error)
 }
 
 // AssetInventoryClient exposes GCP Asset Inventory functionality.
@@ -158,15 +158,21 @@ func NewClient(ctx context.Context) (*AssetInventoryClient, error) {
 	}, nil
 }
 
+type IAMOptions struct {
+	Scope      string
+	Query      string
+	AssetTypes []string
+}
+
 // IAM returns all IAM that matches the given query.
-func (c *AssetInventoryClient) IAM(ctx context.Context, scope, query string, assetTypes []string) ([]*AssetIAM, error) {
+func (c *AssetInventoryClient) IAM(ctx context.Context, opts IAMOptions) ([]*AssetIAM, error) {
 	// gcloud asset search-all-iam-policies \
 	// --query="$QUERY"
 	// --scope="$SCOPE"
 	req := &assetpb.SearchAllIamPoliciesRequest{
-		Scope:      scope,
-		Query:      query,
-		AssetTypes: assetTypes,
+		Scope:      opts.Scope,
+		Query:      opts.Query,
+		AssetTypes: opts.AssetTypes,
 	}
 	it := c.assetClient.SearchAllIamPolicies(ctx, req)
 	var results []*AssetIAM

--- a/pkg/assetinventory/assetinventory_mock.go
+++ b/pkg/assetinventory/assetinventory_mock.go
@@ -35,7 +35,7 @@ type MockAssetInventoryClient struct {
 	AssetErr         error
 }
 
-func (m *MockAssetInventoryClient) IAM(ctx context.Context, scope, query string) ([]*AssetIAM, error) {
+func (m *MockAssetInventoryClient) IAM(ctx context.Context, scope, query string, assetTypes []string) ([]*AssetIAM, error) {
 	if m.IAMErr != nil {
 		return nil, m.IAMErr
 	}

--- a/pkg/assetinventory/assetinventory_mock.go
+++ b/pkg/assetinventory/assetinventory_mock.go
@@ -35,7 +35,7 @@ type MockAssetInventoryClient struct {
 	AssetErr         error
 }
 
-func (m *MockAssetInventoryClient) IAM(ctx context.Context, opts IAMOptions) ([]*AssetIAM, error) {
+func (m *MockAssetInventoryClient) IAM(ctx context.Context, opts *IAMOptions) ([]*AssetIAM, error) {
 	if m.IAMErr != nil {
 		return nil, m.IAMErr
 	}

--- a/pkg/assetinventory/assetinventory_mock.go
+++ b/pkg/assetinventory/assetinventory_mock.go
@@ -35,7 +35,7 @@ type MockAssetInventoryClient struct {
 	AssetErr         error
 }
 
-func (m *MockAssetInventoryClient) IAM(ctx context.Context, scope, query string, assetTypes []string) ([]*AssetIAM, error) {
+func (m *MockAssetInventoryClient) IAM(ctx context.Context, opts IAMOptions) ([]*AssetIAM, error) {
 	if m.IAMErr != nil {
 		return nil, m.IAMErr
 	}

--- a/pkg/commands/drift/drift.go
+++ b/pkg/commands/drift/drift.go
@@ -192,7 +192,7 @@ func (d *IAMDriftDetector) DetectDrift(
 // Returns a map of asset URI to asset IAM.
 func (d *IAMDriftDetector) actualGCPIAM(ctx context.Context) (map[string]*assetinventory.AssetIAM, error) {
 	// TODO: Add query to filter out projects/folders in "DELETE_REQUESTED" state.
-	iamResults, err := d.assetInventoryClient.IAM(ctx, assetinventory.IAMOptions{
+	iamResults, err := d.assetInventoryClient.IAM(ctx, &assetinventory.IAMOptions{
 		Scope: fmt.Sprintf("organizations/%s", d.organizationID),
 		AssetTypes: []string{
 			"cloudresourcemanager.googleapis.com/Organization",

--- a/pkg/commands/drift/drift.go
+++ b/pkg/commands/drift/drift.go
@@ -199,7 +199,14 @@ func (d *IAMDriftDetector) DetectDrift(
 // actualGCPIAM queries the GCP Asset Inventory to determine the IAM settings on all resources.
 // Returns a map of asset URI to asset IAM.
 func (d *IAMDriftDetector) actualGCPIAM(ctx context.Context) (map[string]*assetinventory.AssetIAM, error) {
-	iamResults, err := d.assetInventoryClient.IAM(ctx, fmt.Sprintf("organizations/%s", d.organizationID), "", []string{"cloudresourcemanager.googleapis.com/Organization", "cloudresourcemanager.googleapis.com/Folder", "cloudresourcemanager.googleapis.com/Project"})
+	iamResults, err := d.assetInventoryClient.IAM(ctx, assetinventory.IAMOptions{
+		Scope: fmt.Sprintf("organizations/%s", d.organizationID),
+		AssetTypes: []string{
+			"cloudresourcemanager.googleapis.com/Organization",
+			"cloudresourcemanager.googleapis.com/Folder",
+			"cloudresourcemanager.googleapis.com/Project",
+		},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to search all IAM resources for organization: %w", err)
 	}

--- a/pkg/commands/drift/drift.go
+++ b/pkg/commands/drift/drift.go
@@ -24,7 +24,6 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/abcxyz/guardian/pkg/assetinventory"
-	"github.com/abcxyz/guardian/pkg/iam"
 	"github.com/abcxyz/guardian/pkg/terraform/parser"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/sets"
@@ -39,7 +38,6 @@ type IAMDrift struct {
 
 type IAMDriftDetector struct {
 	assetInventoryClient  assetinventory.AssetInventory
-	iamClient             iam.IAM
 	terraformParser       parser.Terraform
 	organizationID        string
 	maxConcurrentRequests int64
@@ -53,11 +51,6 @@ func NewIAMDriftDetector(ctx context.Context, organizationID string, maxConcurre
 		return nil, fmt.Errorf("failed to initialize assets client: %w", err)
 	}
 
-	iamClient, err := iam.NewClient(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize iam client: %w", err)
-	}
-
 	terraformParser, err := parser.NewTerraformParser(ctx, organizationID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize terraform parser: %w", err)
@@ -68,7 +61,6 @@ func NewIAMDriftDetector(ctx context.Context, organizationID string, maxConcurre
 
 	return &IAMDriftDetector{
 		assetInventoryClient,
-		iamClient,
 		terraformParser,
 		organizationID,
 		maxConcurrentRequests,

--- a/pkg/commands/drift/drift.go
+++ b/pkg/commands/drift/drift.go
@@ -199,7 +199,7 @@ func (d *IAMDriftDetector) DetectDrift(
 // actualGCPIAM queries the GCP Asset Inventory to determine the IAM settings on all resources.
 // Returns a map of asset URI to asset IAM.
 func (d *IAMDriftDetector) actualGCPIAM(ctx context.Context) (map[string]*assetinventory.AssetIAM, error) {
-	iamResults, err := d.assetInventoryClient.IAM(ctx, fmt.Sprintf("organizations/%s", d.organizationID), "")
+	iamResults, err := d.assetInventoryClient.IAM(ctx, fmt.Sprintf("organizations/%s", d.organizationID), "", []string{"cloudresourcemanager.googleapis.com/Organization", "cloudresourcemanager.googleapis.com/Folder", "cloudresourcemanager.googleapis.com/Project"})
 	if err != nil {
 		return nil, fmt.Errorf("failed to search all IAM resources for organization: %w", err)
 	}

--- a/pkg/commands/drift/drift.go
+++ b/pkg/commands/drift/drift.go
@@ -191,6 +191,7 @@ func (d *IAMDriftDetector) DetectDrift(
 // actualGCPIAM queries the GCP Asset Inventory to determine the IAM settings on all resources.
 // Returns a map of asset URI to asset IAM.
 func (d *IAMDriftDetector) actualGCPIAM(ctx context.Context) (map[string]*assetinventory.AssetIAM, error) {
+	// TODO: Add query to filter out projects/folders in "DELETE_REQUESTED" state.
 	iamResults, err := d.assetInventoryClient.IAM(ctx, assetinventory.IAMOptions{
 		Scope: fmt.Sprintf("organizations/%s", d.organizationID),
 		AssetTypes: []string{

--- a/pkg/commands/iamcleanup/iamcleanup.go
+++ b/pkg/commands/iamcleanup/iamcleanup.go
@@ -44,7 +44,7 @@ func (c *IAMCleaner) Do(
 	evaluateCondition bool,
 ) error {
 	logger := logging.FromContext(ctx)
-	iams, err := c.assetInventoryClient.IAM(ctx, scope, iamQuery)
+	iams, err := c.assetInventoryClient.IAM(ctx, scope, iamQuery, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get iam: %w", err)
 	}

--- a/pkg/commands/iamcleanup/iamcleanup.go
+++ b/pkg/commands/iamcleanup/iamcleanup.go
@@ -44,7 +44,7 @@ func (c *IAMCleaner) Do(
 	evaluateCondition bool,
 ) error {
 	logger := logging.FromContext(ctx)
-	iams, err := c.assetInventoryClient.IAM(ctx, assetinventory.IAMOptions{
+	iams, err := c.assetInventoryClient.IAM(ctx, &assetinventory.IAMOptions{
 		Scope: scope,
 		Query: iamQuery,
 	})

--- a/pkg/commands/iamcleanup/iamcleanup.go
+++ b/pkg/commands/iamcleanup/iamcleanup.go
@@ -44,7 +44,10 @@ func (c *IAMCleaner) Do(
 	evaluateCondition bool,
 ) error {
 	logger := logging.FromContext(ctx)
-	iams, err := c.assetInventoryClient.IAM(ctx, scope, iamQuery, nil)
+	iams, err := c.assetInventoryClient.IAM(ctx, assetinventory.IAMOptions{
+		Scope: scope,
+		Query: iamQuery,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to get iam: %w", err)
 	}


### PR DESCRIPTION
This change leverages Cloud Asset Inventory API to reduce the number of req/min. The previous behavior would invoke the resourcemanager API once per project and folder in the organization but now it will call CAI based on the number of IAM resources / page_size.

Note, `asset.SearchAllIamPolicies` will also include IAM policies of projects and folders in `DELETE_REQUESTED` state, so in a follow up, we should call CAI to fetch all the projects in `DELETE_REQUESTED` state and exclude them using the query for `asset.SearchAllIamPolicies`.