### PR TITLE
Link directly to logs for job in Guardian github comments

### DIFF
--- a/pkg/commands/apply/apply.go
+++ b/pkg/commands/apply/apply.go
@@ -258,7 +258,7 @@ func (c *ApplyCommand) Process(ctx context.Context) (merr error) {
 	}
 	logger.DebugContext(ctx, "computed pull request number", "computed_pull_request_number", c.computedPullRequestNumber)
 
-	c.gitHubLogURL = fmt.Sprintf("[[logs](%s/%s/%s/actions/runs/%d/attempts/%d)]", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, c.cfg.RunAttempt)
+	c.gitHubLogURL = fmt.Sprintf("[[logs](%s/%s/%s/actions/runs/%d/job/%s)]", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, c.cfg.Job)
 	logger.DebugContext(ctx, "computed github log url", "github_log_url", c.gitHubLogURL)
 
 	planBucketPath := path.Join(c.childPath, c.planFileName)

--- a/pkg/commands/apply/config.go
+++ b/pkg/commands/apply/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	ServerURL  string // this value is used to generate URLs for creating links in pull request comments
 	RunID      int64
 	RunAttempt int64
+	Job        string
 }
 
 // MapGitHubContext maps values from the GitHub context.
@@ -31,5 +32,6 @@ func (c *Config) MapGitHubContext(context *githubactions.GitHubContext) error {
 	c.ServerURL = context.ServerURL
 	c.RunID = context.RunID
 	c.RunAttempt = context.RunAttempt
+	c.Job = context.Job
 	return nil
 }

--- a/pkg/commands/plan/config.go
+++ b/pkg/commands/plan/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	ServerURL  string // this value is used to generate URLs for creating links in pull request comments
 	RunID      int64
 	RunAttempt int64
+	Job        string
 }
 
 // MapGitHubContext maps values from the GitHub context.
@@ -45,6 +46,11 @@ func (c *Config) MapGitHubContext(context *githubactions.GitHubContext) error {
 	c.RunAttempt = context.RunAttempt
 	if c.RunAttempt <= 0 {
 		merr = errors.Join(merr, fmt.Errorf("GITHUB_RUN_ATTEMPT is required"))
+	}
+
+	c.Job = context.Job
+	if c.Job == "" {
+		merr = errors.Join(merr, fmt.Errorf("GITHUB_JOB is required"))
 	}
 
 	return merr

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -244,7 +244,7 @@ func (c *PlanCommand) Process(ctx context.Context) error {
 		c.planFilename = "tfplan.binary"
 	}
 
-	c.gitHubLogURL = fmt.Sprintf("[[logs](%s/%s/%s/actions/runs/%d/attempts/%d)]", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, c.cfg.RunAttempt)
+	c.gitHubLogURL = fmt.Sprintf("[[logs](%s/%s/%s/actions/runs/%d/job/%s)]", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, c.cfg.Job)
 	logger.DebugContext(ctx, "computed github log url", "github_log_url", c.gitHubLogURL)
 
 	startComment, err := c.createStartCommentForActions(ctx)


### PR DESCRIPTION
Context: https://github.com/abcxyz/guardian/issues/179

Make Guardian github comments' log links go directly to the logs for the relevant job instead of to the summary page. 