### PR TITLE
feat: complete destroy

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -193,6 +193,7 @@ jobs:
           -job-name="${JOB_NAME}"
 
   plan_destroy:
+    name: 'plan_destroy (${{ matrix.working_directory }})'
     if: |
       needs.init.outputs.destroy != '[]'
     needs:
@@ -257,6 +258,7 @@ jobs:
           DIRECTORY: '${{ matrix.working_directory }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
+          JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
         run: |-
           guardian plan \
           -destroy \
@@ -265,7 +267,8 @@ jobs:
           -github-token="${REPO_TOKEN}" \
           -pull-request-number="${PULL_REQUEST_NUMBER}" \
           -bucket-name="${GUARDIAN_BUCKET_NAME}" \
-          -dir="${DIRECTORY}"
+          -dir="${DIRECTORY}" \
+          -job-name="${JOB_NAME}"
 
       # this is done only for integration testing since our tests do not have remote state.
       # we plan the destroy and apply the destroy in the same step.
@@ -276,6 +279,7 @@ jobs:
           COMMIT_SHA: '${{ github.sha }}'
           # used to create comments on pull requests (access to only this repo)
           REPO_TOKEN: '${{ github.token }}'
+          JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
         run: |-
           guardian apply \
           -github-owner="${GITHUB_OWNER_NAME}" \
@@ -283,7 +287,8 @@ jobs:
           -github-token="${REPO_TOKEN}" \
           -pull-request-number="${PULL_REQUEST_NUMBER}" \
           -bucket-name="${GUARDIAN_BUCKET_NAME}" \
-          -dir="${DIRECTORY}"
+          -dir="${DIRECTORY}" \
+          -job-name="${JOB_NAME}"
 
   plan_success:
     if: '${{ always() }}'
@@ -404,4 +409,3 @@ jobs:
           -- destroy \
           -input=false \
           -auto-approve
-          -dir="${DIRECTORY}"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,6 +31,7 @@ permissions:
 # only one plan, per pr should run at a time
 concurrency:
   group: '${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
 
 env:
   GITHUB_OWNER_NAME: '${{ github.event.repository.owner.login }}'
@@ -77,13 +78,13 @@ jobs:
       contents: 'read'
       pull-requests: 'write'
     outputs:
-      directories: '${{ steps.dirs.outputs.directories }}'
+      modified: '${{ steps.entrypoints.outputs.modified }}'
+      destroy: '${{ steps.entrypoints.outputs.destroy }}'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4
         with:
           fetch-depth: 0 # get everything so we can use git diff
-          ref: '${{ github.event.pull_request.head.sha }}'
 
       - name: 'Download Guardian'
         uses: 'actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e' # ratchet:actions/download-artifact@v4
@@ -99,15 +100,18 @@ jobs:
           echo "${INSTALL_PATH}" >> $GITHUB_PATH
 
       - name: 'Guardian Directories'
-        id: 'dirs'
+        id: 'entrypoints'
         shell: 'bash'
         env:
           SOURCE_REF: '${{ github.event.pull_request.base.sha }}'
           DEST_REF: '${{ github.event.pull_request.head.sha }}'
         run: |-
-          DIRECTORIES=$(guardian entrypoints -dir=./terraform)
-          echo "entrypoints -> ${DIRECTORIES}"
-          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+          ENTRYPOINTS=$(guardian entrypoints -dir=./terraform -body-contents="GUARDIAN_DESTROY=terraform/project2")
+          echo "entrypoints -> ${ENTRYPOINTS}"
+
+          # parse the json response and create outputs for each type of directory
+          echo "modified=$(echo $ENTRYPOINTS | jq -j -c '.modified')" >> $GITHUB_OUTPUT
+          echo "destroy=$(echo $ENTRYPOINTS | jq -j -c '.destroy')" >> $GITHUB_OUTPUT
 
       - name: 'Guardian Remove Previous Plan/Apply Comments'
         shell: 'bash'
@@ -125,6 +129,8 @@ jobs:
 
   plan:
     name: 'plan (${{ matrix.working_directory }})'
+    if: |
+      needs.init.outputs.modified != '[]'
     needs:
       - 'init'
     runs-on: 'ubuntu-latest'
@@ -136,12 +142,10 @@ jobs:
       fail-fast: false
       max-parallel: 100
       matrix:
