### PR TITLE
fix: cleanup plan command

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,7 +39,6 @@ env:
   GUARDIAN_WIF_SERVICE_ACCOUNT: 'guardian-automation-bot@ghg-guardian-ci-i-6ad437.iam.gserviceaccount.com'
   GUARDIAN_BUCKET_NAME: 'guardian-ci-i-guardian-state-c79e1f4759'
   GUARDIAN_TERRAFORM_VERSION: '1.7.1'
-  TF_IN_AUTOMATION: 'true'
 
 jobs:
   build:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,6 +39,7 @@ env:
   GUARDIAN_WIF_SERVICE_ACCOUNT: 'guardian-automation-bot@ghg-guardian-ci-i-6ad437.iam.gserviceaccount.com'
   GUARDIAN_BUCKET_NAME: 'guardian-ci-i-guardian-state-c79e1f4759'
   GUARDIAN_TERRAFORM_VERSION: '1.7.1'
+  TF_IN_AUTOMATION: 'true'
 
 jobs:
   build:

--- a/pkg/child/child.go
+++ b/pkg/child/child.go
@@ -25,17 +25,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/abcxyz/guardian/internal/version"
 	"github.com/abcxyz/pkg/logging"
 )
-
-// overrideEnvVars are the environment variables to inject into the child
-// process, no matter what the user configured. These take precedence over all
-// other configurables.
-var overrideEnvVars = []string{
-	"GOOGLE_TERRAFORM_USERAGENT_EXTENSION=" + version.UserAgent,
-	"TF_APPEND_USER_AGENT=" + version.UserAgent,
-}
 
 // RunConfig are the inputs for a run operation.
 type RunConfig struct {
@@ -50,6 +41,11 @@ type RunConfig struct {
 	// [filepath.Match].
 	AllowedEnvKeys []string
 	DeniedEnvKeys  []string
+
+	// OverrideEnvVars are the environment variables to inject into the child
+	// process, no matter what the user configured. These take precedence over all
+	// other configurables.
+	OverrideEnvVars []string
 }
 
 // Run executes a child process with the provided arguments.
@@ -87,7 +83,7 @@ func Run(ctx context.Context, cfg *RunConfig) (int, error) {
 	cmd.Args = append(cmd.Args, cfg.Args...)
 
 	// Compute and set a custom environment for the child process.
-	env := environ(os.Environ(), cfg.AllowedEnvKeys, cfg.DeniedEnvKeys, overrideEnvVars)
+	env := environ(os.Environ(), cfg.AllowedEnvKeys, cfg.DeniedEnvKeys, cfg.OverrideEnvVars)
 	logger.DebugContext(ctx, "computed environment", "env", env)
 	cmd.Env = env
 

--- a/pkg/commands/apply/apply.go
+++ b/pkg/commands/apply/apply.go
@@ -163,7 +163,8 @@ func (c *ApplyCommand) Run(ctx context.Context, args []string) error {
 	}
 	c.childPath = childPath
 
-	c.terraformClient = terraform.NewTerraformClient(c.directory)
+	tfEnvVars := []string{"TF_IN_AUTOMATION=true"}
+	c.terraformClient = terraform.NewTerraformClient(c.directory, tfEnvVars)
 
 	storagePrefix, err := c.platformConfig.StoragePrefix()
 	if err != nil {

--- a/pkg/commands/apply/apply.go
+++ b/pkg/commands/apply/apply.go
@@ -310,10 +310,7 @@ func (c *ApplyCommand) terraformApply(ctx context.Context) (*RunResult, error) {
 
 	stderr.Reset()
 
-	util.Headerf(c.Stdout(), "Formatting output")
-	githubOutput := terraform.FormatOutputForGitHubDiff(stdout.String())
-
-	return &RunResult{commentDetails: githubOutput}, nil
+	return &RunResult{commentDetails: stdout.String()}, nil
 }
 
 // downloadGuardianPlan downloads the Guardian plan binary from the configured Guardian storage bucket

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -191,7 +191,8 @@ func (c *PlanCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to get absolute path for output directory: %w", err)
 	}
 
-	c.terraformClient = terraform.NewTerraformClient(c.directory)
+	tfEnvVars := []string{"TF_IN_AUTOMATION=true"}
+	c.terraformClient = terraform.NewTerraformClient(c.directory, tfEnvVars)
 
 	storagePrefix, err := c.platformConfig.StoragePrefix()
 	if err != nil {
@@ -210,8 +211,6 @@ func (c *PlanCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to create reporter client: %w", err)
 	}
 	c.reporterClient = rc
-
-	os.Setenv("TF_IN_AUTOMATION", "true")
 
 	return c.Process(ctx)
 }

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -52,6 +52,9 @@ const (
 	OperationDestroy = "destroy"
 
 	ownerReadWritePerms = 0o600
+
+	planFilename     = "tfplan.binary"
+	planJSONFilename = "tfplan.json"
 )
 
 var _ cli.Command = (*PlanCommand)(nil)
@@ -65,11 +68,9 @@ type RunResult struct {
 type PlanCommand struct {
 	cli.BaseCommand
 
-	directory        string
-	childPath        string
-	planFilename     string
-	planJSONFilename string
-	storagePrefix    string
+	directory     string
+	childPath     string
+	storagePrefix string
 
 	platformConfig platform.Config
 
@@ -219,13 +220,6 @@ func (c *PlanCommand) Process(ctx context.Context) error {
 
 	util.Headerf(c.Stdout(), ("Starting Guardian Plan"))
 
-	if c.planFilename == "" {
-		c.planFilename = "tfplan.binary"
-	}
-	if c.planJSONFilename == "" {
-		c.planJSONFilename = "tfplan.json"
-	}
-
 	operation := "plan"
 	if c.flagDestroy {
 		operation = "plan (destroy)"
@@ -322,8 +316,14 @@ func (c *PlanCommand) terraformPlan(ctx context.Context) (*RunResult, error) {
 	var planExitCode int
 
 	util.Headerf(c.Stdout(), "Planning Terraform")
-	planAbsFilepath := path.Join(c.flagOutputDir, c.planFilename)
-	exitCode, err := c.terraformClient.Plan(ctx, multiStdout, multiStderr, &terraform.PlanOptions{
+
+	// create a separate writer for plan output
+	// this output will be sent back for reporting status
+	var planOut strings.Builder
+	multiPlanOut := io.MultiWriter(c.Stdout(), &planOut)
+
+	planAbsFilepath := path.Join(c.flagOutputDir, planFilename)
+	exitCode, err := c.terraformClient.Plan(ctx, multiPlanOut, multiStderr, &terraform.PlanOptions{
 		Out:              pointer.To(planAbsFilepath),
 		Input:            pointer.To(false),
 		NoColor:          pointer.To(true),
@@ -340,16 +340,18 @@ func (c *PlanCommand) terraformPlan(ctx context.Context) (*RunResult, error) {
 	if err != nil && !hasChanges {
 		commentDetails := stderr.String()
 		if commentDetails == "" {
-			commentDetails = stdout.String()
+			commentDetails = planOut.String()
 		}
 		return &RunResult{commentDetails: commentDetails}, fmt.Errorf("failed to plan: %w", err)
 	}
 
-	stdout.Reset()
 	stderr.Reset()
 
-	var jsonOut strings.Builder
 	util.Headerf(c.Stdout(), "Writing Plan to Local JSON File")
+
+	// we dont need to write the contents of the plan json to stdout,
+	// instead capture the output in memory for writing to file in output-dir
+	var jsonOut strings.Builder
 	if _, err = c.terraformClient.Show(ctx, &jsonOut, multiStderr, &terraform.ShowOptions{
 		File:    pointer.To(planAbsFilepath),
 		NoColor: pointer.To(true),
@@ -361,23 +363,11 @@ func (c *PlanCommand) terraformPlan(ctx context.Context) (*RunResult, error) {
 		}, fmt.Errorf("failed to terraform show: %w", err)
 	}
 
-	planJSONAbsFilepath := path.Join(c.flagOutputDir, c.planJSONFilename)
+	planJSONAbsFilepath := path.Join(c.flagOutputDir, planJSONFilename)
 	if err := os.WriteFile(planJSONAbsFilepath, []byte(jsonOut.String()), ownerReadWritePerms); err != nil {
 		return &RunResult{hasChanges: hasChanges}, fmt.Errorf("failed to write plan to json file: %w", err)
 	}
 	c.Outf("Plan JSON file path: %s", planJSONAbsFilepath)
-	stderr.Reset()
-
-	util.Headerf(c.Stdout(), "Formatting output")
-	if _, err := c.terraformClient.Show(ctx, multiStdout, multiStderr, &terraform.ShowOptions{
-		File:    pointer.To(planAbsFilepath),
-		NoColor: pointer.To(true),
-	}); err != nil {
-		return &RunResult{
-			commentDetails: stderr.String(),
-			hasChanges:     hasChanges,
-		}, fmt.Errorf("failed to terraform show: %w", err)
-	}
 
 	stderr.Reset()
 
@@ -388,7 +378,7 @@ func (c *PlanCommand) terraformPlan(ctx context.Context) (*RunResult, error) {
 
 	util.Headerf(c.Stdout(), "Saving Plan File")
 
-	planFileLocalPath := path.Join(c.childPath, c.planFilename)
+	planFileLocalPath := path.Join(c.childPath, planFilename)
 	if err := c.saveGuardianPlan(ctx, planFileLocalPath, planData, planExitCode); err != nil {
 		return &RunResult{hasChanges: hasChanges}, fmt.Errorf("failed to upload plan data: %w", err)
 	}
@@ -396,7 +386,7 @@ func (c *PlanCommand) terraformPlan(ctx context.Context) (*RunResult, error) {
 	stderr.Reset()
 
 	return &RunResult{
-		commentDetails: stdout.String(),
+		commentDetails: planOut.String(),
 		hasChanges:     hasChanges,
 	}, nil
 }

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -211,6 +211,8 @@ func (c *PlanCommand) Run(ctx context.Context, args []string) error {
 	}
 	c.reporterClient = rc
 
+	os.Setenv("TF_IN_AUTOMATION", "true")
+
 	return c.Process(ctx)
 }
 

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -146,14 +146,14 @@ func TestPlan_Process(t *testing.T) {
 			expReporterClientReqs: []*reporter.Request{
 				{
 					Name:   "Status",
-					Params: []any{reporter.StatusSuccess, &reporter.StatusParams{HasDiff: true, Details: "terraform show success with diff", Dir: "testdata", Operation: "plan"}},
+					Params: []any{reporter.StatusSuccess, &reporter.StatusParams{HasDiff: true, Details: "terraform plan success with diff", Dir: "testdata", Operation: "plan"}},
 				},
 			},
 			expStorageClientReqs: []*storage.Request{
 				{
 					Name: "CreateObject",
 					Params: []any{
-						"testdata/test-tfplan.binary",
+						"testdata/tfplan.binary",
 						"this is a plan binary",
 					},
 				},
@@ -170,14 +170,14 @@ func TestPlan_Process(t *testing.T) {
 			expReporterClientReqs: []*reporter.Request{
 				{
 					Name:   "Status",
-					Params: []any{reporter.StatusSuccess, &reporter.StatusParams{HasDiff: true, Details: "terraform show success with diff", Dir: "testdata", Operation: "plan (destroy)"}},
+					Params: []any{reporter.StatusSuccess, &reporter.StatusParams{HasDiff: true, Details: "terraform plan success with diff", Dir: "testdata", Operation: "plan (destroy)"}},
 				},
 			},
 			expStorageClientReqs: []*storage.Request{
 				{
 					Name: "CreateObject",
 					Params: []any{
-						"testdata/test-tfplan.binary",
+						"testdata/tfplan.binary",
 						"this is a plan binary",
 					},
 				},
@@ -200,7 +200,7 @@ func TestPlan_Process(t *testing.T) {
 				{
 					Name: "CreateObject",
 					Params: []any{
-						"testdata/test-tfplan.binary",
+						"testdata/tfplan.binary",
 						"this is a plan binary",
 					},
 				},
@@ -237,7 +237,6 @@ func TestPlan_Process(t *testing.T) {
 			c := &PlanCommand{
 				directory:                tc.directory,
 				childPath:                tc.directory,
-				planFilename:             "test-tfplan.binary",
 				storagePrefix:            tc.storagePrefix,
 				flagOutputDir:            t.TempDir(),
 				flagDestroy:              tc.flagDestroy,

--- a/pkg/commands/run/run.go
+++ b/pkg/commands/run/run.go
@@ -122,7 +122,8 @@ func (c *RunCommand) Run(ctx context.Context, args []string) error {
 	}
 	c.childPath = childPath
 
-	c.terraformClient = terraform.NewTerraformClient(c.directory)
+	tfEnvVars := []string{"TF_IN_AUTOMATION=true"}
+	c.terraformClient = terraform.NewTerraformClient(c.directory, tfEnvVars)
 
 	return c.Process(ctx)
 }

--- a/pkg/terraform/run.go
+++ b/pkg/terraform/run.go
@@ -26,7 +26,7 @@ import (
 // overrideEnvVars are the environment variables to inject into the Terraform
 // child process, no matter what the user configured. These take precedence
 // over all other configurables.
-var overrideEnvVars = []string{
+var defaultOverrideEnvVars = []string{
 	"GOOGLE_TERRAFORM_USERAGENT_EXTENSION=" + version.UserAgent,
 	"TF_APPEND_USER_AGENT=" + version.UserAgent,
 }
@@ -39,7 +39,7 @@ func (t *TerraformClient) Run(ctx context.Context, stdout, stderr io.Writer, sub
 		runArgs = append(runArgs, args...)
 	}
 
-	overrideEnvVars = slices.Concat(nil, t.envVars, overrideEnvVars)
+	overrideEnvVars := slices.Concat(nil, t.envVars, defaultOverrideEnvVars)
 
 	return child.Run(ctx, &child.RunConfig{ //nolint:wrapcheck
 		Stdout:          stdout,

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -98,6 +98,7 @@ type Terraform interface {
 // TerraformClient implements the Terraform interface.
 type TerraformClient struct {
 	workingDir string
+	envVars    []string
 }
 
 // TerraformResponse is the response from running a terraform command.
@@ -132,9 +133,10 @@ type ModuleUsageGraph struct {
 }
 
 // NewTerraformClient creates a new Terraform client.
-func NewTerraformClient(workingDir string) *TerraformClient {
+func NewTerraformClient(workingDir string, envVars []string) *TerraformClient {
 	return &TerraformClient{
 		workingDir: workingDir,
+		envVars:    envVars,
 	}
 }
 


### PR DESCRIPTION
Also removed the override env vars from the child process to being passed in by the caller.

/cc @gjonathanhong 