### PR TITLE
Revert "feat: add a flag to optionally fail if plan finds a diff" in PR #326

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -97,7 +97,7 @@ Also supports [GitHub Options](#github-options) and [Retry Options](#retry-optio
   and commit-sha can be given.
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
-* **-pull-request-number="100"** - The GitHub pull request number associated with this
+* **-pull-request-number="100"** The GitHub pull request number associated with this
   apply. Only one of pull-request-number and commit-sha can be given. The default value is "0".
 
 ## Plan
@@ -124,12 +124,8 @@ Also supports [GitHub Options](#github-options) and [Retry Options](#retry-optio
 * **-bucket-name="my-guardian-state-bucket"** - The Google Cloud Storage bucket name to store Guardian plan files.
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
-* **-pull-request-number="100"** - The GitHub pull request number associated with this
+* **-pull-request-number="100"** The GitHub pull request number associated with this
   plan. Only one of pull-request-number and commit-sha can be given. The default value is "0".
-* **-fail-on-diff** - Returns an exit code of 2 to the OS if `terraform plan` returns a plan with
-any changes. This can be useful to run occasionally to detect if your cloud resources match their
-intended state on the `.tf` files. This doesn't detect spurious extra resources that were created
-outside of terraform.
 
 ## Run
 

--- a/cli.md
+++ b/cli.md
@@ -97,7 +97,7 @@ Also supports [GitHub Options](#github-options) and [Retry Options](#retry-optio
   and commit-sha can be given.
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
-* **-pull-request-number="100"** The GitHub pull request number associated with this
+* **-pull-request-number="100"** - The GitHub pull request number associated with this
   apply. Only one of pull-request-number and commit-sha can be given. The default value is "0".
 
 ## Plan
@@ -124,7 +124,7 @@ Also supports [GitHub Options](#github-options) and [Retry Options](#retry-optio
 * **-bucket-name="my-guardian-state-bucket"** - The Google Cloud Storage bucket name to store Guardian plan files.
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
-* **-pull-request-number="100"** The GitHub pull request number associated with this
+* **-pull-request-number="100"** - The GitHub pull request number associated with this
   plan. Only one of pull-request-number and commit-sha can be given. The default value is "0".
 
 ## Run
@@ -153,7 +153,7 @@ Also supports [GitHub Options](#github-options) and [Retry Options](#retry-optio
   and commit-sha can be given.
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
-* **-pull-request-number="100"** The GitHub pull request number associated with this
+* **-pull-request-number="100"** - The GitHub pull request number associated with this
   apply run. Only one of pull-request-number and commit-sha can be given. The default value is "0".
 
 ## IAM cleanup

--- a/cmd/guardian/main.go
+++ b/cmd/guardian/main.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -33,7 +32,6 @@ import (
 	"github.com/abcxyz/guardian/pkg/commands/plan"
 	"github.com/abcxyz/guardian/pkg/commands/run"
 	"github.com/abcxyz/guardian/pkg/commands/workflows"
-	"github.com/abcxyz/guardian/pkg/util"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 )
@@ -118,22 +116,8 @@ func main() {
 
 	if err := realMain(ctx); err != nil {
 		done()
-
-		// On error, the exit code is 1 unless otherwise requested.
-		exitCode := 1
-
-		// In the special case where there's an ExitCodeErr, use that code.
-		var exitErr *util.ExitCodeError
-		if errors.As(err, &exitErr) {
-			exitCode = exitErr.Code
-			err = exitErr.Unwrap()
-		}
-
-		if err != nil { // Could be nil if the ExitCodeErr wasn't wrapping anything
-			fmt.Fprintln(os.Stderr, err.Error())
-		}
-
-		os.Exit(exitCode)
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
 	}
 }
 

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -69,7 +69,6 @@ type PlanCommand struct {
 	flagBucketName           string
 	flagPullRequestNumber    int
 	flagAllowLockfileChanges bool
-	flagFailOnDiff           bool
 	flagLockTimeout          time.Duration
 
 	gitHubClient    github.GitHub
@@ -118,13 +117,6 @@ func (c *PlanCommand) Flags() *cli.FlagSet {
 		Target:  &c.flagAllowLockfileChanges,
 		Example: "true",
 		Usage:   "Allow modification of the Terraform lockfile.",
-	})
-
-	f.BoolVar(&cli.BoolVar{
-		Name:    "fail-on-diff",
-		Target:  &c.flagFailOnDiff,
-		Example: "true",
-		Usage:   "Return a status code of 2 to the OS if there are any diffs",
 	})
 
 	f.DurationVar(&cli.DurationVar{
@@ -269,17 +261,7 @@ func (c *PlanCommand) Process(ctx context.Context) error {
 		merr = errors.Join(merr, fmt.Errorf("failed to write result comment: %w", err))
 	}
 
-	if merr != nil {
-		return merr
-	}
-
-	if result.hasChanges && c.flagFailOnDiff {
-		return &util.ExitCodeError{
-			Code: 2,
-		}
-	}
-
-	return nil
+	return merr
 }
 
 func (c *PlanCommand) createStartCommentForActions(ctx context.Context) (*github.IssueComment, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -88,23 +88,3 @@ func PathEvalAbs(path string) (string, error) {
 
 	return abs, nil
 }
-
-// ExitCodeErr is an implementation of the error interface that contains an
-// command exit status. This is intended to be returned from a Run() function
-// when a command wants to return a specific error code to the OS.
-type ExitCodeError struct {
-	Code int
-
-	// Err may be nil if nothing went wrong, but we still want to exit with a
-	// nonzero status
-	Err error
-}
-
-func (e *ExitCodeError) Error() string {
-	// The CLI user should never see this, it's unwrapped in main().
-	return fmt.Sprintf("exit code %d: %v", e.Code, e.Err)
-}
-
-func (e *ExitCodeError) Unwrap() error {
-	return e.Err
-}


### PR DESCRIPTION
This reverts commit https://github.com/abcxyz/guardian/commit/d88f16193d6d5f1cd66b50bd34ab7fbc2c192517.

This was the wrong way to accomplish my intent. The nightly cron job will use `guardian run plan` rather than `guardian plan`, so this whole feature was misguided.