-        working_directory: '${{ fromJSON(needs.init.outputs.directories).entrypoints }}'
+        working_directory: '${{ fromJSON(needs.init.outputs.modified) }}'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4
-        with:
-          ref: '${{ github.event.pull_request.head.sha }}'
 
       - name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa' # ratchet:google-github-actions/auth@v2
@@ -188,10 +192,105 @@ jobs:
           -dir="${DIRECTORY}" \
           -job-name="${JOB_NAME}"
 
+  plan_destroy:
+    if: |
+      needs.init.outputs.destroy != '[]'
+    needs:
+      - 'init'
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      pull-requests: 'write'
+    strategy:
+      fail-fast: false
+      max-parallel: 100
+      matrix:
+        working_directory: '${{ fromJSON(needs.init.outputs.destroy) }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4
+
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa' # ratchet:google-github-actions/auth@v2
+        with:
+          workload_identity_provider: '${{ env.GUARDIAN_WIF_PROVIDER }}'
+          service_account: '${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}'
+
+      - name: 'Setup Terraform'
+        uses: 'abcxyz/secure-setup-terraform@fa5832adc577578c1dfb422d13722bdeb711cf29' # ratchet:abcxyz/secure-setup-terraform@main
+        with:
+          terraform_version: '${{ env.GUARDIAN_TERRAFORM_VERSION }}'
+          terraform_module_location: './${{ matrix.working_directory }}'
+          terraform_lockfile_location: './${{ matrix.working_directory }}'
+          protect_lockfile: true
+          terraform_wrapper: false
+
+      - name: 'Download Guardian'
+        uses: 'actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e' # ratchet:actions/download-artifact@v4
+        with:
+          name: 'guardian'
+          path: '${{ runner.temp }}/.guardian'
+
+      - name: 'Setup Guardian'
+        env:
+          INSTALL_PATH: '${{ runner.temp }}/.guardian'
+        run: |-
+          chmod +x "${INSTALL_PATH}/guardian"
+          echo "${INSTALL_PATH}" >> $GITHUB_PATH
+
+      # Since our tests are stateless, we need an apply before a plan destroy
+      - name: 'Guardian Apply'
+        env:
+          DIRECTORY: '${{ matrix.working_directory }}'
+        shell: 'bash'
+        run: |-
+          guardian run \
+          -dir="${DIRECTORY}" \
+          -- apply \
+          -input=false \
+          -auto-approve
+
+      - name: 'Guardian Plan'
+        shell: 'bash'
+        env:
+          DIRECTORY: '${{ matrix.working_directory }}'
+          # used to create comments on pull requests (access to only this repo)
+          REPO_TOKEN: '${{ github.token }}'
+        run: |-
+          guardian plan \
+          -destroy \
+          -github-owner="${GITHUB_OWNER_NAME}" \
+          -github-repo="${GITHUB_REPO_NAME}" \
+          -github-token="${REPO_TOKEN}" \
+          -pull-request-number="${PULL_REQUEST_NUMBER}" \
+          -bucket-name="${GUARDIAN_BUCKET_NAME}" \
+          -dir="${DIRECTORY}"
+
+      # this is done only for integration testing since our tests do not have remote state.
+      # we plan the destroy and apply the destroy in the same step.
+      - name: 'Guardian Destroy'
+        shell: 'bash'
+        env:
+          DIRECTORY: '${{ matrix.working_directory }}'
+          COMMIT_SHA: '${{ github.sha }}'
+          # used to create comments on pull requests (access to only this repo)
+          REPO_TOKEN: '${{ github.token }}'
+        run: |-
+          guardian apply \
+          -github-owner="${GITHUB_OWNER_NAME}" \
+          -github-repo="${GITHUB_REPO_NAME}" \
+          -github-token="${REPO_TOKEN}" \
+          -pull-request-number="${PULL_REQUEST_NUMBER}" \
+          -bucket-name="${GUARDIAN_BUCKET_NAME}" \
+          -dir="${DIRECTORY}"
+
   plan_success:
+    if: '${{ always() }}'
     needs:
       - 'init'
       - 'plan'
+      - 'plan_destroy'
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'
@@ -199,8 +298,6 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4
-        with:
-          ref: '${{ github.event.pull_request.head.sha }}'
 
       - name: 'Download Guardian'
         uses: 'actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e' # ratchet:actions/download-artifact@v4
