### PR TITLE
Link directly to logs for job in Guardian github comments

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -124,6 +124,7 @@ jobs:
             -for-command="apply"
 
   plan:
+    name: 'plan (${{ matrix.working_directory }})'
     needs:
       - 'init'
     runs-on: 'ubuntu-latest'
@@ -229,6 +230,7 @@ jobs:
           -plan-result="${{ needs.plan.result }}"
 
   apply:
+    name: 'apply (${{ matrix.working_directory }})'
     needs:
       - 'init'
       - 'plan'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -176,6 +176,7 @@ jobs:
           DIRECTORY: '${{ matrix.working_directory }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
+          JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
         run: |-
           guardian plan \
           -github-owner="${GITHUB_OWNER_NAME}" \
@@ -183,7 +184,8 @@ jobs:
           -github-token="${REPO_TOKEN}" \
           -pull-request-number="${PULL_REQUEST_NUMBER}" \
           -bucket-name="${GUARDIAN_BUCKET_NAME}" \
-          -dir="${DIRECTORY}"
+          -dir="${DIRECTORY}" \
+          -job-name="${JOB_NAME}"
 
   plan_success:
     needs:
@@ -280,6 +282,7 @@ jobs:
           COMMIT_SHA: '${{ github.sha }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
+          JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
         run: |-
           guardian apply \
           -github-owner="${GITHUB_OWNER_NAME}" \
@@ -287,7 +290,8 @@ jobs:
           -github-token="${REPO_TOKEN}" \
           -pull-request-number="${PULL_REQUEST_NUMBER}" \
           -bucket-name="${GUARDIAN_BUCKET_NAME}" \
-          -dir="${DIRECTORY}"
+          -dir="${DIRECTORY}" \
+          -job-name="${JOB_NAME}"
 
       - name: 'Guardian Destroy'
         env:

--- a/abc.templates/base-workflows/contents/guardian-apply.yml
+++ b/abc.templates/base-workflows/contents/guardian-apply.yml
@@ -68,6 +68,7 @@ jobs:
           echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
 
   apply:
+    name: 'apply (${{ matrix.working_directory }})'
     if: |
       needs.init.outputs.directories != '[]'
     needs:

--- a/abc.templates/base-workflows/contents/guardian-apply.yml
+++ b/abc.templates/base-workflows/contents/guardian-apply.yml
@@ -119,6 +119,7 @@ jobs:
           COMMIT_SHA: '${{ github.sha }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
+          JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
         run: |-
           guardian apply \
           -dir="${DIRECTORY}" \
@@ -126,4 +127,5 @@ jobs:
           -github-repo="${GITHUB_REPO_NAME}" \
           -github-token="${REPO_TOKEN}" \
           -commit-sha="${COMMIT_SHA}" \
-          -bucket-name="${GUARDIAN_BUCKET_NAME}"
+          -bucket-name="${GUARDIAN_BUCKET_NAME}" \
+          -job-name="${JOB_NAME}"

--- a/abc.templates/base-workflows/contents/guardian-plan.yml
+++ b/abc.templates/base-workflows/contents/guardian-plan.yml
@@ -143,6 +143,7 @@ jobs:
           DIRECTORY: '${{ matrix.working_directory }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
+          JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
         run: |-
           guardian plan \
           -dir="${DIRECTORY}" \
@@ -150,7 +151,8 @@ jobs:
           -github-repo="${GITHUB_REPO_NAME}" \
           -github-token="${REPO_TOKEN}" \
           -pull-request-number="${PULL_REQUEST_NUMBER}" \
-          -bucket-name="${GUARDIAN_BUCKET_NAME}"
+          -bucket-name="${GUARDIAN_BUCKET_NAME}" \
+          -job-name="${JOB_NAME}"
 
   plan_success:
     if: '${{ always() }}'

--- a/abc.templates/base-workflows/contents/guardian-plan.yml
+++ b/abc.templates/base-workflows/contents/guardian-plan.yml
@@ -91,6 +91,7 @@ jobs:
             -for-command="plan"
 
   plan:
+    name: 'plan (${{ matrix.working_directory }})'
     if: |
       needs.init.outputs.directories != '[]'
     needs:

