### PR TITLE
Create new GitHub implementation of Platform interface

### DIFF
--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package github provides the functionality to send requests to the GitHub API.
 package platform
 
 import (

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -1,0 +1,80 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package github provides the functionality to send requests to the GitHub API.
+package platform
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/go-github/v53/github"
+	"golang.org/x/oauth2"
+
+	"github.com/abcxyz/pkg/githubauth"
+
+	gh "github.com/abcxyz/guardian/pkg/github"
+)
+
+var _ Platform = (*GitHub)(nil)
+
+// GitHub implements the Platform interface.
+type GitHub struct {
+	cfg    *gh.Config
+	client *github.Client
+}
+
+// NewGitHub creates a new GitHub client.
+func NewGitHub(ctx context.Context, cfg *gh.Config) (*GitHub, error) {
+	if cfg.MaxRetries <= 0 {
+		cfg.MaxRetries = 3
+	}
+	if cfg.InitialRetryDelay <= 0 {
+		cfg.InitialRetryDelay = 1 * time.Second
+	}
+	if cfg.MaxRetryDelay <= 0 {
+		cfg.MaxRetryDelay = 20 * time.Second
+	}
+
+	var ts oauth2.TokenSource
+	if cfg.GitHubToken != "" {
+		ts = oauth2.StaticTokenSource(&oauth2.Token{
+			AccessToken: cfg.GitHubToken,
+		})
+	} else {
+		app, err := githubauth.NewApp(cfg.GitHubAppID, cfg.GitHubAppPrivateKeyPEM)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create github app token source: %w", err)
+		}
+
+		installation, err := app.InstallationForID(ctx, cfg.GitHubAppInstallationID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get github app installation: %w", err)
+		}
+
+		ts = installation.SelectedReposOAuth2TokenSource(ctx, cfg.Permissions, cfg.GitHubRepo)
+	}
+
+	tc := oauth2.NewClient(ctx, ts)
+
+	client := github.NewClient(tc)
+
+	g := &GitHub{
+		cfg:    cfg,
+		client: client,
+	}
+
+	return g, nil
+}

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -23,9 +23,8 @@ import (
 	"github.com/google/go-github/v53/github"
 	"golang.org/x/oauth2"
 
-	"github.com/abcxyz/pkg/githubauth"
-
 	gh "github.com/abcxyz/guardian/pkg/github"
+	"github.com/abcxyz/pkg/githubauth"
 )
 
 var _ Platform = (*GitHub)(nil)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/posener/complete/v2"
 
-	"github.com/abcxyz/guardian/pkg/github"
+	gh "github.com/abcxyz/guardian/pkg/github"
 	"github.com/abcxyz/pkg/cli"
 )
 
@@ -47,7 +47,7 @@ var (
 		sort.Strings(allowed)
 		return allowed
 	}()
-	_ Platform = (*github.GitHubClient)(nil)
+	_ Platform = (*GitHub)(nil)
 )
 
 // Platform defines the minimum interface for a code review platform.
@@ -57,7 +57,7 @@ type Platform interface{}
 type Config struct {
 	Type string
 
-	GitHub github.Config
+	GitHub gh.Config
 }
 
 func (c *Config) RegisterFlags(set *cli.FlagSet) {
@@ -104,9 +104,9 @@ func NewPlatform(ctx context.Context, cfg *Config) (Platform, error) {
 	}
 
 	if strings.EqualFold(cfg.Type, TypeGitHub) {
-		gc, err := github.NewGitHubClient(ctx, &cfg.GitHub)
+		gc, err := NewGitHub(ctx, &cfg.GitHub)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create github client: %w", err)
+			return nil, fmt.Errorf("failed to create github: %w", err)
 		}
 		return gc, nil
 	}


### PR DESCRIPTION
This creates a new GitHub type to implement the Platform interface. All the methods of the GitHub interface in `github.com/abcxyz/guardian/pkg/github` will be moved to the Platform interface/package.