@@ -227,13 +324,15 @@ jobs:
           -github-token="${REPO_TOKEN}" \
           -pull-request-number="${PULL_REQUEST_NUMBER}" \
           -init-result="${{ needs.init.result }}" \
-          -plan-result="${{ needs.plan.result }}"
+          -plan-result="${{ needs.plan.result }}" \
+          -plan-result="${{ needs.plan_destroy.result }}"
 
   apply:
     name: 'apply (${{ matrix.working_directory }})'
+    if: |
+      needs.init.outputs.modified != '[]'
     needs:
       - 'init'
-      - 'plan'
       - 'plan_success'
     runs-on: 'ubuntu-latest'
     permissions:
@@ -244,7 +343,7 @@ jobs:
       fail-fast: false
       max-parallel: 100
       matrix:
-        working_directory: '${{ fromJSON(needs.init.outputs.directories).entrypoints }}'
+        working_directory: '${{ fromJSON(needs.init.outputs.modified) }}'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4
@@ -305,3 +404,4 @@ jobs:
           -- destroy \
           -input=false \
           -auto-approve
+          -dir="${DIRECTORY}"

--- a/pkg/commands/apply/apply_test.go
+++ b/pkg/commands/apply/apply_test.go
@@ -89,6 +89,7 @@ func TestApply_Process(t *testing.T) {
 		flagAllowLockfileChanges bool
 		flagLockTimeout          time.Duration
 		flagJobName              string
+		isDestroy                bool
 		config                   *Config
 		planExitCode             string
 		terraformClient          *terraform.MockTerraformClient
@@ -213,6 +214,58 @@ func TestApply_Process(t *testing.T) {
 			},
 		},
 		{
+			name:                     "success_destroy",
+			directory:                "testdir",
+			flagIsGitHubActions:      true,
+			flagGitHubOwner:          "owner",
+			flagGitHubRepo:           "repo",
+			flagCommitSHA:            "commit-sha-1",
+			flagBucketName:           "my-bucket-name",
+			flagAllowLockfileChanges: true,
+			flagLockTimeout:          10 * time.Minute,
+			isDestroy:                true,
+			config:                   defaultConfig,
+			planExitCode:             "2",
+			terraformClient:          terraformMock,
+			expGitHubClientReqs: []*github.Request{
+				{
+					Name:   "ListPullRequestsForCommit",
+					Params: []any{"owner", "repo", "commit-sha-1"},
+				},
+				{
+					Name:   "CreateIssueComment",
+					Params: []any{"owner", "repo", int(1), fmt.Sprintf("**`🔱 Guardian 🔱 APPLY`** - 🟨 Running for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]%s", DestroyCommentText)},
+				},
+				{
+					Name:   "UpdateIssueComment",
+					Params: []any{"owner", "repo", int64(1), fmt.Sprintf("**`🔱 Guardian 🔱 APPLY`** - 🟩 Successful for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]%s\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform apply success\n```\n</details>", DestroyCommentText)},
+				},
+			},
+			expStorageClientReqs: []*storage.Request{
+				{
+					Name: "ObjectMetadata",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
+					},
+				},
+				{
+					Name: "DownloadObject",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
+					},
+				},
+				{
+					Name: "DeleteObject",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
+					},
+				},
+			},
+		},
+		{
 			name:                     "skips_no_diff",
 			directory:                "testdir",
 			flagIsGitHubActions:      false,
@@ -306,6 +359,57 @@ func TestApply_Process(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                     "handles_error_destroy",
+			directory:                "testdir",
+			flagIsGitHubActions:      true,
+			flagGitHubOwner:          "owner",
+			flagGitHubRepo:           "repo",
+			flagPullRequestNumber:    3,
+			flagBucketName:           "my-bucket-name",
+			flagAllowLockfileChanges: true,
+			flagLockTimeout:          10 * time.Minute,
+			isDestroy:                true,
+			config:                   defaultConfig,
+			planExitCode:             "2",
+			terraformClient:          terraformErrorMock,
+			expStdout:                "terraform apply output",
+			expStderr:                "terraform apply failed",
+			err:                      "failed to run Guardian apply: failed to apply: failed to run terraform apply",
+			expGitHubClientReqs: []*github.Request{
+				{
+					Name:   "CreateIssueComment",
+					Params: []any{"owner", "repo", int(3), fmt.Sprintf("**`🔱 Guardian 🔱 APPLY`** - 🟨 Running for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]%s", DestroyCommentText)},
+				},
+				{
+					Name:   "UpdateIssueComment",
+					Params: []any{"owner", "repo", int64(1), fmt.Sprintf("**`🔱 Guardian 🔱 APPLY`** - 🟥 Failed for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]%s\n\n<details>\n<summary>Error</summary>\n\n```\n\nfailed to apply: failed to run terraform apply\n```\n</details>\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform apply failed\n```\n</details>", DestroyCommentText)},
+				},
+			},
+			expStorageClientReqs: []*storage.Request{
+				{
+					Name: "ObjectMetadata",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/3/testdir/test-tfplan.binary",
+					},
+				},
+				{
+					Name: "DownloadObject",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/3/testdir/test-tfplan.binary",
+					},
+				},
+				{
+					Name: "DeleteObject",
+					Params: []any{
+						"my-bucket-name",
+						"guardian-plans/owner/repo/3/testdir/test-tfplan.binary",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -345,6 +449,7 @@ func TestApply_Process(t *testing.T) {
 				flagAllowLockfileChanges: tc.flagAllowLockfileChanges,
 				flagLockTimeout:          tc.flagLockTimeout,
 				flagJobName:              tc.flagJobName,
+				isDestroy:                tc.isDestroy,
 				gitHubClient:             gitHubClient,
 				storageClient:            storageClient,
 				terraformClient:          tc.terraformClient,

--- a/pkg/commands/apply/apply_test.go
+++ b/pkg/commands/apply/apply_test.go
@@ -223,6 +223,7 @@ func TestApply_Process(t *testing.T) {
 			flagBucketName:           "my-bucket-name",
 			flagAllowLockfileChanges: true,
 			flagLockTimeout:          10 * time.Minute,
+			flagJobName:              "example-job",
 			isDestroy:                true,
 			config:                   defaultConfig,
 			planExitCode:             "2",
@@ -233,12 +234,16 @@ func TestApply_Process(t *testing.T) {
 					Params: []any{"owner", "repo", "commit-sha-1"},
 				},
 				{
+					Name:   "ResolveJobLogsURL",
+					Params: []any{"example-job", "owner", "repo", int64(100)},
+				},
+				{
 					Name:   "CreateIssueComment",
-					Params: []any{"owner", "repo", int(1), fmt.Sprintf("**`🔱 Guardian 🔱 APPLY`** - 🟨 Running for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]%s", DestroyCommentText)},
+					Params: []any{"owner", "repo", int(1), fmt.Sprintf("**`🔱 Guardian 🔱 APPLY`** - 🟨 Running for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]%s", DestroyCommentText)},
 				},
 				{
 					Name:   "UpdateIssueComment",
-					Params: []any{"owner", "repo", int64(1), fmt.Sprintf("**`🔱 Guardian 🔱 APPLY`** - 🟩 Successful for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]%s\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform apply success\n```\n</details>", DestroyCommentText)},
+					Params: []any{"owner", "repo", int64(1), fmt.Sprintf("**`🔱 Guardian 🔱 APPLY`** - 🟩 Successful for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]%s\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform apply success\n```\n</details>", DestroyCommentText)},
 				},
 			},
 			expStorageClientReqs: []*storage.Request{
@@ -369,6 +374,7 @@ func TestApply_Process(t *testing.T) {
 			flagBucketName:           "my-bucket-name",
 			flagAllowLockfileChanges: true,
 			flagLockTimeout:          10 * time.Minute,
+			flagJobName:              "example-job",
 			isDestroy:                true,
 			config:                   defaultConfig,
 			planExitCode:             "2",
@@ -378,12 +384,16 @@ func TestApply_Process(t *testing.T) {
 			err:                      "failed to run Guardian apply: failed to apply: failed to run terraform apply",
 			expGitHubClientReqs: []*github.Request{
 				{
+					Name:   "ResolveJobLogsURL",
+					Params: []any{"example-job", "owner", "repo", int64(100)},
+				},
+				{
 					Name:   "CreateIssueComment",
-					Params: []any{"owner", "repo", int(3), fmt.Sprintf("**`🔱 Guardian 🔱 APPLY`** - 🟨 Running for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]%s", DestroyCommentText)},
+					Params: []any{"owner", "repo", int(3), fmt.Sprintf("**`🔱 Guardian 🔱 APPLY`** - 🟨 Running for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]%s", DestroyCommentText)},
 				},
 				{
 					Name:   "UpdateIssueComment",
-					Params: []any{"owner", "repo", int64(1), fmt.Sprintf("**`🔱 Guardian 🔱 APPLY`** - 🟥 Failed for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]%s\n\n<details>\n<summary>Error</summary>\n\n```\n\nfailed to apply: failed to run terraform apply\n```\n</details>\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform apply failed\n```\n</details>", DestroyCommentText)},
+					Params: []any{"owner", "repo", int64(1), fmt.Sprintf("**`🔱 Guardian 🔱 APPLY`** - 🟥 Failed for dir: `testdir` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]%s\n\n<details>\n<summary>Error</summary>\n\n```\n\nfailed to apply: failed to run terraform apply\n```\n</details>\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform apply failed\n```\n</details>", DestroyCommentText)},
 				},
 			},
 			expStorageClientReqs: []*storage.Request{

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -199,11 +199,11 @@ func TestPlan_Process(t *testing.T) {
 				},
 				{
 					Name:   "CreateIssueComment",
-					Params: []any{"owner", "repo", int(1), "**`🔱 Guardian 🔱 PLAN`** - 🟨 Running for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]"},
+					Params: []any{"owner", "repo", int(1), CommentPrefix + " 🟨 Running for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]"},
 				},
 				{
 					Name:   "UpdateIssueComment",
-					Params: []any{"owner", "repo", int64(1), "**`🔱 Guardian 🔱 PLAN`** - 🟩 Successful for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform show success with diff\n```\n</details>"},
+					Params: []any{"owner", "repo", int64(1), CommentPrefix + " 🟩 Successful for dir: `testdata`  [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform show success with diff\n```\n</details>"},
 				},
 			},
 			expStorageClientReqs: []*storage.Request{
@@ -276,11 +276,11 @@ func TestPlan_Process(t *testing.T) {
 				},
 				{
 					Name:   "CreateIssueComment",
-					Params: []any{"owner", "repo", int(2), "**`🔱 Guardian 🔱 PLAN`** - 🟨 Running for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
+					Params: []any{"owner", "repo", int(2), CommentPrefix + " 🟨 Running for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
 				},
 				{
 					Name:   "UpdateIssueComment",
-					Params: []any{"owner", "repo", int64(1), "**`🔱 Guardian 🔱 PLAN`** - 🟦 No changes for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
+					Params: []any{"owner", "repo", int64(1), CommentPrefix + " 🟦 No changes for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
 				},
 			},
 			expStorageClientReqs: []*storage.Request{
@@ -341,7 +341,7 @@ func TestPlan_Process(t *testing.T) {
 				},
 				{
 					Name:   "CreateIssueComment",
-					Params: []any{"owner", "repo", int(3), "**`🔱 Guardian 🔱 PLAN`** - 🟨 Running for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]"},
+					Params: []any{"owner", "repo", int(3), CommentPrefix + " 🟨 Running for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]"},
 				},
 				{
 					Name: "UpdateIssueComment",
@@ -349,7 +349,7 @@ func TestPlan_Process(t *testing.T) {
 						"owner",
 						"repo",
 						int64(1),
-						"**`🔱 Guardian 🔱 PLAN`** - 🟥 Failed for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]\n" +
+						CommentPrefix + " 🟥 Failed for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]\n" +
 							"\n" +
 							"<details>\n" +
 							"<summary>Error</summary>\n" +
@@ -457,7 +457,7 @@ func TestGetMessageBody(t *testing.T) {
 				commentDetails: "This comment is within the limits",
 			},
 			resultErr: nil,
-			want:      "**`🔱 Guardian 🔱 PLAN`** - 🟩 Successful for dir: `foo` http://github.com/logs\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nThis comment is within the limits\n```\n</details>",
+			want:      CommentPrefix + " 🟩 Successful for dir: `foo` http://github.com/logs\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nThis comment is within the limits\n```\n</details>",
 		},
 		{
 			name: "result_error",
@@ -470,7 +470,7 @@ func TestGetMessageBody(t *testing.T) {
 				commentDetails: "This is a detailed error message",
 			},
 			resultErr: fmt.Errorf("the result had an error"),
-			want:      "**`🔱 Guardian 🔱 PLAN`** - 🟥 Failed for dir: `foo` http://github.com/logs\n\n<details>\n<summary>Error</summary>\n\n```\n\nthe result had an error\n```\n</details>\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nThis is a detailed error message\n```\n</details>",
+			want:      CommentPrefix + " 🟥 Failed for dir: `foo` http://github.com/logs\n\n<details>\n<summary>Error</summary>\n\n```\n\nthe result had an error\n```\n</details>\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nThis is a detailed error message\n```\n</details>",
 		},
 		{
 			name: "result_no_changes",
@@ -483,7 +483,50 @@ func TestGetMessageBody(t *testing.T) {
 				commentDetails: "",
 			},
 			resultErr: nil,
-			want:      "**`🔱 Guardian 🔱 PLAN`** - 🟦 No changes for dir: `foo` http://github.com/logs",
+			want:      CommentPrefix + " 🟦 No changes for dir: `foo` http://github.com/logs",
+		},
+
+		{
+			name: "result_success_destroy",
+			cmd: &PlanCommand{
+				flagDestroy:  true,
+				childPath:    "foo",
+				gitHubLogURL: "http://github.com/logs",
+			},
+			result: &RunResult{
+				hasChanges:     true,
+				commentDetails: "This comment is within the limits",
+			},
+			resultErr: nil,
+			want:      CommentPrefix + " 🟩 Successful for dir: `foo` http://github.com/logs" + DestroyCommentText + "\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nThis comment is within the limits\n```\n</details>",
+		},
+		{
+			name: "result_error_destroy",
+			cmd: &PlanCommand{
+				flagDestroy:  true,
+				childPath:    "foo",
+				gitHubLogURL: "http://github.com/logs",
+			},
+			result: &RunResult{
+				hasChanges:     true,
+				commentDetails: "This is a detailed error message",
+			},
+			resultErr: fmt.Errorf("the result had an error"),
+			want:      CommentPrefix + " 🟥 Failed for dir: `foo` http://github.com/logs" + DestroyCommentText + "\n\n<details>\n<summary>Error</summary>\n\n```\n\nthe result had an error\n```\n</details>\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nThis is a detailed error message\n```\n</details>",
+		},
+		{
+			name: "result_no_changes_destroy",
+			cmd: &PlanCommand{
+				flagDestroy:  true,
+				childPath:    "foo",
+				gitHubLogURL: "http://github.com/logs",
+			},
+			result: &RunResult{
+				hasChanges:     false,
+				commentDetails: "",
+			},
+			resultErr: nil,
+			want:      CommentPrefix + " 🟦 No changes for dir: `foo` http://github.com/logs" + DestroyCommentText,
 		},
 		{
 			name: "result_success_over_limit",
@@ -496,7 +539,7 @@ func TestGetMessageBody(t *testing.T) {
 				commentDetails: bigMessage,
 			},
 			resultErr: nil,
-			want:      fmt.Sprintf("**`🔱 Guardian 🔱 PLAN`** - 🟩 Successful for dir: `foo` http://github.com/logs\n\n<details>\n<summary>Details</summary>\n\n```diff\n\n%s...\n```\n</details>\n\nMessage has been truncated. See workflow logs to view the full message.", bigMessage[:gitHubMaxCommentLength-216]),
+			want:      fmt.Sprintf(CommentPrefix+" 🟩 Successful for dir: `foo` http://github.com/logs\n\n<details>\n<summary>Details</summary>\n\n```diff\n\n%s...\n```\n</details>\n\nMessage has been truncated. See workflow logs to view the full message.", bigMessage[:gitHubMaxCommentLength-216]),
 		},
 	}
 

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -203,7 +203,7 @@ func TestPlan_Process(t *testing.T) {
 				},
 				{
 					Name:   "UpdateIssueComment",
-					Params: []any{"owner", "repo", int64(1), CommentPrefix + " 🟩 Successful for dir: `testdata`  [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform show success with diff\n```\n</details>"},
+					Params: []any{"owner", "repo", int64(1), CommentPrefix + " 🟩 Successful for dir: `testdata` [[logs](https://github.com/owner/repo/actions/runs/100/job/1)]\n\n<details>\n<summary>Details</summary>\n\n```diff\n\nterraform show success with diff\n```\n</details>"},
 				},
 			},
 			expStorageClientReqs: []*storage.Request{

--- a/pkg/commands/workflows/plan_status_comments_test.go
+++ b/pkg/commands/workflows/plan_status_comments_test.go
@@ -96,7 +96,7 @@ func TestPlanStatusCommentsProcess(t *testing.T) {
 		flagGitHubRepo        string
 		flagPullRequestNumber int
 		flagInitResult        string
-		flagPlanResult        string
+		flagPlanResult        []string
 		gitHubClient          *github.MockGitHubClient
 		err                   string
 		expGitHubClientReqs   []*github.Request
@@ -110,7 +110,7 @@ func TestPlanStatusCommentsProcess(t *testing.T) {
 			flagGitHubRepo:        "repo",
 			flagPullRequestNumber: 1,
 			flagInitResult:        "success",
-			flagPlanResult:        "success",
+			flagPlanResult:        []string{"success"},
 			gitHubClient:          &github.MockGitHubClient{},
 			expGitHubClientReqs: []*github.Request{
 				{
@@ -123,13 +123,26 @@ func TestPlanStatusCommentsProcess(t *testing.T) {
 			expStderr: "",
 		},
 		{
+			name:                  "multi_failure",
+			flagIsGitHubActions:   true,
+			flagGitHubOwner:       "owner",
+			flagGitHubRepo:        "repo",
+			flagPullRequestNumber: 1,
+			flagInitResult:        "success",
+			flagPlanResult:        []string{"success", "failure"},
+			gitHubClient:          &github.MockGitHubClient{},
+			err:                   "init or plan has one or more failures",
+			expStdout:             "",
+			expStderr:             "",
+		},
+		{
 			name:                  "failure",
 			flagIsGitHubActions:   true,
 			flagGitHubOwner:       "owner",
 			flagGitHubRepo:        "repo",
 			flagPullRequestNumber: 2,
 			flagInitResult:        "failure",
-			flagPlanResult:        "failure",
+			flagPlanResult:        []string{"success"},
 			gitHubClient:          &github.MockGitHubClient{},
 			expGitHubClientReqs:   nil,
 			err:                   "init or plan has one or more failures",
@@ -143,7 +156,7 @@ func TestPlanStatusCommentsProcess(t *testing.T) {
 			flagGitHubRepo:        "repo",
 			flagPullRequestNumber: 3,
 			flagInitResult:        "cancelled",
-			flagPlanResult:        "skipped",
+			flagPlanResult:        []string{"cancelled"},
 			gitHubClient:          &github.MockGitHubClient{},
 			expGitHubClientReqs: []*github.Request{
 				{
@@ -151,7 +164,7 @@ func TestPlanStatusCommentsProcess(t *testing.T) {
 					Params: []any{"owner", "repo", 3, "**`🔱 Guardian 🔱 PLAN`** - 🟨 Unable to determine plan status. [[logs](https://github.com/owner/repo/actions/runs/100/attempts/1)]"},
 				},
 			},
-			err:       "unable to determine plan status, init and/or plan was skipped or cancelled",
+			err:       "unable to determine plan status",
 			expStdout: "",
 			expStderr: "",
 		},
@@ -162,7 +175,7 @@ func TestPlanStatusCommentsProcess(t *testing.T) {
 			flagGitHubRepo:        "repo",
 			flagPullRequestNumber: 4,
 			flagInitResult:        "success",
-			flagPlanResult:        "success",
+			flagPlanResult:        []string{"success"},
 			gitHubClient: &github.MockGitHubClient{
 				CreateIssueCommentsErr: fmt.Errorf("error creating comment"),
 			},

--- a/pkg/terraform/plan.go
+++ b/pkg/terraform/plan.go
@@ -25,6 +25,7 @@ import (
 // PlanOptions are the set of options for running a terraform plan.
 type PlanOptions struct {
 	CompactWarnings  *bool
+	Destroy          *bool
 	DetailedExitcode *bool
 	NoColor          *bool
 	Input            *bool
@@ -35,7 +36,7 @@ type PlanOptions struct {
 
 // planArgsFromOptions generated the terrafrom plan arguments from the provided options.
 func planArgsFromOptions(opts *PlanOptions) []string {
-	args := make([]string, 0, 7) // 7 potential args to be added
+	args := make([]string, 0, 8) // 8 potential args to be added
 
 	if opts == nil {
 		return args
@@ -43,6 +44,10 @@ func planArgsFromOptions(opts *PlanOptions) []string {
 
 	if pointer.Deref(opts.CompactWarnings) {
 		args = append(args, "-compact-warnings")
+	}
+
+	if pointer.Deref(opts.Destroy) {
+		args = append(args, "-destroy")
 	}
 
 	if pointer.Deref(opts.DetailedExitcode) {

--- a/pkg/terraform/plan_test.go
+++ b/pkg/terraform/plan_test.go
@@ -17,9 +17,8 @@ package terraform
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-
 	"github.com/abcxyz/pkg/pointer"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestPlanArgsFromOptions(t *testing.T) {
@@ -34,6 +33,7 @@ func TestPlanArgsFromOptions(t *testing.T) {
 			name: "truthy",
 			opts: &PlanOptions{
 				CompactWarnings:  pointer.To(true),
+				Destroy:          pointer.To(true),
 				DetailedExitcode: pointer.To(true),
 				Lock:             pointer.To(true),
 				LockTimeout:      pointer.To("10m"),
@@ -43,6 +43,7 @@ func TestPlanArgsFromOptions(t *testing.T) {
 			},
 			exp: []string{
 				"-compact-warnings",
+				"-destroy",
 				"-detailed-exitcode",
 				"-no-color",
 				"-input=true",
@@ -55,6 +56,7 @@ func TestPlanArgsFromOptions(t *testing.T) {
 			name: "falsey",
 			opts: &PlanOptions{
 				CompactWarnings:  pointer.To(false),
+				Destroy:          pointer.To(false),
 				DetailedExitcode: pointer.To(false),
 				Lock:             pointer.To(false),
 				LockTimeout:      pointer.To("10m"),

--- a/pkg/terraform/plan_test.go
+++ b/pkg/terraform/plan_test.go
@@ -17,8 +17,9 @@ package terraform
 import (
 	"testing"
 
-	"github.com/abcxyz/pkg/pointer"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/abcxyz/pkg/pointer"
 )
 
 func TestPlanArgsFromOptions(t *testing.T) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -26,6 +26,22 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+// SliceContainsOnly checks that all values of a slice are a single value.
+// Returns false when the input is an empty slice.
+func SliceContainsOnly[T comparable](slice []T, value T) bool {
+	if len(slice) == 0 {
+		return false
+	}
+
+	for _, v := range slice {
+		if v != value {
+			return false
+		}
+	}
+
+	return true
+}
+
 // SortedMapKeys returns the sorted slice of map key strings.
 func SortedMapKeys[M ~map[K]V, K cmp.Ordered, V any](m M) []K {
 	k := maps.Keys(m)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -21,6 +21,55 @@ import (
 	"github.com/abcxyz/pkg/testutil"
 )
 
+func TestSliceContainsOnly(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		slice []string
+		value string
+		exp   bool
+	}{
+		{
+			name:  "true",
+			slice: []string{"success"},
+			value: "success",
+			exp:   true,
+		},
+		{
+			name:  "empty",
+			slice: []string{},
+			value: "success",
+			exp:   false,
+		},
+		{
+			name:  "multi_true",
+			slice: []string{"success", "success"},
+			value: "failure",
+			exp:   false,
+		},
+		{
+			name:  "multi_false",
+			slice: []string{"success", "skipped"},
+			value: "failure",
+			exp:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := SliceContainsOnly(tc.slice, tc.value)
+			if got, want := got, tc.exp; got != want {
+				t.Errorf("expected %t to be %t", got, want)
+			}
+		})
+	}
+}
+
 func TestChildPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Open to suggestions on the output formatting. The integration workflow is not representative of what the end state will look like in production.

Actual flow:

```
init
  -> modified or "just plan" directories
  -> destroy or plan -destroy directories

plan
  business as usual for modified dirs

plan-destroy
  checkout main
  guardian plan with -destroy flag


PR MERGED

init
  -> modified or "just plan" directories
  -> destroy or plan -destroy directories

apply
  business as usual for modified dirs

apply-destroy
  checkout HEAD-1 (`github.events.pull_request.before`)
  guardian apply (parse destroy from GCS plan file metadata)
```

* Checking out main/head-1 is needed because we potentially deleted the directory or want to delete all existing resources.
* Splitting the jobs allows us to customize per operation (plan/destroy).
* Using GCS object metadata, we can determine if we are doing a destroy during the apply phase for informing the end user as needed, this wont affect the actual apply process, which is driven by the plan file contents.