### PR TITLE
update to latest gcp auth action

### DIFF
--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
@@ -101,7 +101,7 @@ jobs:
         uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4
 
       - name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@5a50e581162a13f4baa8916d01180d2acbc04363' # ratchet:google-github-actions/auth@v2
+        uses: 'google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa' # ratchet:google-github-actions/auth@v2
         with:
           workload_identity_provider: '${{ env.GUARDIAN_WIF_PROVIDER}}'
           service_account: '${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}'

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-apply.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-apply.yml
@@ -83,7 +83,7 @@ jobs:
         uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4
 
       - name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@5a50e581162a13f4baa8916d01180d2acbc04363' # ratchet:google-github-actions/auth@v2
+        uses: 'google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa' # ratchet:google-github-actions/auth@v2
         with:
           workload_identity_provider: '${{ env.GUARDIAN_WIF_PROVIDER }}'
           service_account: '${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}'

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-plan.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-plan.yml
@@ -106,7 +106,7 @@ jobs:
           ref: '${{ github.event.pull_request.head.sha }}'
 
       - name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@5a50e581162a13f4baa8916d01180d2acbc04363' # ratchet:google-github-actions/auth@v2
+        uses: 'google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa' # ratchet:google-github-actions/auth@v2
         with:
           workload_identity_provider: '${{ env.GUARDIAN_WIF_PROVIDER }}'
           service_account: '${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}'

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-run.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-run.yml
@@ -93,7 +93,7 @@ jobs:
         uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4
 
       - name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@5a50e581162a13f4baa8916d01180d2acbc04363' # ratchet:google-github-actions/auth@v2
+        uses: 'google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa' # ratchet:google-github-actions/auth@v2
         with:
           workload_identity_provider: '${{ env.GUARDIAN_WIF_PROVIDER}}'
           service_account: '${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}'

--- a/abc.templates/drift-workflows/testdata/golden/basic/data/.github/workflows/guardian-drift-detection.yml
+++ b/abc.templates/drift-workflows/testdata/golden/basic/data/.github/workflows/guardian-drift-detection.yml
@@ -54,7 +54,7 @@ jobs:
           add_to_path: true
 
       - name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@67e9c72af6e0492df856527b474995862b7b6591' # ratchet:google-github-actions/auth@v2
+        uses: 'google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa' # ratchet:google-github-actions/auth@v2
         with:
           workload_identity_provider: '${{ env.GUARDIAN_WIF_PROVIDER }}'
           service_account: '${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}'
@@ -90,7 +90,7 @@ jobs:
           add_to_path: true
 
       - name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@67e9c72af6e0492df856527b474995862b7b6591' # ratchet:google-github-actions/auth@v2
+        uses: 'google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa' # ratchet:google-github-actions/auth@v2
         with:
           workload_identity_provider: '${{ env.GUARDIAN_WIF_PROVIDER }}'
           service_account: '${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}'


### PR DESCRIPTION
The release is https://github.com/google-github-actions/auth/releases/tag/v2.1.3. This was already used in some places in this repo, but not everywhere. This PR updates every place in this repo where this action is used.