### PR TITLE
Add Platform flag to new GlobalFlags section

### DIFF
--- a/pkg/flags/global.go
+++ b/pkg/flags/global.go
@@ -51,6 +51,11 @@ func (g *GlobalFlags) Register(set *cli.FlagSet) {
 
 	set.AfterParse(func(merr error) error {
 		g.FlagPlatform = strings.ToLower(strings.TrimSpace(g.FlagPlatform))
+
+		if _, ok := allowedPlatforms[g.FlagPlatform]; !ok && g.FlagPlatform != "" {
+			merr = errors.Join(merr, fmt.Errorf("unsupported value for platform flag: %s", g.FlagPlatform))
+		}
+
 		switch g.FlagPlatform {
 		case "github":
 		case "local":
@@ -61,10 +66,6 @@ func (g *GlobalFlags) Register(set *cli.FlagSet) {
 			}
 
 			g.FlagPlatform = "local"
-		}
-
-		if _, ok := allowedPlatforms[g.FlagPlatform]; !ok {
-			merr = errors.Join(merr, fmt.Errorf("unsupported value for platform flag: %s", g.FlagPlatform))
 		}
 
 		return merr

--- a/pkg/flags/global.go
+++ b/pkg/flags/global.go
@@ -27,6 +27,8 @@ var allowedPlatforms = map[string]struct{}{
 	"github": {},
 }
 
+// GlobalFlags represents the set of global flags that MUST be embeded in all
+// commands.
 type GlobalFlags struct {
 	FlagPlatform string
 }

--- a/pkg/flags/global.go
+++ b/pkg/flags/global.go
@@ -17,7 +17,8 @@ package flags
 import (
 	"errors"
 	"fmt"
-	"os"
+	"strconv"
+	"strings"
 
 	"github.com/abcxyz/pkg/cli"
 )
@@ -49,10 +50,12 @@ func (g *GlobalFlags) Register(set *cli.FlagSet) {
 	})
 
 	set.AfterParse(func(merr error) error {
+		g.FlagPlatform = strings.ToLower(strings.TrimSpace(g.FlagPlatform))
 		switch g.FlagPlatform {
 		case "github":
+		case "local":
 		default:
-			if os.Getenv("GITHUB_ACTIONS") == "true" {
+			if v, _ := strconv.ParseBool(set.GetEnv("GITHUB_ACTIONS")); v {
 				g.FlagPlatform = "github"
 				break
 			}

--- a/pkg/flags/global.go
+++ b/pkg/flags/global.go
@@ -27,7 +27,7 @@ var allowedPlatforms = map[string]struct{}{
 	"github": {},
 }
 
-// GlobalFlags represents the set of global flags that MUST be embeded in all
+// GlobalFlags represents the set of global flags that MUST be embedded in all
 // commands.
 type GlobalFlags struct {
 	FlagPlatform string

--- a/pkg/flags/global.go
+++ b/pkg/flags/global.go
@@ -1,0 +1,62 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/abcxyz/pkg/cli"
+)
+
+var allowedPlatforms = map[string]struct{}{
+	"local":  {},
+	"github": {},
+}
+
+type GlobalFlags struct {
+	FlagPlatform string
+}
+
+func (g *GlobalFlags) Register(set *cli.FlagSet) {
+	f := set.NewSection("GLOBAL OPTIONS")
+
+	f.StringVar(&cli.StringVar{
+		Name:    "platform",
+		Target:  &g.FlagPlatform,
+		Example: "github",
+		Usage:   "The code review platform for Guardian to integrate with.",
+	})
+
+	set.AfterParse(func(merr error) error {
+		switch g.FlagPlatform {
+		case "github":
+		default:
+			if os.Getenv("GITHUB_ACTIONS") == "true" {
+				g.FlagPlatform = "github"
+				break
+			}
+
+			g.FlagPlatform = "local"
+		}
+
+		if _, ok := allowedPlatforms[g.FlagPlatform]; !ok {
+			merr = errors.Join(merr, fmt.Errorf("unsupported value for platform flag: %s", g.FlagPlatform))
+		}
+
+		return merr
+	})
+}

--- a/pkg/flags/global.go
+++ b/pkg/flags/global.go
@@ -34,6 +34,11 @@ type GlobalFlags struct {
 func (g *GlobalFlags) Register(set *cli.FlagSet) {
 	f := set.NewSection("GLOBAL OPTIONS")
 
+	// FlagPlatform value is loaded in the following order:
+	//
+	// 1. Explicit value set through --platform flag
+	// 2. Inferred environment from well-known environment variables
+	// 3. Default value of "local"
 	f.StringVar(&cli.StringVar{
 		Name:    "platform",
 		Target:  &g.FlagPlatform,


### PR DESCRIPTION
This change helps provide context about which CI/CD environment a Guardian command is running in. This is useful for determining which client implementations to initialize. 