### PR TITLE
feat: add filesystem storage impl

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -188,7 +188,7 @@ jobs:
           -github-repo="${GITHUB_REPO_NAME}" \
           -github-token="${REPO_TOKEN}" \
           -pull-request-number="${PULL_REQUEST_NUMBER}" \
-          -bucket-name="${GUARDIAN_BUCKET_NAME}" \
+          -storage="gcs://${GUARDIAN_BUCKET_NAME}" \
           -dir="${DIRECTORY}" \
           -job-name="${JOB_NAME}"
 
@@ -266,7 +266,7 @@ jobs:
           -github-repo="${GITHUB_REPO_NAME}" \
           -github-token="${REPO_TOKEN}" \
           -pull-request-number="${PULL_REQUEST_NUMBER}" \
-          -bucket-name="${GUARDIAN_BUCKET_NAME}" \
+          -storage="gcs://${GUARDIAN_BUCKET_NAME}" \
           -dir="${DIRECTORY}" \
           -job-name="${JOB_NAME}"
 

--- a/pkg/commands/apply/apply_test.go
+++ b/pkg/commands/apply/apply_test.go
@@ -134,14 +134,7 @@ func TestApply_Process(t *testing.T) {
 			},
 			expStorageClientReqs: []*storage.Request{
 				{
-					Name: "ObjectMetadata",
-					Params: []any{
-						"my-bucket-name",
-						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
-					},
-				},
-				{
-					Name: "DownloadObject",
+					Name: "GetObject",
 					Params: []any{
 						"my-bucket-name",
 						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
@@ -191,14 +184,7 @@ func TestApply_Process(t *testing.T) {
 			},
 			expStorageClientReqs: []*storage.Request{
 				{
-					Name: "ObjectMetadata",
-					Params: []any{
-						"my-bucket-name",
-						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
-					},
-				},
-				{
-					Name: "DownloadObject",
+					Name: "GetObject",
 					Params: []any{
 						"my-bucket-name",
 						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
@@ -248,14 +234,7 @@ func TestApply_Process(t *testing.T) {
 			},
 			expStorageClientReqs: []*storage.Request{
 				{
-					Name: "ObjectMetadata",
-					Params: []any{
-						"my-bucket-name",
-						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
-					},
-				},
-				{
-					Name: "DownloadObject",
+					Name: "GetObject",
 					Params: []any{
 						"my-bucket-name",
 						"guardian-plans/owner/repo/1/testdir/test-tfplan.binary",
@@ -286,14 +265,7 @@ func TestApply_Process(t *testing.T) {
 			terraformClient:          terraformMock,
 			expStorageClientReqs: []*storage.Request{
 				{
-					Name: "ObjectMetadata",
-					Params: []any{
-						"my-bucket-name",
-						"guardian-plans/owner/repo/2/testdir/test-tfplan.binary",
-					},
-				},
-				{
-					Name: "DownloadObject",
+					Name: "GetObject",
 					Params: []any{
 						"my-bucket-name",
 						"guardian-plans/owner/repo/2/testdir/test-tfplan.binary",
@@ -342,14 +314,7 @@ func TestApply_Process(t *testing.T) {
 			},
 			expStorageClientReqs: []*storage.Request{
 				{
-					Name: "ObjectMetadata",
-					Params: []any{
-						"my-bucket-name",
-						"guardian-plans/owner/repo/3/testdir/test-tfplan.binary",
-					},
-				},
-				{
-					Name: "DownloadObject",
+					Name: "GetObject",
 					Params: []any{
 						"my-bucket-name",
 						"guardian-plans/owner/repo/3/testdir/test-tfplan.binary",
@@ -398,14 +363,7 @@ func TestApply_Process(t *testing.T) {
 			},
 			expStorageClientReqs: []*storage.Request{
 				{
-					Name: "ObjectMetadata",
-					Params: []any{
-						"my-bucket-name",
-						"guardian-plans/owner/repo/3/testdir/test-tfplan.binary",
-					},
-				},
-				{
-					Name: "DownloadObject",
+					Name: "GetObject",
 					Params: []any{
 						"my-bucket-name",
 						"guardian-plans/owner/repo/3/testdir/test-tfplan.binary",

--- a/pkg/commands/cleanup/cleanup.go
+++ b/pkg/commands/cleanup/cleanup.go
@@ -92,11 +92,7 @@ func (c *CleanupCommand) Run(ctx context.Context, args []string) error {
 	}
 	c.directory = dirAbs
 
-	sc, err := storage.NewGoogleCloudStorage(
-		ctx,
-		storage.WithRetryInitialDelay(c.RetryFlags.FlagRetryInitialDelay),
-		storage.WithRetryMaxDelay(c.RetryFlags.FlagRetryMaxDelay),
-	)
+	sc, err := storage.NewGoogleCloudStorage(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create google cloud storage client: %w", err)
 	}
@@ -151,7 +147,7 @@ func (c *CleanupCommand) Process(ctx context.Context) error {
 		return fmt.Errorf("failed to parse gcs object %s: %w", statefileURI, err)
 	}
 
-	if err = c.storageClient.DeleteObject(ctx, *bucketName, *objectName); err != nil {
+	if err = c.storageClient.DeleteObject(ctx, bucketName, objectName); err != nil {
 		return fmt.Errorf("failed to delete statefile stored in gcs %s: %w", statefileURI, err)
 	}
 

--- a/pkg/commands/cleanup/cleanup_test.go
+++ b/pkg/commands/cleanup/cleanup_test.go
@@ -76,7 +76,7 @@ func TestEntrypointsProcess(t *testing.T) {
 			getStatefileResp: emptyStatefile,
 			expStorageClientReqs: []*storage.Request{
 				{
-					Name:   "DownloadObject",
+					Name:   "GetObject",
 					Params: []any{string("my-made-up-bucket"), string("my/path/to/file/project1/default.tfstate")},
 				},
 				{
@@ -94,7 +94,7 @@ func TestEntrypointsProcess(t *testing.T) {
 			getStatefileResp: statefileWithResources,
 			expStorageClientReqs: []*storage.Request{
 				{
-					Name:   "DownloadObject",
+					Name:   "GetObject",
 					Params: []any{string("my-made-up-bucket"), string("my/path/to/file/project2/default.tfstate")},
 				},
 			},

--- a/pkg/commands/drift/statefiles/statefiles.go
+++ b/pkg/commands/drift/statefiles/statefiles.go
@@ -373,7 +373,7 @@ func (c *DriftStatefilesCommand) actualStatefileUris(ctx context.Context, logger
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse GCS URI: %w", err)
 			}
-			buckets = append(buckets, *bucket)
+			buckets = append(buckets, bucket)
 		}
 	} else {
 		buckets, err = c.assetInventoryClient.Buckets(ctx, c.flagOrganizationID, c.flagGCSBucketQuery)

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -244,11 +244,7 @@ func (c *PlanCommand) Run(ctx context.Context, args []string) error {
 	)
 	c.terraformClient = terraform.NewTerraformClient(c.directory)
 
-	sc, err := storage.NewGoogleCloudStorage(
-		ctx,
-		storage.WithRetryInitialDelay(c.RetryFlags.FlagRetryInitialDelay),
-		storage.WithRetryMaxDelay(c.RetryFlags.FlagRetryMaxDelay),
-	)
+	sc, err := storage.NewGoogleCloudStorage(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create google cloud storage client: %w", err)
 	}
@@ -546,7 +542,7 @@ func (c *PlanCommand) uploadGuardianPlan(ctx context.Context, path string, data 
 		metadata[MetaKeyOperation] = OperationDestroy
 	}
 
-	if err := c.storageClient.UploadObject(ctx, c.flagBucketName, path, data,
+	if err := c.storageClient.CreateObject(ctx, c.flagBucketName, path, data,
 		storage.WithContentType("application/octet-stream"),
 		storage.WithMetadata(metadata),
 		storage.WithAllowOverwrite(true),

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -208,7 +208,7 @@ func TestPlan_Process(t *testing.T) {
 			},
 			expStorageClientReqs: []*storage.Request{
 				{
-					Name: "UploadObject",
+					Name: "CreateObject",
 					Params: []any{
 						"my-bucket-name",
 						"guardian-plans/owner/repo/1/testdata/test-tfplan.binary",
@@ -246,7 +246,7 @@ func TestPlan_Process(t *testing.T) {
 			},
 			expStorageClientReqs: []*storage.Request{
 				{
-					Name: "UploadObject",
+					Name: "CreateObject",
 					Params: []any{
 						"my-bucket-name",
 						"guardian-plans/owner/repo/2/testdata/test-tfplan.binary",
@@ -285,7 +285,7 @@ func TestPlan_Process(t *testing.T) {
 			},
 			expStorageClientReqs: []*storage.Request{
 				{
-					Name: "UploadObject",
+					Name: "CreateObject",
 					Params: []any{
 						"my-bucket-name",
 						"guardian-plans/owner/repo/2/testdata/test-tfplan.binary",
@@ -309,7 +309,7 @@ func TestPlan_Process(t *testing.T) {
 			terraformClient:          terraformNoDiffMock,
 			expStorageClientReqs: []*storage.Request{
 				{
-					Name: "UploadObject",
+					Name: "CreateObject",
 					Params: []any{
 						"my-bucket-name",
 						"guardian-plans/owner/repo/2/testdata/test-tfplan.binary",

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -53,11 +53,6 @@ func TestAfterParse(t *testing.T) {
 			args: []string{"-github-owner=owner", "-github-repo=repo", "-bucket-name=my-bucket"},
 			err:  "missing flag: pull-request-number is required",
 		},
-		{
-			name: "validate_bucket_name",
-			args: []string{"-github-owner=owner", "-github-repo=repo", "-pull-request-number=1"},
-			err:  "missing flag: bucket-name is required",
-		},
 	}
 
 	for _, tc := range cases {
@@ -162,11 +157,12 @@ func TestPlan_Process(t *testing.T) {
 	cases := []struct {
 		name                     string
 		directory                string
+		storageParent            string
+		storagePrefix            string
 		flagIsGitHubActions      bool
 		flagGitHubOwner          string
 		flagGitHubRepo           string
 		flagPullRequestNumber    int
-		flagBucketName           string
 		flagAllowLockfileChanges bool
 		flagLockTimeout          time.Duration
 		flagJobName              string
@@ -182,11 +178,12 @@ func TestPlan_Process(t *testing.T) {
 		{
 			name:                     "success_with_diff",
 			directory:                "testdata",
+			storageParent:            "storage-parent",
+			storagePrefix:            "",
 			flagIsGitHubActions:      true,
 			flagGitHubOwner:          "owner",
 			flagGitHubRepo:           "repo",
 			flagPullRequestNumber:    1,
-			flagBucketName:           "my-bucket-name",
 			flagAllowLockfileChanges: true,
 			flagLockTimeout:          10 * time.Minute,
 			flagJobName:              "example-job",
@@ -210,8 +207,8 @@ func TestPlan_Process(t *testing.T) {
 				{
 					Name: "CreateObject",
 					Params: []any{
-						"my-bucket-name",
-						"guardian-plans/owner/repo/1/testdata/test-tfplan.binary",
+						"storage-parent",
+						"testdata/test-tfplan.binary",
 						"this is a plan binary",
 					},
 				},
@@ -220,11 +217,12 @@ func TestPlan_Process(t *testing.T) {
 		{
 			name:                     "success_with_no_diff",
 			directory:                "testdata",
+			storageParent:            "storage-parent",
+			storagePrefix:            "",
 			flagIsGitHubActions:      true,
 			flagGitHubOwner:          "owner",
 			flagGitHubRepo:           "repo",
 			flagPullRequestNumber:    2,
-			flagBucketName:           "my-bucket-name",
 			flagAllowLockfileChanges: true,
 			flagLockTimeout:          10 * time.Minute,
 			flagJobName:              "example-job",
@@ -248,8 +246,8 @@ func TestPlan_Process(t *testing.T) {
 				{
 					Name: "CreateObject",
 					Params: []any{
-						"my-bucket-name",
-						"guardian-plans/owner/repo/2/testdata/test-tfplan.binary",
+						"storage-parent",
+						"testdata/test-tfplan.binary",
 						"this is a plan binary",
 					},
 				},
@@ -258,11 +256,12 @@ func TestPlan_Process(t *testing.T) {
 		{
 			name:                     "success_when_direct_log_url_resolution_fails",
 			directory:                "testdata",
+			storageParent:            "storage-parent",
+			storagePrefix:            "",
 			flagIsGitHubActions:      true,
 			flagGitHubOwner:          "owner",
 			flagGitHubRepo:           "repo",
 			flagPullRequestNumber:    2,
-			flagBucketName:           "my-bucket-name",
 			flagAllowLockfileChanges: true,
 			flagLockTimeout:          10 * time.Minute,
 			flagJobName:              "example-job",
@@ -287,8 +286,8 @@ func TestPlan_Process(t *testing.T) {
 				{
 					Name: "CreateObject",
 					Params: []any{
-						"my-bucket-name",
-						"guardian-plans/owner/repo/2/testdata/test-tfplan.binary",
+						"storage-parent",
+						"testdata/test-tfplan.binary",
 						"this is a plan binary",
 					},
 				},
@@ -297,11 +296,12 @@ func TestPlan_Process(t *testing.T) {
 		{
 			name:                     "skips_comments",
 			directory:                "testdata",
+			storageParent:            "storage-parent",
+			storagePrefix:            "",
 			flagIsGitHubActions:      false,
 			flagGitHubOwner:          "owner",
 			flagGitHubRepo:           "repo",
 			flagPullRequestNumber:    2,
-			flagBucketName:           "my-bucket-name",
 			flagAllowLockfileChanges: true,
 			flagLockTimeout:          10 * time.Minute,
 			flagJobName:              "example-job",
@@ -311,8 +311,8 @@ func TestPlan_Process(t *testing.T) {
 				{
 					Name: "CreateObject",
 					Params: []any{
-						"my-bucket-name",
-						"guardian-plans/owner/repo/2/testdata/test-tfplan.binary",
+						"storage-parent",
+						"testdata/test-tfplan.binary",
 						"this is a plan binary",
 					},
 				},
@@ -321,11 +321,12 @@ func TestPlan_Process(t *testing.T) {
 		{
 			name:                     "handles_error",
 			directory:                "testdata",
+			storageParent:            "storage-parent",
+			storagePrefix:            "",
 			flagIsGitHubActions:      true,
 			flagGitHubOwner:          "owner",
 			flagGitHubRepo:           "repo",
 			flagPullRequestNumber:    3,
-			flagBucketName:           "my-bucket-name",
 			flagAllowLockfileChanges: true,
 			flagLockTimeout:          10 * time.Minute,
 			flagJobName:              "example-job",
@@ -397,12 +398,13 @@ func TestPlan_Process(t *testing.T) {
 				},
 				cfg: tc.config,
 
-				directory:    tc.directory,
-				childPath:    tc.directory,
-				planFilename: "test-tfplan.binary",
+				directory:     tc.directory,
+				childPath:     tc.directory,
+				planFilename:  "test-tfplan.binary",
+				storageParent: tc.storageParent,
+				storagePrefix: tc.storagePrefix,
 
 				flagPullRequestNumber:    tc.flagPullRequestNumber,
-				flagBucketName:           tc.flagBucketName,
 				flagAllowLockfileChanges: tc.flagAllowLockfileChanges,
 				flagLockTimeout:          tc.flagLockTimeout,
 				flagJobName:              tc.flagJobName,

--- a/pkg/storage/filesystem_storage.go
+++ b/pkg/storage/filesystem_storage.go
@@ -1,0 +1,94 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// FilesystemStorage implements the Storage interface for a local filesystem.
+type FilesystemStorage struct{}
+
+// FilesystemStorage creates a new FilesystemStorage client.
+func NewFilesystemStorage(ctx context.Context) (*FilesystemStorage, error) {
+	return &FilesystemStorage{}, nil
+}
+
+// CreateObject creates a file in the supplied to the local filesystem..
+func (s *FilesystemStorage) CreateObject(ctx context.Context, folder, filename string, contents []byte, _ ...CreateOption) (merr error) {
+	pth := filepath.Join(folder, filename)
+	dir := filepath.Dir(pth)
+
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	if err := os.WriteFile(pth, contents, 0o600); err != nil {
+		return fmt.Errorf("failed to create object: %w", err)
+	}
+	return nil
+}
+
+// GetObject returns a reader for a file on the local filesystem. The caller must call Close on the returned Reader when done reading.
+func (s *FilesystemStorage) GetObject(ctx context.Context, folder, filename string) (io.ReadCloser, map[string]string, error) {
+	pth := filepath.Join(folder, filename)
+	f, err := os.Open(pth)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read file: %w", err)
+	}
+	return f, nil, nil
+}
+
+// DeleteObject deletes an object from a from the local filesystem. If the object does not exist, no error
+// will be returned.
+func (s *FilesystemStorage) DeleteObject(ctx context.Context, folder, filename string) error {
+	pth := filepath.Join(folder, filename)
+	if err := os.Remove(pth); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to delete object: %w", err)
+	}
+	return nil
+}
+
+// ObjectsWithName recursively searches a directory for files matching the given filename.
+func (s *FilesystemStorage) ObjectsWithName(ctx context.Context, folder, filename string) ([]string, error) {
+	var matches []string
+
+	if err := filepath.WalkDir(folder, func(pth string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("failed to walk directory %s: %w", pth, err)
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if filepath.Base(pth) != filename {
+			return nil
+		}
+
+		matches = append(matches, pth)
+
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to find files: %w", err)
+	}
+
+	return matches, nil
+}

--- a/pkg/storage/google_cloud_storage.go
+++ b/pkg/storage/google_cloud_storage.go
@@ -50,18 +50,12 @@ type GoogleCloudStorage struct {
 }
 
 // NewGoogleCloudStorage creates a new GoogleCloudStorage client.
-func NewGoogleCloudStorage(ctx context.Context, opts ...Option) (*GoogleCloudStorage, error) {
+func NewGoogleCloudStorage(ctx context.Context) (*GoogleCloudStorage, error) {
 	cfg := &Config{
 		initialRetryDelay: 1 * time.Second,
 		maxRetryDelay:     20 * time.Second,
 		retryMultiplier:   2,
 		retryTimeout:      60 * time.Second,
-	}
-
-	for _, opt := range opts {
-		if opt != nil {
-			cfg = opt(cfg)
-		}
 	}
 
 	client, err := storage.NewClient(ctx)
@@ -89,9 +83,9 @@ func (s *GoogleCloudStorage) objectHandleWithRetries(ctx context.Context, bucket
 	return o, ctx, cancel
 }
 
-// makeUploadConfig creates default upload config and overwrites with the user
+// makeCreateConfig creates default create config and overwrites with the user
 // provided upload options.
-func makeUploadConfig(contentLength int, opts []UploadOption) *uploadConfig {
+func makeCreateConfig(contentLength int, opts []CreateOption) *createConfig {
 	defaultChunkSize := 16 * MiB // default for cloud storage client
 
 	// we can send smaller files in one request
@@ -99,7 +93,7 @@ func makeUploadConfig(contentLength int, opts []UploadOption) *uploadConfig {
 		defaultChunkSize = contentLength + 256
 	}
 
-	cfg := &uploadConfig{
+	cfg := &createConfig{
 		chunkSize:          defaultChunkSize,
 		cacheMaxAgeSeconds: 86400, // 1 day
 		allowOverwrite:     false,
@@ -120,9 +114,9 @@ func makeUploadConfig(contentLength int, opts []UploadOption) *uploadConfig {
 	return cfg
 }
 
-// UploadObject uploads an object to a Google Cloud Storage bucket using a set of upload options.
-func (s *GoogleCloudStorage) UploadObject(ctx context.Context, bucket, name string, contents []byte, opts ...UploadOption) (merr error) {
-	cfg := makeUploadConfig(len(contents), opts)
+// CreateObject uploads an object to a Google Cloud Storage bucket using a set of upload options.
+func (s *GoogleCloudStorage) CreateObject(ctx context.Context, bucket, name string, contents []byte, opts ...CreateOption) (merr error) {
+	cfg := makeCreateConfig(len(contents), opts)
 
 	o, ctx, cancel := s.objectHandleWithRetries(ctx, bucket, name)
 	defer cancel()
@@ -180,32 +174,26 @@ func (s *GoogleCloudStorage) UploadObject(ctx context.Context, bucket, name stri
 	return merr
 }
 
-// DownloadObject downloads an object from a Google Cloud Storage bucket. The caller must call Close on the returned Reader when done reading.
-func (s *GoogleCloudStorage) DownloadObject(ctx context.Context, bucket, name string) (io.ReadCloser, error) {
+// GetObject downloads an object from a Google Cloud Storage bucket. The caller must call Close on the returned Reader when done reading.
+func (s *GoogleCloudStorage) GetObject(ctx context.Context, bucket, name string) (io.ReadCloser, map[string]string, error) {
 	o, ctx, cancel := s.objectHandleWithRetries(ctx, bucket, name)
 
 	r, err := o.NewReader(ctx)
 	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("failed to get google cloud storage reader: %w", err)
+		return nil, nil, fmt.Errorf("failed to get google cloud storage reader: %w", err)
+	}
+
+	// Get Metadata
+	attrs, err := o.Attrs(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get object metadata: %w", err)
 	}
 
 	return &readCloserCanceller{
 		ReadCloser: r,
 		cancelFunc: cancel,
-	}, nil
-}
-
-// ObjectMetadata gets the metadata for a Google Cloud Storage object.
-func (s *GoogleCloudStorage) ObjectMetadata(ctx context.Context, bucket, name string) (map[string]string, error) {
-	o, ctx, cancel := s.objectHandleWithRetries(ctx, bucket, name)
-	defer cancel()
-
-	attrs, err := o.Attrs(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get object metadata: %w", err)
-	}
-	return attrs.Metadata, nil
+	}, attrs.Metadata, nil
 }
 
 // DeleteObject deletes an object from a Google Cloud Storage bucket. If the object does not exist, no error
@@ -249,41 +237,6 @@ func (s *GoogleCloudStorage) ObjectsWithName(ctx context.Context, bucket, filena
 	return uris, nil
 }
 
-// Option is an optional config value for the Google Cloud Storage.
-type Option func(*Config) *Config
-
-// WithRetryInitialDelay configures the initial delay time before sending a retry for the Google Cloud Storage Client.
-func WithRetryInitialDelay(initialRetryDelay time.Duration) Option {
-	return func(c *Config) *Config {
-		c.initialRetryDelay = initialRetryDelay
-		return c
-	}
-}
-
-// WithRetryMaxDelay configures the maximum delay time before sending a retry for the Google Cloud Storage Client.
-func WithRetryMaxDelay(maxRetryDelay time.Duration) Option {
-	return func(c *Config) *Config {
-		c.maxRetryDelay = maxRetryDelay
-		return c
-	}
-}
-
-// WithRetryMultiplier configures the maximum delay time before sending a retry for the Google Cloud Storage Client.
-func WithRetryMultiplier(retryMultiplier float64) Option {
-	return func(c *Config) *Config {
-		c.retryMultiplier = retryMultiplier
-		return c
-	}
-}
-
-// WithRetryTimeout configures the maximum allowed timeout duration before sending a retry for the Google Cloud Storage Client.
-func WithRetryTimeout(retryTimeout time.Duration) Option {
-	return func(c *Config) *Config {
-		c.retryTimeout = retryTimeout
-		return c
-	}
-}
-
 type readCloserCanceller struct {
 	io.ReadCloser
 	cancelFunc context.CancelFunc
@@ -292,4 +245,14 @@ type readCloserCanceller struct {
 func (r *readCloserCanceller) Close() error {
 	defer r.cancelFunc()
 	return r.ReadCloser.Close() //nolint:wrapcheck // Want passthrough
+}
+
+// SplitObjectURI splits a bucket URI into bucket name and object name or returns an error.
+func SplitObjectURI(uri string) (string, string, error) {
+	bucketAndObject := strings.SplitN(strings.Replace(uri, "gs://", "", 1), "/", 2)
+	if len(bucketAndObject) < 2 {
+		return "", "", fmt.Errorf("failed to parse gcs uri: %s", uri)
+	}
+
+	return bucketAndObject[0], bucketAndObject[1], nil
 }

--- a/pkg/storage/google_cloud_storage.go
+++ b/pkg/storage/google_cloud_storage.go
@@ -249,7 +249,7 @@ func (r *readCloserCanceller) Close() error {
 
 // SplitObjectURI splits a bucket URI into bucket name and object name or returns an error.
 func SplitObjectURI(uri string) (string, string, error) {
-	bucketAndObject := strings.SplitN(strings.Replace(uri, "gs://", "", 1), "/", 2)
+	bucketAndObject := strings.SplitN(strings.TrimPrefix(uri, "gs://"), "/", 2)
 	if len(bucketAndObject) < 2 {
 		return "", "", fmt.Errorf("failed to parse gcs uri: %s", uri)
 	}

--- a/pkg/storage/google_cloud_storage_test.go
+++ b/pkg/storage/google_cloud_storage_test.go
@@ -20,19 +20,19 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestMakeUploadConfig(t *testing.T) {
+func TestMakeCreateConfig(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name   string
 		length int
-		opts   []UploadOption
-		exp    *uploadConfig
+		opts   []CreateOption
+		exp    *createConfig
 	}{
 		{
 			name:   "defaults_small_file",
 			length: 1 * MiB,
-			exp: &uploadConfig{
+			exp: &createConfig{
 				chunkSize:          1*MiB + 256,
 				cacheMaxAgeSeconds: 86400,
 				cacheControl:       "public, max-age=86400",
@@ -43,7 +43,7 @@ func TestMakeUploadConfig(t *testing.T) {
 		{
 			name:   "defaults_large_file",
 			length: 30 * MiB,
-			exp: &uploadConfig{
+			exp: &createConfig{
 				chunkSize:          16 * MiB,
 				cacheMaxAgeSeconds: 86400,
 				cacheControl:       "public, max-age=86400",
@@ -54,7 +54,7 @@ func TestMakeUploadConfig(t *testing.T) {
 		{
 			name:   "overwrites_with_opts",
 			length: 1 * MiB,
-			opts: []UploadOption{
+			opts: []CreateOption{
 				WithChunkSize(1000),
 				WithCacheMaxAgeSeconds(1000),
 				WithContentType("application/json"),
@@ -62,7 +62,7 @@ func TestMakeUploadConfig(t *testing.T) {
 					"key": "value",
 				}),
 			},
-			exp: &uploadConfig{
+			exp: &createConfig{
 				chunkSize:          1000,
 				cacheMaxAgeSeconds: 1000,
 				cacheControl:       "public, max-age=1000",
@@ -75,10 +75,10 @@ func TestMakeUploadConfig(t *testing.T) {
 		{
 			name:   "prevents_caching",
 			length: 100 * MiB,
-			opts: []UploadOption{
+			opts: []CreateOption{
 				WithCacheMaxAgeSeconds(0),
 			},
-			exp: &uploadConfig{
+			exp: &createConfig{
 				chunkSize:          16 * MiB,
 				cacheMaxAgeSeconds: 0,
 				cacheControl:       "no-cache, max-age=0",
@@ -94,8 +94,8 @@ func TestMakeUploadConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := makeUploadConfig(tc.length, tc.opts)
-			if diff := cmp.Diff(cfg, tc.exp, cmp.Options{cmp.AllowUnexported(uploadConfig{})}); diff != "" {
+			cfg := makeCreateConfig(tc.length, tc.opts)
+			if diff := cmp.Diff(cfg, tc.exp, cmp.Options{cmp.AllowUnexported(createConfig{})}); diff != "" {
 				t.Errorf(diff)
 			}
 		})

--- a/pkg/storage/options.go
+++ b/pkg/storage/options.go
@@ -14,8 +14,8 @@
 
 package storage
 
-// uploadConfig is the set of configuration used when uploading storage objects.
-type uploadConfig struct {
+// createConfig is the set of configuration used when creating storage objects.
+type createConfig struct {
 	allowOverwrite     bool
 	cacheControl       string
 	cacheMaxAgeSeconds int
@@ -24,13 +24,13 @@ type uploadConfig struct {
 	metadata           map[string]string
 }
 
-// UploadOption is an optional config value for the Google Cloud Storage UploadObject function.
-type UploadOption func(*uploadConfig) *uploadConfig
+// CreateOption is an optional config value for the Google Cloud Storage CreateObject function.
+type CreateOption func(*createConfig) *createConfig
 
 // WithChunkSize configures the chunk size for the object upload. Set this value to 0 to send the
 // entire file in a single request.
-func WithChunkSize(chunkSize int) UploadOption {
-	return func(c *uploadConfig) *uploadConfig {
+func WithChunkSize(chunkSize int) CreateOption {
+	return func(c *createConfig) *createConfig {
 		c.chunkSize = chunkSize
 		return c
 	}
@@ -38,32 +38,32 @@ func WithChunkSize(chunkSize int) UploadOption {
 
 // WithCacheMaxAgeSeconds configures the cache-control header the object upload. Set this value to 0 to prevent
 // caching the file.
-func WithCacheMaxAgeSeconds(cacheMaxAgeSeconds int) UploadOption {
-	return func(c *uploadConfig) *uploadConfig {
+func WithCacheMaxAgeSeconds(cacheMaxAgeSeconds int) CreateOption {
+	return func(c *createConfig) *createConfig {
 		c.cacheMaxAgeSeconds = cacheMaxAgeSeconds
 		return c
 	}
 }
 
 // WithContentType sets the content type for the object upload.
-func WithContentType(contentType string) UploadOption {
-	return func(c *uploadConfig) *uploadConfig {
+func WithContentType(contentType string) CreateOption {
+	return func(c *createConfig) *createConfig {
 		c.contentType = contentType
 		return c
 	}
 }
 
 // WithAllowOverwrite sets the overwrite flag to allow overwriting the destination object.
-func WithAllowOverwrite(allowOverwrite bool) UploadOption {
-	return func(c *uploadConfig) *uploadConfig {
+func WithAllowOverwrite(allowOverwrite bool) CreateOption {
+	return func(c *createConfig) *createConfig {
 		c.allowOverwrite = allowOverwrite
 		return c
 	}
 }
 
 // WithMetadata sets the metadata for the object upload.
-func WithMetadata(metadata map[string]string) UploadOption {
-	return func(c *uploadConfig) *uploadConfig {
+func WithMetadata(metadata map[string]string) CreateOption {
+	return func(c *createConfig) *createConfig {
 		c.metadata = metadata
 		return c
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -17,34 +17,29 @@ package storage
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"strings"
+)
+
+// Type defines the type of storage client.
+type Type int
+
+// The types of storage clients available.
+const (
+	FilesystemType Type = iota
+	GoogleCloudStorageType
 )
 
 // Storage defines the minimum interface for a blob storage system.
 type Storage interface {
-	// UploadObject uploads a blob storage object.
-	UploadObject(ctx context.Context, bucket, name string, contents []byte, opts ...UploadOption) error
+	// CreateObject creates a blob storage object.
+	CreateObject(ctx context.Context, bucket, name string, contents []byte, opts ...CreateOption) error
 
-	// DownloadObject downloads a blob storage object. The caller must call Close on the returned Reader when done reading.
-	DownloadObject(ctx context.Context, bucket, name string) (io.ReadCloser, error)
-
-	// ObjectMetadata gets metadata for a blob storage object.
-	ObjectMetadata(ctx context.Context, bucket, name string) (map[string]string, error)
+	// GetObject gets a blob storage object and metadata if any. The caller must call Close on the returned Reader when done reading.
+	GetObject(ctx context.Context, bucket, name string) (io.ReadCloser, map[string]string, error)
 
 	// DeleteObject deletes a blob storage object.
 	DeleteObject(ctx context.Context, bucket, name string) error
 
-	// ObjectsWithName returns the URIs of files in a given bucket with the filename.
+	// ObjectsWithName returns the paths of files for a given parent with the filename.
 	ObjectsWithName(ctx context.Context, bucket, filename string) ([]string, error)
-}
-
-func SplitObjectURI(uri string) (*string, *string, error) {
-	bucketAndObject := strings.SplitN(strings.Replace(uri, "gs://", "", 1), "/", 2)
-	if len(bucketAndObject) < 2 {
-		return nil, nil, fmt.Errorf("failed to parse gcs uri: %s", uri)
-	}
-
-	return &bucketAndObject[0], &bucketAndObject[1], nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -20,13 +20,10 @@ import (
 	"io"
 )
 
-// Type defines the type of storage client.
-type Type int
-
 // The types of storage clients available.
 const (
-	FilesystemType Type = iota
-	GoogleCloudStorageType
+	FilesystemType         = "file"
+	GoogleCloudStorageType = "gcs"
 )
 
 // Storage defines the minimum interface for a blob storage system.

--- a/pkg/terraform/parser/parser.go
+++ b/pkg/terraform/parser/parser.go
@@ -143,7 +143,7 @@ func (p *TerraformParser) StateWithoutResources(ctx context.Context, uri string)
 	if err != nil {
 		return false, fmt.Errorf("failed to parse GCS URI: %w", err)
 	}
-	r, err := p.GCS.DownloadObject(ctx, *bucket, *name)
+	r, _, err := p.GCS.GetObject(ctx, bucket, name)
 	if err != nil {
 		return false, fmt.Errorf("failed to download gcs URI for terraform: %w", err)
 	}
@@ -166,7 +166,7 @@ func (p *TerraformParser) ProcessStates(ctx context.Context, gcsUris []string) (
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse GCS URI: %w", err)
 		}
-		r, err := p.GCS.DownloadObject(ctx, *bucket, *name)
+		r, _, err := p.GCS.GetObject(ctx, bucket, name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to download gcs URI for terraform: %w", err)
 		}
@@ -228,7 +228,7 @@ func (p *TerraformParser) parseTerraformStateIAM(ctx context.Context, state Terr
 	return iams, nil
 }
 
-func (p *TerraformParser) parseIAMBindingForOrg(ctx context.Context, instances []*InstancesState) []*assetinventory.AssetIAM {
+func (p *TerraformParser) parseIAMBindingForOrg(_ context.Context, instances []*InstancesState) []*assetinventory.AssetIAM {
 	var iams []*assetinventory.AssetIAM
 	for _, i := range instances {
 		for _, m := range i.Attributes.Members {
@@ -284,7 +284,7 @@ func (p *TerraformParser) parseIAMBindingForProject(ctx context.Context, instanc
 	return iams
 }
 
-func (p *TerraformParser) parseIAMMemberForOrg(ctx context.Context, instances []*InstancesState) []*assetinventory.AssetIAM {
+func (p *TerraformParser) parseIAMMemberForOrg(_ context.Context, instances []*InstancesState) []*assetinventory.AssetIAM {
 	iams := make([]*assetinventory.AssetIAM, len(instances))
 	for x, i := range instances {
 		iams[x] = &assetinventory.AssetIAM{


### PR DESCRIPTION
Trying to abstract the storage interface even further. Eventaully, Guardian should run locally with the filesystem storage and write the plan to local filesystem. For now, these changes are in preparation of that.

* Renamed interface functions that arent specific to network requests, eg download
* Updated references to functions
* Created new filesystem storage impl