--- a/pkg/commands/apply/apply.go
+++ b/pkg/commands/apply/apply.go
@@ -69,6 +69,7 @@ type ApplyCommand struct {
 	flags.GitHubFlags
 
 	flagBucketName           string
+	flagJobName              string
 	flagCommitSHA            string
 	flagPullRequestNumber    int
 	flagAllowLockfileChanges bool
@@ -123,6 +124,13 @@ func (c *ApplyCommand) Flags() *cli.FlagSet {
 		Target:  &c.flagBucketName,
 		Example: "my-guardian-state-bucket",
 		Usage:   "The Google Cloud Storage bucket name to store Guardian plan files.",
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "job-name",
+		Target:  &c.flagJobName,
+		Example: "apply (terraform/project1)",
+		Usage:   "The Github Actions job name, used to generate the correct logs URL in PR comments.",
 	})
 
 	f.BoolVar(&cli.BoolVar{
@@ -258,7 +266,7 @@ func (c *ApplyCommand) Process(ctx context.Context) (merr error) {
 	}
 	logger.DebugContext(ctx, "computed pull request number", "computed_pull_request_number", c.computedPullRequestNumber)
 
-	c.gitHubLogURL = fmt.Sprintf("[[logs](%s/%s/%s/actions/runs/%d/attempts/%d)]", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, c.cfg.RunAttempt)
+	c.gitHubLogURL = c.resolveGitHubLogURL(ctx)
 	logger.DebugContext(ctx, "computed github log url", "github_log_url", c.gitHubLogURL)
 
 	planBucketPath := path.Join(c.childPath, c.planFileName)
@@ -317,6 +325,32 @@ func (c *ApplyCommand) Process(ctx context.Context) (merr error) {
 	}
 
 	return merr
+}
+
+func (c *ApplyCommand) resolveGitHubLogURL(ctx context.Context) string {
+	logger := logging.FromContext(ctx)
+
+	// Default to action summary page
+	logURL := fmt.Sprintf("[[logs](%s/%s/%s/actions/runs/%d/attempts/%d)]", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, c.cfg.RunAttempt)
+
+	if !c.FlagIsGitHubActions {
+		logger.DebugContext(ctx, "skipping github log url resolution", "is_github_action", c.FlagIsGitHubActions)
+		return logURL
+	}
+
+	// Link to specific job's logs directly if possible
+	jobs, err := c.gitHubClient.ListJobsForWorkflowRun(ctx, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, nil)
+	if err != nil {
+		logger.DebugContext(ctx, "failed to list jobs for workflow run", "err", err)
+	} else {
+		for _, job := range jobs.Jobs {
+			if c.flagJobName == job.Name {
+				logURL = fmt.Sprintf("[[logs](%s/%s/%s/actions/runs/%d/job/%d)]", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, job.ID)
+			}
+		}
+	}
+
+	return logURL
 }
 
 func (c *ApplyCommand) createStartCommentForActions(ctx context.Context) (*github.IssueComment, error) {

--- a/pkg/commands/apply/apply.go
+++ b/pkg/commands/apply/apply.go
@@ -339,7 +339,7 @@ func (c *ApplyCommand) resolveGitHubLogURL(ctx context.Context) string {
 	}
 
 	// Link to specific job's logs directly if possible
-	directJobURL, err := c.gitHubClient.ResolveJobLogsURL(ctx, c.flagJobName, c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID)
+	directJobURL, err := c.gitHubClient.ResolveJobLogsURL(ctx, c.flagJobName, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID)
 	if err != nil {
 		logger.DebugContext(ctx, "could not resolve direct url to job logs", "err", err)
 		return defaultLogURL

--- a/pkg/commands/apply/apply_test.go
+++ b/pkg/commands/apply/apply_test.go
@@ -88,6 +88,7 @@ func TestApply_Process(t *testing.T) {
 		flagBucketName           string
 		flagAllowLockfileChanges bool
 		flagLockTimeout          time.Duration
+		flagJobName              string
 		config                   *Config
 		planExitCode             string
 		terraformClient          *terraform.MockTerraformClient
@@ -116,12 +117,72 @@ func TestApply_Process(t *testing.T) {
 					Params: []any{"owner", "repo", "commit-sha-1"},
 				},
 				{
+					Name:   "ListJobsForWorkflowRun",
+					Params: []any{"owner", "repo", int64(100)},
+				},
+				{
 					Name:   "CreateIssueComment",
 					Params: []any{"owner", "repo", int(1), "**`🔱 Guardian 🔱 APPLY`** - 🟨 Running for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
 				},
 				{
 					Name:   "UpdateIssueComment",
 					Params: []any{"owner", "repo", int64(1), "**`🔱 Guardian 🔱 APPLY`** - 🟩 Successful for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform apply success\n```\n</details>"},
+				},
+			},
+			expStorageClientReqs: []*storage.Request{
+				{
+					Name: "ObjectMetadata",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
+					},
+				},
+				{
+					Name: "DownloadObject",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
+					},
+				},
+				{
+					Name: "DeleteObject",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
+					},
+				},
+			},
+		},
+		{
+			name:                     "success_with_direct_log_url",
+			directory:                "testdir",
+			flagIsGitHubActions:      true,
+			flagGitHubOwner:          "owner",
+			flagGitHubRepo:           "repo",
+			flagCommitSHA:            "commit-sha-1",
+			flagBucketName:           "my-bucket-name",
+			flagAllowLockfileChanges: true,
+			flagLockTimeout:          10 * time.Minute,
+			flagJobName:              "example-job",
+			config:                   defaultConfig,
+			planExitCode:             "2",
+			terraformClient:          terraformMock,
+			expGitHubClientReqs: []*github.Request{
+				{
+					Name:   "ListPullRequestsForCommit",
+					Params: []any{"owner", "repo", "commit-sha-1"},
+				},
+				{
+					Name:   "ListJobsForWorkflowRun",
+					Params: []any{"owner", "repo", int64(100)},
+				},
+				{
+					Name:   "CreateIssueComment",
+					Params: []any{"owner", "repo", int(1), "**`🔱 Guardian 🔱 APPLY`** - 🟨 Running for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]"},
+				},
+				{
+					Name:   "UpdateIssueComment",
+					Params: []any{"owner", "repo", int64(1), "**`🔱 Guardian 🔱 APPLY`** - 🟩 Successful for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform apply success\n```\n</details>"},
 				},
 			},
 			expStorageClientReqs: []*storage.Request{
@@ -204,6 +265,10 @@ func TestApply_Process(t *testing.T) {
 			err:                      "failed to run Guardian apply: failed to apply: failed to run terraform apply",
 			expGitHubClientReqs: []*github.Request{
 				{
+					Name:   "ListJobsForWorkflowRun",
+					Params: []any{"owner", "repo", int64(100)},
+				},
+				{
 					Name:   "CreateIssueComment",
 					Params: []any{"owner", "repo", int(3), "**`🔱 Guardian 🔱 APPLY`** - 🟨 Running for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
 				},
@@ -272,6 +337,7 @@ func TestApply_Process(t *testing.T) {
 				flagBucketName:           tc.flagBucketName,
 				flagAllowLockfileChanges: tc.flagAllowLockfileChanges,
 				flagLockTimeout:          tc.flagLockTimeout,
+				flagJobName:              tc.flagJobName,
 				gitHubClient:             gitHubClient,
 				storageClient:            storageClient,
 				terraformClient:          tc.terraformClient,

--- a/pkg/commands/apply/apply_test.go
+++ b/pkg/commands/apply/apply_test.go
@@ -120,7 +120,7 @@ func TestApply_Process(t *testing.T) {
 				},
 				{
 					Name:   "ResolveJobLogsURL",
-					Params: []any{"example-job", "https://github.com", "owner", "repo", int64(100)},
+					Params: []any{"example-job", "owner", "repo", int64(100)},
 				},
 				{
 					Name:   "CreateIssueComment",
@@ -177,7 +177,7 @@ func TestApply_Process(t *testing.T) {
 				},
 				{
 					Name:   "ResolveJobLogsURL",
-					Params: []any{"example-job", "https://github.com", "owner", "repo", int64(100)},
+					Params: []any{"example-job", "owner", "repo", int64(100)},
 				},
 				{
 					Name:   "CreateIssueComment",
@@ -271,7 +271,7 @@ func TestApply_Process(t *testing.T) {
 			expGitHubClientReqs: []*github.Request{
 				{
 					Name:   "ResolveJobLogsURL",
-					Params: []any{"example-job", "https://github.com", "owner", "repo", int64(100)},
+					Params: []any{"example-job", "owner", "repo", int64(100)},
 				},
 				{
 					Name:   "CreateIssueComment",

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -252,7 +252,7 @@ func (c *PlanCommand) Process(ctx context.Context) error {
 		c.planFilename = "tfplan.binary"
 	}
 
-	c.gitHubLogURL = c.resolveGitHubLogURL(ctx)
+	c.gitHubLogURL = fmt.Sprintf("[[logs](%s)]", c.resolveGitHubLogURL(ctx))
 	logger.DebugContext(ctx, "computed github log url", "github_log_url", c.gitHubLogURL)
 
 	startComment, err := c.createStartCommentForActions(ctx)
@@ -276,26 +276,21 @@ func (c *PlanCommand) resolveGitHubLogURL(ctx context.Context) string {
 	logger := logging.FromContext(ctx)
 
 	// Default to action summary page
-	logURL := fmt.Sprintf("[[logs](%s/%s/%s/actions/runs/%d/attempts/%d)]", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, c.cfg.RunAttempt)
+	defaultLogURL := fmt.Sprintf("%s/%s/%s/actions/runs/%d/attempts/%d", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, c.cfg.RunAttempt)
 
 	if !c.FlagIsGitHubActions {
 		logger.DebugContext(ctx, "skipping github log url resolution", "is_github_action", c.FlagIsGitHubActions)
-		return logURL
+		return defaultLogURL
 	}
 
 	// Link to specific job's logs directly if possible
-	jobs, err := c.gitHubClient.ListJobsForWorkflowRun(ctx, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, nil)
+	directJobURL, err := c.gitHubClient.ResolveJobLogsURL(ctx, c.flagJobName, c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID)
 	if err != nil {
-		logger.DebugContext(ctx, "failed to list jobs for workflow run", "err", err)
-	} else {
-		for _, job := range jobs.Jobs {
-			if c.flagJobName == job.Name {
-				logURL = fmt.Sprintf("[[logs](%s/%s/%s/actions/runs/%d/job/%d)]", c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID, job.ID)
-			}
-		}
+		logger.DebugContext(ctx, "could not resolve direct url to job logs", "err", err)
+		return defaultLogURL
 	}
 
-	return logURL
+	return directJobURL
 }
 
 func (c *PlanCommand) createStartCommentForActions(ctx context.Context) (*github.IssueComment, error) {

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -284,7 +284,7 @@ func (c *PlanCommand) resolveGitHubLogURL(ctx context.Context) string {
 	}
 
 	// Link to specific job's logs directly if possible
-	directJobURL, err := c.gitHubClient.ResolveJobLogsURL(ctx, c.flagJobName, c.cfg.ServerURL, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID)
+	directJobURL, err := c.gitHubClient.ResolveJobLogsURL(ctx, c.flagJobName, c.GitHubFlags.FlagGitHubOwner, c.GitHubFlags.FlagGitHubRepo, c.cfg.RunID)
 	if err != nil {
 		logger.DebugContext(ctx, "could not resolve direct url to job logs", "err", err)
 		return defaultLogURL

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -195,7 +195,7 @@ func TestPlan_Process(t *testing.T) {
 			expGitHubClientReqs: []*github.Request{
 				{
 					Name:   "ResolveJobLogsURL",
-					Params: []any{"example-job", "https://github.com", "owner", "repo", int64(100)},
+					Params: []any{"example-job", "owner", "repo", int64(100)},
 				},
 				{
 					Name:   "CreateIssueComment",
@@ -233,7 +233,7 @@ func TestPlan_Process(t *testing.T) {
 			expGitHubClientReqs: []*github.Request{
 				{
 					Name:   "ResolveJobLogsURL",
-					Params: []any{"example-job", "https://github.com", "owner", "repo", int64(100)},
+					Params: []any{"example-job", "owner", "repo", int64(100)},
 				},
 				{
 					Name:   "CreateIssueComment",
@@ -272,7 +272,7 @@ func TestPlan_Process(t *testing.T) {
 			expGitHubClientReqs: []*github.Request{
 				{
 					Name:   "ResolveJobLogsURL",
-					Params: []any{"example-job", "https://github.com", "owner", "repo", int64(100)},
+					Params: []any{"example-job", "owner", "repo", int64(100)},
 				},
 				{
 					Name:   "CreateIssueComment",
@@ -337,7 +337,7 @@ func TestPlan_Process(t *testing.T) {
 			expGitHubClientReqs: []*github.Request{
 				{
 					Name:   "ResolveJobLogsURL",
-					Params: []any{"example-job", "https://github.com", "owner", "repo", int64(100)},
+					Params: []any{"example-job", "owner", "repo", int64(100)},
 				},
 				{
 					Name:   "CreateIssueComment",

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -88,7 +88,7 @@ type Job struct {
 	URL  string
 }
 
-// JobsResponse holds a paginated list of Jobs
+// JobsResponse holds a paginated list of Jobs.
 type JobsResponse struct {
 	Jobs       []*Job
 	Pagination *Pagination

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -81,12 +81,14 @@ type PullRequestResponse struct {
 	Pagination   *Pagination
 }
 
+// Job is the GitHub Job that runs as part of a workflow.
 type Job struct {
 	ID   int64
 	Name string
 	URL  string
 }
 
+// JobsResponse holds a paginated list of Jobs
 type JobsResponse struct {
 	Jobs       []*Job
 	Pagination *Pagination

--- a/pkg/github/github_mock.go
+++ b/pkg/github/github_mock.go
@@ -44,6 +44,7 @@ type MockGitHubClient struct {
 	ListPullRequestsForCommitErr error
 	RepoPermissionLevelErr       error
 	RepoPermissionLevel          string
+	ListJobsForWorkflowRunErr    error
 }
 
 func (m *MockGitHubClient) ListRepositories(ctx context.Context, owner string, opts *github.RepositoryListByOrgOptions) ([]*Repository, error) {
@@ -200,4 +201,23 @@ func (m *MockGitHubClient) RepoUserPermissionLevel(ctx context.Context, owner, r
 	}
 
 	return m.RepoPermissionLevel, nil
+}
+
+func (m *MockGitHubClient) ListJobsForWorkflowRun(ctx context.Context, owner, repo string, runID int64, opts *github.ListWorkflowJobsOptions) (*JobsResponse, error) {
+	m.reqMu.Lock()
+	defer m.reqMu.Unlock()
+	m.Reqs = append(m.Reqs, &Request{
+		Name:   "ListJobsForWorkflowRun",
+		Params: []any{owner, repo, runID},
+	})
+
+	if m.ListJobsForWorkflowRunErr != nil {
+		return nil, m.ListJobsForWorkflowRunErr
+	}
+
+	return &JobsResponse{
+		Jobs: []*Job{
+			{ID: 1, Name: "example-job"},
+		},
+	}, nil
 }

--- a/pkg/github/github_mock.go
+++ b/pkg/github/github_mock.go
@@ -224,17 +224,17 @@ func (m *MockGitHubClient) ListJobsForWorkflowRun(ctx context.Context, owner, re
 	}, nil
 }
 
-func (m *MockGitHubClient) ResolveJobLogsURL(ctx context.Context, jobName, serverURL, owner, repo string, runID int64) (string, error) {
+func (m *MockGitHubClient) ResolveJobLogsURL(ctx context.Context, jobName, owner, repo string, runID int64) (string, error) {
 	m.reqMu.Lock()
 	defer m.reqMu.Unlock()
 	m.Reqs = append(m.Reqs, &Request{
 		Name:   "ResolveJobLogsURL",
-		Params: []any{jobName, serverURL, owner, repo, runID},
+		Params: []any{jobName, owner, repo, runID},
 	})
 
 	if m.ResolveJobLogsURLErr != nil {
 		return "", m.ResolveJobLogsURLErr
 	}
 
-	return fmt.Sprintf("%s/%s/%s/actions/runs/%d/job/%d", serverURL, owner, repo, runID, 1), nil
+	return fmt.Sprintf("https://github.com/%s/%s/actions/runs/%d/job/%d", owner, repo, runID, 1), nil
 }

--- a/pkg/github/github_mock.go
+++ b/pkg/github/github_mock.go
@@ -16,6 +16,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/google/go-github/v53/github"
@@ -45,6 +46,7 @@ type MockGitHubClient struct {
 	RepoPermissionLevelErr       error
 	RepoPermissionLevel          string
 	ListJobsForWorkflowRunErr    error
+	ResolveJobLogsURLErr         error
 }
 
 func (m *MockGitHubClient) ListRepositories(ctx context.Context, owner string, opts *github.RepositoryListByOrgOptions) ([]*Repository, error) {
@@ -220,4 +222,19 @@ func (m *MockGitHubClient) ListJobsForWorkflowRun(ctx context.Context, owner, re
 			{ID: 1, Name: "example-job"},
 		},
 	}, nil
+}
+
+func (m *MockGitHubClient) ResolveJobLogsURL(ctx context.Context, jobName, serverURL, owner, repo string, runID int64) (string, error) {
+	m.reqMu.Lock()
+	defer m.reqMu.Unlock()
+	m.Reqs = append(m.Reqs, &Request{
+		Name:   "ResolveJobLogsURL",
+		Params: []any{jobName, serverURL, owner, repo, runID},
+	})
+
+	if m.ResolveJobLogsURLErr != nil {
+		return "", m.ResolveJobLogsURLErr
+	}
+
+	return fmt.Sprintf("%s/%s/%s/actions/runs/%d/job/%d", serverURL, owner, repo, runID, 1), nil
 }


### PR DESCRIPTION
Context: https://github.com/abcxyz/guardian/issues/179

Make Guardian github comment log links go directly to the logs for the relevant job instead of to the summary page when possible. 