### PR TITLE
Add TokenSource function to github package

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -598,7 +598,9 @@ func (g *GitHubClient) withRetries(ctx context.Context, retryFunc retry.RetryFun
 	return nil
 }
 
-type GitHubAppInputs struct {
+type TokenSourceInputs struct {
+	GitHubToken string
+
 	GitHubAppID             string
 	GitHubAppPrivateKeyPEM  string
 	GitHubAppInstallationID string
@@ -608,27 +610,27 @@ type GitHubAppInputs struct {
 
 // TokenSource creates a token source from a GitHub token or GitHub App used for
 // authenticating a github client.
-func TokenSource(ctx context.Context, token string, appInputs *GitHubAppInputs) (githubauth.TokenSource, error) {
-	if token != "" {
-		githubTokenSource, err := githubauth.NewStaticTokenSource(token)
+func TokenSource(ctx context.Context, inputs *TokenSourceInputs) (githubauth.TokenSource, error) {
+	if inputs.GitHubToken != "" {
+		githubTokenSource, err := githubauth.NewStaticTokenSource(inputs.GitHubToken)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create github static token source: %w", err)
 		}
 		return githubTokenSource, nil
 	} else {
 		app, err := githubauth.NewApp(
-			appInputs.GitHubAppID,
-			appInputs.GitHubAppPrivateKeyPEM,
+			inputs.GitHubAppID,
+			inputs.GitHubAppPrivateKeyPEM,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create github app token source: %w", err)
 		}
 
-		installation, err := app.InstallationForID(ctx, appInputs.GitHubAppInstallationID)
+		installation, err := app.InstallationForID(ctx, inputs.GitHubAppInstallationID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get github app installation: %w", err)
 		}
 
-		return installation.SelectedReposTokenSource(appInputs.Permissions, appInputs.GitHubRepo), nil
+		return installation.SelectedReposTokenSource(inputs.Permissions, inputs.GitHubRepo), nil
 	}
 }

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -611,26 +611,30 @@ type TokenSourceInputs struct {
 // TokenSource creates a token source from a GitHub token or GitHub App used for
 // authenticating a github client.
 func TokenSource(ctx context.Context, inputs *TokenSourceInputs) (githubauth.TokenSource, error) {
+	if inputs == nil {
+		return nil, fmt.Errorf("inputs cannot be nil")
+	}
+
 	if inputs.GitHubToken != "" {
 		githubTokenSource, err := githubauth.NewStaticTokenSource(inputs.GitHubToken)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create github static token source: %w", err)
 		}
 		return githubTokenSource, nil
-	} else {
-		app, err := githubauth.NewApp(
-			inputs.GitHubAppID,
-			inputs.GitHubAppPrivateKeyPEM,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create github app token source: %w", err)
-		}
-
-		installation, err := app.InstallationForID(ctx, inputs.GitHubAppInstallationID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get github app installation: %w", err)
-		}
-
-		return installation.SelectedReposTokenSource(inputs.Permissions, inputs.GitHubRepo), nil
 	}
+
+	app, err := githubauth.NewApp(
+		inputs.GitHubAppID,
+		inputs.GitHubAppPrivateKeyPEM,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create github app token source: %w", err)
+	}
+
+	installation, err := app.InstallationForID(ctx, inputs.GitHubAppInstallationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get github app installation: %w", err)
+	}
+
+	return installation.SelectedReposTokenSource(inputs.Permissions, inputs.GitHubRepo), nil
 }


### PR DESCRIPTION
This is a generalized version of the TokenSource function, which we will need frequently when instantiating new GitHub clients. The previous implementation tied us to generating `TokenSource`s from `flags.GitHubFlags`