### PR TITLE
feat: add destroy functionality

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,7 @@ name: 'integration'
 on:
   pull_request:
     types:
+      - 'edited'
       - 'opened'
       - 'synchronize'
       - 'reopened'
@@ -134,7 +135,7 @@ jobs:
       fail-fast: false
       max-parallel: 100
       matrix:
-        working_directory: '${{ fromJSON(needs.init.outputs.directories) }}'
+        working_directory: '${{ fromJSON(needs.init.outputs.directories).entrypoints }}'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4
@@ -239,7 +240,7 @@ jobs:
       fail-fast: false
       max-parallel: 100
       matrix:
-        working_directory: '${{ fromJSON(needs.init.outputs.directories) }}'
+        working_directory: '${{ fromJSON(needs.init.outputs.directories).entrypoints }}'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4

--- a/abc.templates/base-workflows/testdata/golden/basic/test.yaml
+++ b/abc.templates/base-workflows/testdata/golden/basic/test.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 api_version: 'cli.abcxyz.dev/v1beta3'
 kind: 'GoldenTest'
 inputs:

--- a/abc.templates/drift-workflows/testdata/golden/basic/test.yaml
+++ b/abc.templates/drift-workflows/testdata/golden/basic/test.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 api_version: 'cli.abcxyz.dev/v1beta3'
 kind: 'GoldenTest'
 inputs:

--- a/pkg/commands/entrypoints/entrypoints.go
+++ b/pkg/commands/entrypoints/entrypoints.go
@@ -21,31 +21,32 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"slices"
 	"sort"
-	"strings"
 
-	"github.com/posener/complete/v2"
 	"golang.org/x/exp/maps"
 
 	"github.com/abcxyz/guardian/pkg/flags"
 	"github.com/abcxyz/guardian/pkg/git"
+	"github.com/abcxyz/guardian/pkg/modifiers"
 	"github.com/abcxyz/guardian/pkg/terraform"
 	"github.com/abcxyz/guardian/pkg/util"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/sets"
 )
 
 var _ cli.Command = (*EntrypointsCommand)(nil)
 
