### PR TITLE
Link directly to logs for job in Guardian github comments

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -175,7 +175,7 @@ jobs:
           DIRECTORY: '${{ matrix.working_directory }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
-          JOB_NAME: '${ github.job } (${{ matrix.working_directory }})'
+          JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
         run: |-
           guardian plan \
           -github-owner="${GITHUB_OWNER_NAME}" \
@@ -281,7 +281,7 @@ jobs:
           COMMIT_SHA: '${{ github.sha }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
-          JOB_NAME: '${ github.job } (${{ matrix.working_directory }})'
+          JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
         run: |-
           guardian apply \
           -github-owner="${GITHUB_OWNER_NAME}" \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -175,6 +175,7 @@ jobs:
           DIRECTORY: '${{ matrix.working_directory }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
+          JOB_NAME: '${ github.job } (${{ matrix.working_directory }})'
         run: |-
           guardian plan \
           -github-owner="${GITHUB_OWNER_NAME}" \
@@ -182,7 +183,8 @@ jobs:
           -github-token="${REPO_TOKEN}" \
           -pull-request-number="${PULL_REQUEST_NUMBER}" \
           -bucket-name="${GUARDIAN_BUCKET_NAME}" \
-          -dir="${DIRECTORY}"
+          -dir="${DIRECTORY}" \
+          -job-name="${JOB_NAME}"
 
   plan_success:
     needs:
@@ -279,6 +281,7 @@ jobs:
           COMMIT_SHA: '${{ github.sha }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
+          JOB_NAME: '${ github.job } (${{ matrix.working_directory }})'
         run: |-
           guardian apply \
           -github-owner="${GITHUB_OWNER_NAME}" \
@@ -286,7 +289,8 @@ jobs:
           -github-token="${REPO_TOKEN}" \
           -pull-request-number="${PULL_REQUEST_NUMBER}" \
           -bucket-name="${GUARDIAN_BUCKET_NAME}" \
-          -dir="${DIRECTORY}"
+          -dir="${DIRECTORY}" \
+          -job-name="${JOB_NAME}"
 
       - name: 'Guardian Destroy'
         env:

--- a/abc.templates/base-workflows/contents/guardian-apply.yml
+++ b/abc.templates/base-workflows/contents/guardian-apply.yml
@@ -119,7 +119,7 @@ jobs:
           COMMIT_SHA: '${{ github.sha }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
-          JOB_NAME: '${ github.job } (${{ matrix.working_directory }})'
+          JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
         run: |-
           guardian apply \
           -dir="${DIRECTORY}" \

--- a/abc.templates/base-workflows/contents/guardian-apply.yml
+++ b/abc.templates/base-workflows/contents/guardian-apply.yml
@@ -119,6 +119,7 @@ jobs:
           COMMIT_SHA: '${{ github.sha }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
+          JOB_NAME: '${ github.job } (${{ matrix.working_directory }})'
         run: |-
           guardian apply \
           -dir="${DIRECTORY}" \
@@ -126,4 +127,5 @@ jobs:
           -github-repo="${GITHUB_REPO_NAME}" \
           -github-token="${REPO_TOKEN}" \
           -commit-sha="${COMMIT_SHA}" \
-          -bucket-name="${GUARDIAN_BUCKET_NAME}"
+          -bucket-name="${GUARDIAN_BUCKET_NAME}" \
+          -job-name="${JOB_NAME}"

--- a/abc.templates/base-workflows/contents/guardian-plan.yml
+++ b/abc.templates/base-workflows/contents/guardian-plan.yml
@@ -143,7 +143,7 @@ jobs:
           DIRECTORY: '${{ matrix.working_directory }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
-          JOB_NAME: '${ github.job } (${{ matrix.working_directory }})'
+          JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
         run: |-
           guardian plan \
           -dir="${DIRECTORY}" \

--- a/abc.templates/base-workflows/contents/guardian-plan.yml
+++ b/abc.templates/base-workflows/contents/guardian-plan.yml
@@ -143,6 +143,7 @@ jobs:
           DIRECTORY: '${{ matrix.working_directory }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
+          JOB_NAME: '${ github.job } (${{ matrix.working_directory }})'
         run: |-
           guardian plan \
           -dir="${DIRECTORY}" \
@@ -150,7 +151,8 @@ jobs:
           -github-repo="${GITHUB_REPO_NAME}" \
           -github-token="${REPO_TOKEN}" \
           -pull-request-number="${PULL_REQUEST_NUMBER}" \
-          -bucket-name="${GUARDIAN_BUCKET_NAME}"
+          -bucket-name="${GUARDIAN_BUCKET_NAME}" \
+          -job-name="${JOB_NAME}"
 
   plan_success:
     if: '${{ always() }}'

