### PR TITLE
Save plan file as JSON file in plan command

### DIFF
--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -326,7 +326,7 @@ func (c *PlanCommand) terraformPlan(ctx context.Context) (*RunResult, error) {
 	stdout.Reset()
 	stderr.Reset()
 
-	util.Headerf(c.Stdout(), "Saving output to JSON file")
+	util.Headerf(c.Stdout(), "Writing Plan to Local JSON File")
 	_, err = c.terraformClient.Show(ctx, &stdout, multiStderr, &terraform.ShowOptions{
 		File:    pointer.To(c.planFilename),
 		NoColor: pointer.To(true),

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -186,7 +186,7 @@ func (c *PlanCommand) Run(ctx context.Context, args []string) error {
 		c.flagOutputDir = childPath
 	}
 	if c.flagOutputDir, err = filepath.Abs(c.flagOutputDir); err != nil {
-		return fmt.Errorf("failted to get absolute path for output directory: %w", err)
+		return fmt.Errorf("failed to get absolute path for output directory: %w", err)
 	}
 
 	c.terraformClient = terraform.NewTerraformClient(c.directory)

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -326,8 +326,9 @@ func (c *PlanCommand) terraformPlan(ctx context.Context) (*RunResult, error) {
 	stderr.Reset()
 
 	if !c.skipJSONPlanFile {
+		var jsonOut strings.Builder
 		util.Headerf(c.Stdout(), "Writing Plan to Local JSON File")
-		if _, err = c.terraformClient.Show(ctx, &stdout, multiStderr, &terraform.ShowOptions{
+		if _, err = c.terraformClient.Show(ctx, &jsonOut, multiStderr, &terraform.ShowOptions{
 			File:    pointer.To(c.planFilename),
 			NoColor: pointer.To(true),
 			JSON:    pointer.To(true),
@@ -341,11 +342,10 @@ func (c *PlanCommand) terraformPlan(ctx context.Context) (*RunResult, error) {
 		planBasename := strings.TrimSuffix(c.planFilename, path.Ext(c.planFilename))
 		jsonFilepath := path.Join(c.childPath, planBasename+".json")
 
-		if err := os.WriteFile(jsonFilepath, []byte(stdout.String()), ownerReadWritePerms); err != nil {
+		if err := os.WriteFile(jsonFilepath, []byte(jsonOut.String()), ownerReadWritePerms); err != nil {
 			return &RunResult{hasChanges: hasChanges}, fmt.Errorf("failed to write plan to json file: %w", err)
 		}
 		c.Outf("Plan JSON file path: %s", jsonFilepath)
-		stdout.Reset()
 		stderr.Reset()
 	}
 

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -345,10 +345,9 @@ func (c *PlanCommand) terraformPlan(ctx context.Context) (*RunResult, error) {
 			return &RunResult{hasChanges: hasChanges}, fmt.Errorf("failed to write plan to json file: %w", err)
 		}
 		c.Outf("Plan JSON file path: %s", jsonFilepath)
+		stdout.Reset()
+		stderr.Reset()
 	}
-
-	stdout.Reset()
-	stderr.Reset()
 
 	util.Headerf(c.Stdout(), "Formatting output")
 	if _, err := c.terraformClient.Show(ctx, multiStdout, multiStderr, &terraform.ShowOptions{

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -339,7 +339,7 @@ func (c *PlanCommand) terraformPlan(ctx context.Context) (*RunResult, error) {
 		}, fmt.Errorf("failed to terraform show: %w", err)
 	}
 
-	planBasename := c.planFilename[:len(c.planFilename)-len(path.Ext(c.planFilename))]
+	planBasename := strings.TrimSuffix(c.planFilename, path.Ext(c.planFilename))
 	jsonFilepath := path.Join(c.childPath, planBasename+".json")
 
 	var data any

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -141,7 +141,8 @@ func (c *PlanCommand) Flags() *cli.FlagSet {
 	f.StringVar(&cli.StringVar{
 		Name:    "output-dir",
 		Target:  &c.flagOutputDir,
-		Example: ".",
+		Example: "./output/plan",
+		Usage:   "Write the plan binary and JSON file to a target local directory.",
 	})
 	return set
 }

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -16,7 +16,9 @@
 package plan
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -49,6 +51,8 @@ const (
 	// plan files metadata operation values.
 	OperationPlan    = "plan"
 	OperationDestroy = "destroy"
+
+	ownerReadWritePerms = 0o600
 )
 
 var _ cli.Command = (*PlanCommand)(nil)
@@ -318,6 +322,40 @@ func (c *PlanCommand) terraformPlan(ctx context.Context) (*RunResult, error) {
 		}
 		return &RunResult{commentDetails: commentDetails}, fmt.Errorf("failed to plan: %w", err)
 	}
+
+	stdout.Reset()
+	stderr.Reset()
+
+	util.Headerf(c.Stdout(), "Saving output to JSON file")
+	_, err = c.terraformClient.Show(ctx, &stdout, multiStderr, &terraform.ShowOptions{
+		File:    pointer.To(c.planFilename),
+		NoColor: pointer.To(true),
+		JSON:    pointer.To(true),
+	})
+	if err != nil {
+		return &RunResult{
+			commentDetails: stderr.String(),
+			hasChanges:     hasChanges,
+		}, fmt.Errorf("failed to terraform show: %w", err)
+	}
+
+	planBasename := c.planFilename[:len(c.planFilename)-len(path.Ext(c.planFilename))]
+	jsonFilepath := path.Join(c.childPath, planBasename+".json")
+
+	var data any
+	if err := json.Unmarshal([]byte(stdout.String()), &data); err != nil {
+		return &RunResult{hasChanges: hasChanges}, fmt.Errorf("failed to unmarshal json plan: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(data); err != nil {
+		return &RunResult{hasChanges: hasChanges}, fmt.Errorf("failed to encode json: %w", err)
+	}
+
+	if err := os.WriteFile(jsonFilepath, buf.Bytes(), ownerReadWritePerms); err != nil {
+		return &RunResult{hasChanges: hasChanges}, fmt.Errorf("failed to write plan to json file: %w", err)
+	}
+	c.Outf("Plan JSON file path: %s", jsonFilepath)
 
 	stdout.Reset()
 	stderr.Reset()

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -235,7 +235,6 @@ func TestPlan_Process(t *testing.T) {
 				directory:                tc.directory,
 				childPath:                tc.directory,
 				planFilename:             "test-tfplan.binary",
-				skipJSONPlanFile:         true,
 				storagePrefix:            tc.storagePrefix,
 				flagDestroy:              tc.flagDestroy,
 				flagAllowLockfileChanges: tc.flagAllowLockfileChanges,

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 var terraformNoDiffMock = &terraform.MockTerraformClient{
+	PlanBody: []byte("this is a plan binary"),
 	FormatResponse: &terraform.MockTerraformResponse{
 		Stdout:   "terraform format success",
 		ExitCode: 0,
@@ -58,6 +59,7 @@ var terraformNoDiffMock = &terraform.MockTerraformClient{
 }
 
 var terraformDiffMock = &terraform.MockTerraformClient{
+	PlanBody: []byte("this is a plan binary"),
 	FormatResponse: &terraform.MockTerraformResponse{
 		Stdout:   "terraform format success",
 		ExitCode: 0,
@@ -85,6 +87,7 @@ var terraformDiffMock = &terraform.MockTerraformClient{
 }
 
 var terraformErrorMock = &terraform.MockTerraformClient{
+	PlanBody: []byte("this is a plan binary"),
 	FormatResponse: &terraform.MockTerraformResponse{
 		Stdout:   "terraform format success",
 		ExitCode: 0,

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -51,6 +51,10 @@ var terraformNoDiffMock = &terraform.MockTerraformClient{
 		Stdout:   "terraform show success - no diff",
 		ExitCode: 0,
 	},
+	ShowJSONResponse: &terraform.MockTerraformResponse{
+		Stdout:   `{"result": "terraform show success - no diff"}`,
+		ExitCode: 0,
+	},
 }
 
 var terraformDiffMock = &terraform.MockTerraformClient{
@@ -72,6 +76,10 @@ var terraformDiffMock = &terraform.MockTerraformClient{
 	},
 	ShowResponse: &terraform.MockTerraformResponse{
 		Stdout:   "terraform show success with diff",
+		ExitCode: 0,
+	},
+	ShowJSONResponse: &terraform.MockTerraformResponse{
+		Stdout:   `{"result": "terraform show success with diff"}`,
 		ExitCode: 0,
 	},
 }
@@ -97,6 +105,10 @@ var terraformErrorMock = &terraform.MockTerraformClient{
 	},
 	ShowResponse: &terraform.MockTerraformResponse{
 		Stdout:   "terraform show success - no diff",
+		ExitCode: 0,
+	},
+	ShowJSONResponse: &terraform.MockTerraformResponse{
+		Stdout:   `{"result": "terraform show success - no diff"}`,
 		ExitCode: 0,
 	},
 }
@@ -223,6 +235,7 @@ func TestPlan_Process(t *testing.T) {
 				directory:                tc.directory,
 				childPath:                tc.directory,
 				planFilename:             "test-tfplan.binary",
+				skipJSONPlanFile:         true,
 				storagePrefix:            tc.storagePrefix,
 				flagDestroy:              tc.flagDestroy,
 				flagAllowLockfileChanges: tc.flagAllowLockfileChanges,

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -236,6 +236,7 @@ func TestPlan_Process(t *testing.T) {
 				childPath:                tc.directory,
 				planFilename:             "test-tfplan.binary",
 				storagePrefix:            tc.storagePrefix,
+				flagOutputDir:            t.TempDir(),
 				flagDestroy:              tc.flagDestroy,
 				flagAllowLockfileChanges: tc.flagAllowLockfileChanges,
 				flagLockTimeout:          tc.flagLockTimeout,

--- a/pkg/terraform/terraform_mock.go
+++ b/pkg/terraform/terraform_mock.go
@@ -35,6 +35,7 @@ type MockTerraformClient struct {
 	PlanResponse     *MockTerraformResponse
 	ApplyResponse    *MockTerraformResponse
 	ShowResponse     *MockTerraformResponse
+	ShowJSONResponse *MockTerraformResponse
 	FormatResponse   *MockTerraformResponse
 	RunResponse      *MockTerraformResponse
 }
@@ -76,6 +77,12 @@ func (m *MockTerraformClient) Apply(ctx context.Context, stdout, stderr io.Write
 }
 
 func (m *MockTerraformClient) Show(ctx context.Context, stdout, stderr io.Writer, opts *ShowOptions) (int, error) {
+	if opts.JSON != nil && *opts.JSON && m.ShowJSONResponse != nil {
+		stdout.Write([]byte(m.ShowJSONResponse.Stdout))
+		stderr.Write([]byte(m.ShowJSONResponse.Stderr))
+		return m.ShowJSONResponse.ExitCode, m.ShowJSONResponse.Err
+	}
+
 	if m.ShowResponse != nil {
 		stdout.Write([]byte(m.ShowResponse.Stdout))
 		stderr.Write([]byte(m.ShowResponse.Stderr))

--- a/pkg/terraform/terraform_mock.go
+++ b/pkg/terraform/terraform_mock.go
@@ -34,6 +34,8 @@ type MockTerraformResponse struct {
 
 // MockTerraformClient creates a mock TerraformClient for use with testing.
 type MockTerraformClient struct {
+	// PlanBody is the content written to the test binary file when calling Plan.
+	PlanBody         []byte
 	InitResponse     *MockTerraformResponse
 	ValidateResponse *MockTerraformResponse
 	PlanResponse     *MockTerraformResponse
@@ -67,7 +69,7 @@ func (m *MockTerraformClient) Plan(ctx context.Context, stdout, stderr io.Writer
 		stdout.Write([]byte(m.PlanResponse.Stdout))
 		stderr.Write([]byte(m.PlanResponse.Stderr))
 
-		if err := os.WriteFile(*opts.Out, []byte("this is a plan binary"), ownerReadWritePerms); err != nil {
+		if err := os.WriteFile(*opts.Out, m.PlanBody, ownerReadWritePerms); err != nil {
 			return 1, fmt.Errorf("failed to write plan file: %w", err)
 		}
 


### PR DESCRIPTION
This change writes the plan to a JSON file, in addition to the existing plan binary, so that it can be parsed by other commands (specifically the `policy` command). 

Added a new `output-dir` flag to specify the directory that plan binary and json files are written to. This is helpful for writing to temp directories in unit tests, so that any written files are cleaned up after running unit tests.