-// allowedFormats are the allowed format flags for this command.
-var allowedFormats = map[string]struct{}{
-	"json": {},
-	"text": {},
+// EntrypointsResult is the entryponts command result.
+type EntrypointsResult struct {
+	Entrypoints []string `json:"entrypoints"`
+	Modified    []string `json:"modified"`
+	Destroy     []string `json:"destroy"`
 }
-
-// allowedFormatNames are the sorted allowed format names for the format flag.
-// This is used for printing messages and prediction.
-var allowedFormatNames = util.SortedMapKeys(allowedFormats)
 
 type EntrypointsCommand struct {
 	cli.BaseCommand
@@ -58,7 +59,6 @@ type EntrypointsCommand struct {
 	flagDestRef                 string
 	flagSourceRef               string
 	flagDetectChanges           bool
-	flagFormat                  string
 	flagFailUnresolvableModules bool
 	flagMaxDepth                int
 
@@ -107,17 +107,6 @@ func (c *EntrypointsCommand) Flags() *cli.FlagSet {
 		Usage:  "Detect file changes, including all local module dependencies, and run for all entrypoint directories.",
 	})
 
-	f.StringVar(&cli.StringVar{
-		Name:    "format",
-		Target:  &c.flagFormat,
-		Example: "json",
-		Usage:   fmt.Sprintf("The format to print the output directories. The supported formats are: %s.", allowedFormatNames),
-		Default: "text",
-		Predict: complete.PredictFunc(func(prefix string) []string {
-			return allowedFormatNames
-		}),
-	})
-
 	f.BoolVar(&cli.BoolVar{
 		Name:    "fail-unresolvable-modules",
 		Target:  &c.flagFailUnresolvableModules,
@@ -135,10 +124,6 @@ func (c *EntrypointsCommand) Flags() *cli.FlagSet {
 	set.AfterParse(func(existingErr error) (merr error) {
 		if c.flagDetectChanges && c.flagSourceRef == "" && c.flagDestRef == "" {
 			merr = errors.Join(merr, fmt.Errorf("invalid flag: source-ref and dest-ref are required to detect changes, to ignore changes set the detect-changes flag"))
-		}
-
-		if _, ok := allowedFormats[c.flagFormat]; !ok {
-			merr = errors.Join(merr, fmt.Errorf("invalid flag: format %s (supported formats are: %s)", c.flagFormat, allowedFormatNames))
 		}
 
 		if c.flagMaxDepth != -1 {
@@ -186,11 +171,55 @@ func (c *EntrypointsCommand) Run(ctx context.Context, args []string) error {
 func (c *EntrypointsCommand) Process(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 
+	cwd, err := c.WorkingDir()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	entrypointDirs, removedDirs, err := c.findEntrypointDirs(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to find entrypoint directories: %w", err)
+	}
+
+	metaValues := modifiers.ParseBodyMetaValues(ctx, c.FlagBodyContents)
+	logger.DebugContext(ctx, "parsed body meta values", "values", metaValues)
+
+	allEntrypointDirs := slices.Concat(nil, entrypointDirs, removedDirs)
+
+	destroyDirs, err := c.processDestroyMetaValues(cwd, allEntrypointDirs, metaValues)
+	if err != nil {
+		return fmt.Errorf("failed to find entrypoint directories: %w", err)
+	}
+	logger.DebugContext(ctx, "found destroy dirs from meta values", "dirs", destroyDirs)
+
+	modifiedDirs := sets.Subtract(entrypointDirs, destroyDirs)
+
+	// TODO(verbanicm): write a comment to help the user with abandonded dirs
+	abandonedDirs := sets.Subtract(removedDirs, destroyDirs)
+	logger.DebugContext(ctx, "found abandonded dirs", "dirs", abandonedDirs)
+
+	results := &EntrypointsResult{
+		Entrypoints: entrypointDirs,
+		Modified:    modifiedDirs,
+		Destroy:     destroyDirs,
+	}
+
+	if err := c.writeOutput(cwd, results); err != nil {
+		return fmt.Errorf("failed to write output: %w", err)
+	}
+
+	return nil
+}
+
+// FindEntrypointDirs finds all the entrypoint directories.
+func (c *EntrypointsCommand) findEntrypointDirs(ctx context.Context) ([]string, []string, error) {
+	logger := logging.FromContext(ctx)
+
 	logger.DebugContext(ctx, "finding entrypoint directories")
 
 	entrypoints, err := terraform.GetEntrypointDirectories(c.directory, c.parsedFlagMaxDepth)
 	if err != nil {
-		return fmt.Errorf("failed to find terraform directories: %w", err)
+		return nil, nil, fmt.Errorf("failed to find terraform directories: %w", err)
 	}
 
 	entrypointDirs := make([]string, 0, len(entrypoints))
@@ -198,20 +227,26 @@ func (c *EntrypointsCommand) Process(ctx context.Context) error {
 		entrypointDirs = append(entrypointDirs, e.Path)
 	}
 
-	logger.DebugContext(ctx, "terraform entrypoint directories", "entrypoint_dirs", entrypoints)
+	logger.DebugContext(ctx, "terraform entrypoint directories", "entrypoint_dirs", entrypointDirs)
 
+	removedDirs := make([]string, 0)
 	if c.flagDetectChanges {
 		logger.DebugContext(ctx, "finding git diff directories")
 
 		diffDirs, err := c.gitClient.DiffDirsAbs(ctx, c.flagSourceRef, c.flagDestRef)
 		if err != nil {
-			return fmt.Errorf("failed to find git diff directories: %w", err)
+			return nil, nil, fmt.Errorf("failed to find git diff directories: %w", err)
 		}
 		logger.DebugContext(ctx, "git diff directories", "directories", diffDirs)
 
+		removedDirs, err = c.findRemovedDirs(diffDirs)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to find removed dirs: %w", err)
+		}
+
 		moduleUsageGraph, err := terraform.ModuleUsage(ctx, c.directory, c.parsedFlagMaxDepth, !c.flagFailUnresolvableModules)
 		if err != nil {
-			return fmt.Errorf("failed to get module usage for %s: %w", c.directory, err)
+			return nil, nil, fmt.Errorf("failed to get module usage for %s: %w", c.directory, err)
 		}
 
 		modifiedEntrypoints := make(map[string]struct{})
@@ -233,43 +268,78 @@ func (c *EntrypointsCommand) Process(ctx context.Context) error {
 		entrypointDirs = files
 	}
 
-	logger.DebugContext(ctx, "target directories", "target_directories", entrypointDirs)
+	logger.DebugContext(ctx, "calculated entrypoints and removed dirs",
+		"entrypoints", entrypointDirs,
+		"removed_dirs", removedDirs,
+	)
 
-	if err := c.writeOutput(entrypointDirs); err != nil {
-		return fmt.Errorf("failed to write output: %w", err)
+	return entrypointDirs, removedDirs, nil
+}
+
+// findRemovedDirs tests if any directories were removed from the filesystem and returns the list of removed dirs.
+func (c *EntrypointsCommand) findRemovedDirs(dirs []string) ([]string, error) {
+	removed := make([]string, 0)
+
+	for _, dir := range dirs {
+		_, err := os.Stat(dir)
+		// there was an error testing if dir exists
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("failed to check if dir exists: %w", err)
+		}
+
+		if errors.Is(err, fs.ErrNotExist) {
+			removed = append(removed, dir)
+		}
 	}
 
-	return nil
+	return removed, nil
+}
+
+// processDestroyMetaValues processes the user supplied meta values for directories to destroy.
+func (c *EntrypointsCommand) processDestroyMetaValues(cwd string, dirs []string, metaValues modifiers.MetaValues) ([]string, error) {
+	metaDestroyDirs, ok := metaValues[modifiers.MetaKeyGuardianDestroy]
+	if !ok {
+		return []string{}, nil
+	}
+
+	for i, dir := range metaDestroyDirs {
+		metaDestroyDirs[i] = path.Join(cwd, dir)
+	}
+
+	destroyDirs := sets.Intersect(dirs, metaDestroyDirs)
+	return destroyDirs, nil
 }
 
 // writeOutput writes the command output.
-func (c *EntrypointsCommand) writeOutput(dirs []string) error {
-	cwd, err := c.WorkingDir()
-	if err != nil {
-		return fmt.Errorf("failed to get current working directory: %w", err)
-	}
-
+func (c *EntrypointsCommand) writeOutput(cwd string, results *EntrypointsResult) error {
 	// convert to child path for output
 	// using absolute path creates an ugly github workflow name
-	for k, dir := range dirs {
+	for k, dir := range results.Entrypoints {
 		childPath, err := util.ChildPath(cwd, dir)
 		if err != nil {
-			return fmt.Errorf("failed to get child path for: %w", err)
+			return fmt.Errorf("failed to get child path for [%s]: %w", dir, err)
 		}
-		dirs[k] = childPath
+		results.Entrypoints[k] = childPath
 	}
 
-	switch v := strings.TrimSpace(strings.ToLower(c.flagFormat)); v {
-	case "json":
-		if err := json.NewEncoder(c.Stdout()).Encode(dirs); err != nil {
-			return fmt.Errorf("failed to create json string: %w", err)
+	for k, dir := range results.Modified {
+		childPath, err := util.ChildPath(cwd, dir)
+		if err != nil {
+			return fmt.Errorf("failed to get child path for [%s]: %w", dir, err)
 		}
-	case "text":
-		for _, dir := range dirs {
-			c.Outf("%s", dir)
+		results.Modified[k] = childPath
+	}
+
+	for k, dir := range results.Destroy {
+		childPath, err := util.ChildPath(cwd, dir)
+		if err != nil {
+			return fmt.Errorf("failed to get child path for [%s]: %w", dir, err)
 		}
-	default:
-		return fmt.Errorf("invalid format flag: %s (supported formats are: %s)", c.flagFormat, allowedFormatNames)
+		results.Destroy[k] = childPath
+	}
+
+	if err := json.NewEncoder(c.Stdout()).Encode(results); err != nil {
+		return fmt.Errorf("failed to create json string: %w", err)
 	}
 
 	return nil

--- a/pkg/flags/common.go
+++ b/pkg/flags/common.go
@@ -19,7 +19,8 @@ import (
 )
 
 type CommonFlags struct {
-	FlagDir string
+	FlagDir          string
+	FlagBodyContents string
 }
 
 func (c *CommonFlags) Register(set *cli.FlagSet) {
@@ -30,5 +31,12 @@ func (c *CommonFlags) Register(set *cli.FlagSet) {
 		Target:  &c.FlagDir,
 		Example: "./terraform",
 		Usage:   "The location of the terraform directory",
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "body-contents",
+		Target:  &c.FlagBodyContents,
+		Example: "${{ github.event.pull_request.body }}",
+		Usage:   "The string contents of the change request body.",
 	})
 }

--- a/pkg/modifiers/modifiers.go
+++ b/pkg/modifiers/modifiers.go
@@ -1,0 +1,49 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package modifiers provides the functionality to parse meta modifiers from text.
+package modifiers
+
+import (
+	"context"
+	"regexp"
+)
+
+const (
+	MetaKeyGuardianDestroy = "GUARDIAN_DESTROY"
+)
+
+var (
+	// newline is a regexp to split strings at line breaks.
+	newline = regexp.MustCompile("\r?\n")
+
+	// metaValuesKVRegex is a regex to split key value pairs for comment modifiers.
+	metaValuesKVRegex = regexp.MustCompile(`^(GUARDIAN_[A-Z0-9_]+)=(.*)$`)
+)
+
+type MetaValues map[string][]string
+
+func ParseBodyMetaValues(ctx context.Context, contents string) MetaValues {
+	metaValues := make(MetaValues, 0)
+
+	for _, line := range newline.Split(contents, -1) {
+		match := metaValuesKVRegex.FindStringSubmatch(line)
+		if len(match) == 3 {
+			metaKey := match[1]
+			metaValue := match[2]
+			metaValues[metaKey] = append(metaValues[metaKey], metaValue)
+		}
+	}
+	return metaValues
+}

--- a/pkg/modifiers/modifiers_test.go
+++ b/pkg/modifiers/modifiers_test.go
@@ -1,0 +1,86 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modifiers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseMetaValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		contents string
+		exp      MetaValues
+	}{
+		{
+			name:     "success",
+			contents: "GUARDIAN_DESTROY=test-destroy",
+			exp: MetaValues{
+				"GUARDIAN_DESTROY": []string{"test-destroy"},
+			},
+		},
+		{
+			name: "success_multiple",
+			contents: `GUARDIAN_DESTROY=test-destroy1
+GUARDIAN_DESTROY=test-destroy2
+GUARDIAN_DESTROY=test-destroy3`,
+			exp: MetaValues{
+				"GUARDIAN_DESTROY": []string{
+					"test-destroy1",
+					"test-destroy2",
+					"test-destroy3",
+				},
+			},
+		},
+		{
+			name: "success_mixed",
+			contents: `this is a body of text
+GUARDIAN_VALUE=test-value1
+that contains
+GUARDIAN_VALUE=test-value2
+no kv pairs
+`,
+			exp: MetaValues{
+				"GUARDIAN_VALUE": []string{"test-value1", "test-value2"},
+			},
+		},
+		{
+			name: "no_modifiers",
+			contents: `this is a body of text
+that contains
+no kv pairs
+`,
+			exp: MetaValues{},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := ParseBodyMetaValues(context.Background(), tc.contents)
+			if diff := cmp.Diff(m, tc.exp); diff != "" {
+				t.Errorf("response not as expected; (-got,+want): %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/terraform/testdata/with-modules/modules/module-a/main.tf
+++ b/pkg/terraform/testdata/with-modules/modules/module-a/main.tf
@@ -1,0 +1,14 @@
+# Copyright 2024 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/pkg/terraform/testdata/with-modules/modules/module-b-using-a/main.tf
+++ b/pkg/terraform/testdata/with-modules/modules/module-b-using-a/main.tf
@@ -1,3 +1,17 @@
+# Copyright 2024 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module "b" {
   source = "../module-a"
 }

--- a/terraform/project1/main.tf
+++ b/terraform/project1/main.tf
@@ -1,3 +1,17 @@
+# Copyright 2024 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   backend "local" {}
 }

--- a/terraform/project2/main.tf
+++ b/terraform/project2/main.tf
@@ -1,3 +1,17 @@
+# Copyright 2024 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   backend "local" {}
 }


### PR DESCRIPTION
Adding the ability to detect removed directories and if a user supplied meta comment of `GUARDIAN_DESTROY=terraform/backends/project1` exists, the supplied directory will be planned and applied as a destroy instead.

This functionality only cover the `entrypoints` command to identify the appropriate directories. The output of this command is a breaking change, as the JSON output has additional fields to support the modified and destroyed directories.

The follow up to this will be to implement the functionality in the plan and apply commands to us the destroy flag.

NOTE: Some of the test data files just had a license header added and can be ignored.

GUARDIAN_DESTROY=terraform/project2