--- a/pkg/commands/apply/apply.go
+++ b/pkg/commands/apply/apply.go
@@ -69,6 +69,7 @@ type ApplyCommand struct {
 	flags.GitHubFlags
 
 	flagBucketName           string
+	flagJobName              string
 	flagCommitSHA            string
 	flagPullRequestNumber    int
 	flagAllowLockfileChanges bool
@@ -123,6 +124,13 @@ func (c *ApplyCommand) Flags() *cli.FlagSet {
 		Target:  &c.flagBucketName,
 		Example: "my-guardian-state-bucket",
 		Usage:   "The Google Cloud Storage bucket name to store Guardian plan files.",
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "job-name",
+		Target:  &c.flagJobName,
+		Example: "apply (terraform/project1)",
+		Usage:   "The Github Actions job name, used to generate the correct logs URL in PR comments.",
 	})
 
 	f.BoolVar(&cli.BoolVar{
@@ -258,7 +266,7 @@ func (c *ApplyCommand) Process(ctx context.Context) (merr error) {
 	}
 	logger.DebugContext(ctx, "computed pull request number", "computed_pull_request_number", c.computedPullRequestNumber)
 
-	c.gitHubLogURL = fmt.Sprintf("[[logs](%s/%s/%s/actions/runs/%d/attempts/%d)]", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, c.cfg.RunAttempt)
+	c.gitHubLogURL = c.resolveGitHubLogURL(ctx)
 	logger.DebugContext(ctx, "computed github log url", "github_log_url", c.gitHubLogURL)
 
 	planBucketPath := path.Join(c.childPath, c.planFileName)
@@ -317,6 +325,32 @@ func (c *ApplyCommand) Process(ctx context.Context) (merr error) {
 	}
 
 	return merr
+}
+
+func (c *ApplyCommand) resolveGitHubLogURL(ctx context.Context) string {
+	logger := logging.FromContext(ctx)
+
+	// Default to action summary page
+	logURL := fmt.Sprintf("[[logs](%s/%s/%s/actions/runs/%d/attempts/%d)]", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, c.cfg.RunAttempt)
+
+	if !c.FlagIsGitHubActions {
+		logger.DebugContext(ctx, "skipping github log url resolution", "is_github_action", c.FlagIsGitHubActions)
+		return logURL
+	}
+
+	// Link to specific job's logs directly if possible
+	jobs, err := c.gitHubClient.ListJobsForWorkflowRun(ctx, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, nil)
+	if err != nil {
+		logger.DebugContext(ctx, "failed to list jobs for workflow run", "err", err)
+	} else {
+		for _, job := range jobs.Jobs {
+			if c.flagJobName == job.Name {
+				logURL = fmt.Sprintf("[[logs](%s/%s/%s/actions/runs/%d/job/%d)]", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, job.ID)
+			}
+		}
+	}
+
+	return logURL
 }
 
 func (c *ApplyCommand) createStartCommentForActions(ctx context.Context) (*github.IssueComment, error) {

--- a/pkg/commands/apply/apply_test.go
+++ b/pkg/commands/apply/apply_test.go
@@ -88,6 +88,7 @@ func TestApply_Process(t *testing.T) {
 		flagBucketName           string
 		flagAllowLockfileChanges bool
 		flagLockTimeout          time.Duration
+		flagJobName              string
 		config                   *Config
 		planExitCode             string
 		terraformClient          *terraform.MockTerraformClient
@@ -116,12 +117,72 @@ func TestApply_Process(t *testing.T) {
 					Params: []any{"owner", "repo", "commit-sha-1"},
 				},
 				{
+					Name:   "ListJobsForWorkflowRun",
+					Params: []any{"owner", "repo", int64(100)},
+				},
+				{
 					Name:   "CreateIssueComment",
 					Params: []any{"owner", "repo", int(1), "**`🔱 Guardian 🔱 APPLY`** - 🟨 Running for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
 				},
 				{
 					Name:   "UpdateIssueComment",
 					Params: []any{"owner", "repo", int64(1), "**`🔱 Guardian 🔱 APPLY`** - 🟩 Successful for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform apply success\n```\n</details>"},
+				},
+			},
+			expStorageClientReqs: []*storage.Request{
+				{
+					Name: "ObjectMetadata",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
+					},
+				},
+				{
+					Name: "DownloadObject",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
+					},
+				},
+				{
+					Name: "DeleteObject",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
+					},
+				},
+			},
+		},
+		{
+			name:                     "success_with_direct_log_url",
+			directory:                "testdir",
+			flagIsGitHubActions:      true,
+			flagGitHubOwner:          "owner",
+			flagGitHubRepo:           "repo",
+			flagCommitSHA:            "commit-sha-1",
+			flagBucketName:           "my-bucket-name",
+			flagAllowLockfileChanges: true,
+			flagLockTimeout:          10 * time.Minute,
+			flagJobName:              "example-job",
+			config:                   defaultConfig,
+			planExitCode:             "2",
+			terraformClient:          terraformMock,
+			expGitHubClientReqs: []*github.Request{
+				{
+					Name:   "ListPullRequestsForCommit",
+					Params: []any{"owner", "repo", "commit-sha-1"},
+				},
+				{
+					Name:   "ListJobsForWorkflowRun",
+					Params: []any{"owner", "repo", int64(100)},
+				},
+				{
+					Name:   "CreateIssueComment",
+					Params: []any{"owner", "repo", int(1), "**`🔱 Guardian 🔱 APPLY`** - 🟨 Running for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]"},
+				},
+				{
+					Name:   "UpdateIssueComment",
+					Params: []any{"owner", "repo", int64(1), "**`🔱 Guardian 🔱 APPLY`** - 🟩 Successful for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform apply success\n```\n</details>"},
 				},
 			},
 			expStorageClientReqs: []*storage.Request{
@@ -204,6 +265,10 @@ func TestApply_Process(t *testing.T) {
 			err:                      "failed to run Guardian apply: failed to apply: failed to run terraform apply",
 			expGitHubClientReqs: []*github.Request{
 				{
+					Name:   "ListJobsForWorkflowRun",
+					Params: []any{"owner", "repo", int64(100)},
+				},
+				{
 					Name:   "CreateIssueComment",
 					Params: []any{"owner", "repo", int(3), "**`🔱 Guardian 🔱 APPLY`** - 🟨 Running for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
 				},
@@ -272,6 +337,7 @@ func TestApply_Process(t *testing.T) {
 				flagBucketName:           tc.flagBucketName,
 				flagAllowLockfileChanges: tc.flagAllowLockfileChanges,
 				flagLockTimeout:          tc.flagLockTimeout,
+				flagJobName:              tc.flagJobName,
 				gitHubClient:             gitHubClient,
 				storageClient:            storageClient,
 				terraformClient:          tc.terraformClient,

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -81,6 +81,16 @@ type PullRequestResponse struct {
 	Pagination   *Pagination
 }
 
+type Job struct {
+	ID   int64
+	Name string
+}
+
+type JobsResponse struct {
+	Jobs       []*Job
+	Pagination *Pagination
+}
+
 const (
 	Closed = "closed"
 	Open   = "open"
@@ -119,6 +129,9 @@ type GitHub interface {
 	// RepoUserPermissionLevel gets the repository permission level for a user. The possible permissions values
 	// are admin, write, read, none.
 	RepoUserPermissionLevel(ctx context.Context, owner, repo, user string) (string, error)
+
+	// ListJobsForWorkflowRun lists the jobs for a specific workflow run attempt.
+	ListJobsForWorkflowRun(ctx context.Context, owner, repo string, runId int64, opts *github.ListWorkflowJobsOptions) (*JobsResponse, error)
 }
 
 var _ GitHub = (*GitHubClient)(nil)
@@ -474,6 +487,37 @@ func (g *GitHubClient) RepoUserPermissionLevel(ctx context.Context, owner, repo,
 	}
 
 	return permissionLevel, nil
+}
+
+func (g *GitHubClient) ListJobsForWorkflowRun(ctx context.Context, owner, repo string, runId int64, opts *github.ListWorkflowJobsOptions) (*JobsResponse, error) {
+	var jobs []*Job
+	var pagination *Pagination
+
+	if err := g.withRetries(ctx, func(ctx context.Context) error {
+		ghJobs, resp, err := g.client.Actions.ListWorkflowJobs(ctx, owner, repo, runId, opts)
+		if err != nil {
+			if resp != nil {
+				if _, ok := ignoredStatusCodes[resp.StatusCode]; !ok {
+					return retry.RetryableError(err)
+				}
+			}
+			return fmt.Errorf("failed to list jobs for workflow run attempt: %w", err)
+		}
+
+		for _, workflowJob := range ghJobs.Jobs {
+			jobs = append(jobs, &Job{ID: workflowJob.GetID(), Name: workflowJob.GetName()})
+		}
+
+		if resp.NextPage != 0 {
+			pagination = &Pagination{NextPage: resp.NextPage}
+		}
+
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list jobs for workflow run attempt: %w", err)
+	}
+
+	return &JobsResponse{Jobs: jobs, Pagination: pagination}, nil
 }
 
 func (g *GitHubClient) withRetries(ctx context.Context, retryFunc retry.RetryFunc) error {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -131,7 +131,7 @@ type GitHub interface {
 	RepoUserPermissionLevel(ctx context.Context, owner, repo, user string) (string, error)
 
 	// ListJobsForWorkflowRun lists the jobs for a specific workflow run attempt.
-	ListJobsForWorkflowRun(ctx context.Context, owner, repo string, runId int64, opts *github.ListWorkflowJobsOptions) (*JobsResponse, error)
+	ListJobsForWorkflowRun(ctx context.Context, owner, repo string, runID int64, opts *github.ListWorkflowJobsOptions) (*JobsResponse, error)
 }
 
 var _ GitHub = (*GitHubClient)(nil)
@@ -489,12 +489,12 @@ func (g *GitHubClient) RepoUserPermissionLevel(ctx context.Context, owner, repo,
 	return permissionLevel, nil
 }
 
-func (g *GitHubClient) ListJobsForWorkflowRun(ctx context.Context, owner, repo string, runId int64, opts *github.ListWorkflowJobsOptions) (*JobsResponse, error) {
+func (g *GitHubClient) ListJobsForWorkflowRun(ctx context.Context, owner, repo string, runID int64, opts *github.ListWorkflowJobsOptions) (*JobsResponse, error) {
 	var jobs []*Job
 	var pagination *Pagination
 
 	if err := g.withRetries(ctx, func(ctx context.Context) error {
-		ghJobs, resp, err := g.client.Actions.ListWorkflowJobs(ctx, owner, repo, runId, opts)
+		ghJobs, resp, err := g.client.Actions.ListWorkflowJobs(ctx, owner, repo, runID, opts)
 		if err != nil {
 			if resp != nil {
 				if _, ok := ignoredStatusCodes[resp.StatusCode]; !ok {

--- a/pkg/github/github_mock.go
+++ b/pkg/github/github_mock.go
@@ -203,12 +203,12 @@ func (m *MockGitHubClient) RepoUserPermissionLevel(ctx context.Context, owner, r
 	return m.RepoPermissionLevel, nil
 }
 
-func (m *MockGitHubClient) ListJobsForWorkflowRun(ctx context.Context, owner, repo string, runId int64, opts *github.ListWorkflowJobsOptions) (*JobsResponse, error) {
+func (m *MockGitHubClient) ListJobsForWorkflowRun(ctx context.Context, owner, repo string, runID int64, opts *github.ListWorkflowJobsOptions) (*JobsResponse, error) {
 	m.reqMu.Lock()
 	defer m.reqMu.Unlock()
 	m.Reqs = append(m.Reqs, &Request{
 		Name:   "ListJobsForWorkflowRun",
-		Params: []any{owner, repo, runId},
+		Params: []any{owner, repo, runID},
 	})
 
 	if m.ListJobsForWorkflowRunErr != nil {

--- a/pkg/github/github_mock.go
+++ b/pkg/github/github_mock.go
@@ -44,6 +44,7 @@ type MockGitHubClient struct {
 	ListPullRequestsForCommitErr error
 	RepoPermissionLevelErr       error
 	RepoPermissionLevel          string
+	ListJobsForWorkflowRunErr    error
 }
 
 func (m *MockGitHubClient) ListRepositories(ctx context.Context, owner string, opts *github.RepositoryListByOrgOptions) ([]*Repository, error) {
@@ -200,4 +201,23 @@ func (m *MockGitHubClient) RepoUserPermissionLevel(ctx context.Context, owner, r
 	}
 
 	return m.RepoPermissionLevel, nil
+}
+
+func (m *MockGitHubClient) ListJobsForWorkflowRun(ctx context.Context, owner, repo string, runId int64, opts *github.ListWorkflowJobsOptions) (*JobsResponse, error) {
+	m.reqMu.Lock()
+	defer m.reqMu.Unlock()
+	m.Reqs = append(m.Reqs, &Request{
+		Name:   "ListJobsForWorkflowRun",
+		Params: []any{owner, repo, runId},
+	})
+
+	if m.ListJobsForWorkflowRunErr != nil {
+		return nil, m.ListJobsForWorkflowRunErr
+	}
+
+	return &JobsResponse{
+		Jobs: []*Job{
+			{ID: 1, Name: "example-job"},
+		},
+	}, nil
 }


### PR DESCRIPTION
Context: https://github.com/abcxyz/guardian/issues/179

Make Guardian github comment log links go directly to the logs for the relevant job instead of to the summary page.