### PR TITLE
Add policy fetch-data command

### DIFF
--- a/cmd/guardian/main.go
+++ b/cmd/guardian/main.go
@@ -111,6 +111,9 @@ var rootCmd = func() cli.Command {
 						"enforce": func() cli.Command {
 							return &policy.EnforceCommand{}
 						},
+						"fetch-data": func() cli.Command {
+							return &policy.FetchDataCommand{}
+						},
 					},
 				}
 			},

--- a/pkg/commands/policy/fetch_data.go
+++ b/pkg/commands/policy/fetch_data.go
@@ -1,0 +1,85 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/abcxyz/guardian/pkg/platform"
+	"github.com/abcxyz/pkg/cli"
+)
+
+var _ cli.Command = (*FetchDataCommand)(nil)
+
+type FetchDataCommand struct {
+	cli.BaseCommand
+
+	platformConfig platform.Config
+	platform       platform.Platform
+}
+
+// Desc implements cli.Command.
+func (c *FetchDataCommand) Desc() string {
+	return "Fetch data used for policy evaluation"
+}
+
+// Help implements cli.Command.
+func (c *FetchDataCommand) Help() string {
+	return `
+Usage: {{ COMMAND }} [options]
+
+  Fetch and aggregate data for the target platform to be used for policy
+  evaluation.
+`
+}
+
+// Flags returns the list of flags that are defined on the command.
+func (c *FetchDataCommand) Flags() *cli.FlagSet {
+	set := cli.NewFlagSet()
+	c.platformConfig.RegisterFlags(set)
+
+	return set
+}
+
+// Run implements cli.Command.
+func (c *FetchDataCommand) Run(ctx context.Context, args []string) error {
+	f := c.Flags()
+	if err := f.Parse(args); err != nil {
+		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+
+	platform, err := platform.NewPlatform(ctx, &c.platformConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create platform: %w", err)
+	}
+	c.platform = platform
+
+	return c.Process(ctx)
+}
+
+// Process handles the main logic for aggregating data for the target platform.
+func (c *FetchDataCommand) Process(ctx context.Context) error {
+	approvers, err := c.platform.GetLatestApprovers(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get latest approvers: %w", err)
+	}
+
+	if err = json.NewEncoder(c.Stdout()).Encode(approvers); err != nil {
+		return fmt.Errorf("failed to write json to output: %w", err)
+	}
+	return nil
+}

--- a/pkg/commands/policy/fetch_data.go
+++ b/pkg/commands/policy/fetch_data.go
@@ -25,6 +25,8 @@ import (
 
 var _ cli.Command = (*FetchDataCommand)(nil)
 
+// FetchDataCommand implements cli.Command. It fetches and aggregates data for
+// a target platform to be used for policy evaluation.
 type FetchDataCommand struct {
 	cli.BaseCommand
 
@@ -73,12 +75,12 @@ func (c *FetchDataCommand) Run(ctx context.Context, args []string) error {
 
 // Process handles the main logic for aggregating data for the target platform.
 func (c *FetchDataCommand) Process(ctx context.Context) error {
-	approvers, err := c.platform.GetLatestApprovers(ctx)
+	data, err := c.platform.GetPolicyData(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get latest approvers: %w", err)
+		return fmt.Errorf("failed to get policy data: %w", err)
 	}
 
-	if err = json.NewEncoder(c.Stdout()).Encode(approvers); err != nil {
+	if err = json.NewEncoder(c.Stdout()).Encode(data); err != nil {
 		return fmt.Errorf("failed to write json to output: %w", err)
 	}
 	return nil

--- a/pkg/commands/policy/fetch_data_test.go
+++ b/pkg/commands/policy/fetch_data_test.go
@@ -1,0 +1,85 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/abcxyz/guardian/pkg/platform"
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/testutil"
+)
+
+func TestFetchData_Process(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
+
+	cases := []struct {
+		name                 string
+		getLatestApproverErr error
+		wantErr              string
+		teams                []string
+		users                []string
+		wantOut              string
+	}{
+		{
+			name:    "prints_teams_and_users",
+			teams:   []string{"team1", "team2"},
+			users:   []string{"user1", "user2"},
+			wantOut: `{"users":["user1","user2"],"teams":["team1","team2"]}`,
+		},
+		{
+			name:    "prints_no_approvers",
+			teams:   []string{},
+			users:   []string{},
+			wantOut: `{"users":[],"teams":[]}`,
+		},
+		{
+			name:                 "fails_with_error",
+			getLatestApproverErr: fmt.Errorf("failed to get latest approvers"),
+			wantErr:              "failed to get latest approvers",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &FetchDataCommand{
+				platform: &platform.MockPlatform{
+					GetLatestApproversErr: tc.getLatestApproverErr,
+					TeamApprovers:         tc.teams,
+					UserApprovers:         tc.users,
+				},
+			}
+			_, stdout, _ := c.Pipe()
+
+			err := c.Process(ctx)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Errorf("unexpected result; (-got,+want): %s", diff)
+			}
+
+			if got, want := strings.TrimSpace(stdout.String()), strings.TrimSpace(tc.wantOut); !strings.Contains(got, want) {
+				t.Errorf("expected stdout\n\n%s\n\nto contain\n\n%s\n\n", got, want)
+			}
+		})
+	}
+}

--- a/pkg/commands/policy/fetch_data_test.go
+++ b/pkg/commands/policy/fetch_data_test.go
@@ -42,13 +42,13 @@ func TestFetchData_Process(t *testing.T) {
 			name:    "prints_teams_and_users",
 			teams:   []string{"team1", "team2"},
 			users:   []string{"user1", "user2"},
-			wantOut: `{"users":["user1","user2"],"teams":["team1","team2"]}`,
+			wantOut: `{"mock":{"approvers":{"users":["user1","user2"],"teams":["team1","team2"]}}}`,
 		},
 		{
 			name:    "prints_no_approvers",
 			teams:   []string{},
 			users:   []string{},
-			wantOut: `{"users":[],"teams":[]}`,
+			wantOut: `{"mock":{"approvers":{"users":[],"teams":[]}}}`,
 		},
 		{
 			name:                 "fails_with_error",

--- a/pkg/commands/policy/fetch_data_test.go
+++ b/pkg/commands/policy/fetch_data_test.go
@@ -22,10 +22,11 @@ import (
 	"path"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/abcxyz/guardian/pkg/platform"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestFetchData_Process(t *testing.T) {

--- a/pkg/commands/policy/flags.go
+++ b/pkg/commands/policy/flags.go
@@ -42,3 +42,18 @@ func (e *EnforceFlags) Register(set *cli.FlagSet) {
 		return merr
 	})
 }
+
+type FetchDataFlags struct {
+	flagOutputDir string
+}
+
+func (fd *FetchDataFlags) Register(set *cli.FlagSet) {
+	f := set.NewSection("FETCH-DATA OPTIONS")
+
+	f.StringVar(&cli.StringVar{
+		Name:    "output-dir",
+		Example: "example/dir",
+		Target:  &fd.flagOutputDir,
+		Usage:   "Write the policy data JSON file to a target local directory.",
+	})
+}

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -32,11 +32,8 @@ func (l *Local) AssignReviewers(ctx context.Context, inputs *AssignReviewersInpu
 }
 
 // GetLatestApprovers returns an empty result.
-func (l *Local) GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error) {
-	return &GetLatestApproversResult{
-		Users: []string{},
-		Teams: []string{},
-	}, nil
+func (l *Local) GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error) {
+	return &GetPolicyDataResult{}, nil
 }
 
 // ModifierContent is a no-op.

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -31,7 +31,7 @@ func (l *Local) AssignReviewers(ctx context.Context, inputs *AssignReviewersInpu
 	return &AssignReviewersResult{}, nil
 }
 
-// GetLatestApprovers returns an empty result.
+// GetPolicyData returns an empty result.
 func (l *Local) GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error) {
 	return &GetPolicyDataResult{}, nil
 }

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -31,6 +31,11 @@ func (l *Local) AssignReviewers(ctx context.Context, inputs *AssignReviewersInpu
 	return &AssignReviewersResult{}, nil
 }
 
+// GetLatestApprovers returns an empty result.
+func (l *Local) GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error) {
+	return &GetLatestApproversResult{}, nil
+}
+
 // GetPolicyData returns an empty result.
 func (l *Local) GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error) {
 	return &GetPolicyDataResult{}, nil

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -33,7 +33,10 @@ func (l *Local) AssignReviewers(ctx context.Context, inputs *AssignReviewersInpu
 
 // GetLatestApprovers returns an empty result.
 func (l *Local) GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error) {
-	return &GetLatestApproversResult{}, nil
+	return &GetLatestApproversResult{
+		Users: []string{},
+		Teams: []string{},
+	}, nil
 }
 
 // ModifierContent is a no-op.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -57,11 +57,18 @@ type AssignReviewersResult struct {
 	Teams []string
 }
 
-// GetLatestApproversResult contains the reviewers whose latest review is an
+// ApproversData contains the reviewers whose latest review is an
 // approval.
-type GetLatestApproversResult struct {
+type ApproversData struct {
 	Users []string `json:"users"`
 	Teams []string `json:"teams"`
+}
+
+// GetPolicyDataResult contains the required data for policy evaluation, by
+// platform.
+type GetPolicyDataResult struct {
+	GitHub *GitHubPolicyData `json:"github,omitempty"`
+	Mock   *MockPolicyData   `json:"mock,omitempty"`
 }
 
 // Platform defines the minimum interface for a code review platform.
@@ -69,9 +76,8 @@ type Platform interface {
 	// AssignReviewers assigns principals to review a change request.
 	AssignReviewers(ctx context.Context, inputs *AssignReviewersInput) (*AssignReviewersResult, error)
 
-	// GetLatestApprovers retrieves the reviewers whose latest review is an
-	// approval.
-	GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error)
+	// GetPolicyData retrieves the required data for policy evaluation.
+	GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error)
 
 	// ModifierContent returns the modifier content for parsing modifier flags.
 	ModifierContent(ctx context.Context) (string, error)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -60,8 +60,8 @@ type AssignReviewersResult struct {
 // GetLatestApproversResult contains the reviewers whose latest review is an
 // approval.
 type GetLatestApproversResult struct {
-	Users []string
-	Teams []string
+	Users []string `json:"users"`
+	Teams []string `json:"teams"`
 }
 
 // Platform defines the minimum interface for a code review platform.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -57,9 +57,9 @@ type AssignReviewersResult struct {
 	Teams []string
 }
 
-// ApproversData contains the reviewers whose latest review is an
+// GetLatestApproversResult contains the reviewers whose latest review is an
 // approval.
-type ApproversData struct {
+type GetLatestApproversResult struct {
 	Users []string `json:"users"`
 	Teams []string `json:"teams"`
 }
@@ -75,6 +75,10 @@ type GetPolicyDataResult struct {
 type Platform interface {
 	// AssignReviewers assigns principals to review a change request.
 	AssignReviewers(ctx context.Context, inputs *AssignReviewersInput) (*AssignReviewersResult, error)
+
+	// GetLatestApprovers retrieves the reviewers whose latest review is an
+	// approval.
+	GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error)
 
 	// GetPolicyData retrieves the required data for policy evaluation.
 	GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error)

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -57,7 +57,20 @@ func (m *MockPlatform) AssignReviewers(ctx context.Context, input *AssignReviewe
 }
 
 type MockPolicyData struct {
-	Approvers *ApproversData `json:"approvers"`
+	Approvers *GetLatestApproversResult `json:"approvers"`
+}
+
+func (m *MockPlatform) GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error) {
+	m.reqMu.Lock()
+	defer m.reqMu.Unlock()
+	m.Reqs = append(m.Reqs, &Request{
+		Name: "GetLatestApprovers",
+	})
+
+	return &GetLatestApproversResult{
+		Teams: m.TeamApprovers,
+		Users: m.UserApprovers,
+	}, nil
 }
 
 func (m *MockPlatform) GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error) {
@@ -73,7 +86,7 @@ func (m *MockPlatform) GetPolicyData(ctx context.Context) (*GetPolicyDataResult,
 
 	return &GetPolicyDataResult{
 		Mock: &MockPolicyData{
-			Approvers: &ApproversData{
+			Approvers: &GetLatestApproversResult{
 				Teams: m.TeamApprovers,
 				Users: m.UserApprovers,
 			},

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -56,7 +56,11 @@ func (m *MockPlatform) AssignReviewers(ctx context.Context, input *AssignReviewe
 	}, nil
 }
 
-func (m *MockPlatform) GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error) {
+type MockPolicyData struct {
+	Approvers *ApproversData `json:"approvers"`
+}
+
+func (m *MockPlatform) GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error) {
 	m.reqMu.Lock()
 	defer m.reqMu.Unlock()
 	m.Reqs = append(m.Reqs, &Request{
@@ -67,9 +71,13 @@ func (m *MockPlatform) GetLatestApprovers(ctx context.Context) (*GetLatestApprov
 		return nil, m.GetLatestApproversErr
 	}
 
-	return &GetLatestApproversResult{
-		Teams: m.TeamApprovers,
-		Users: m.UserApprovers,
+	return &GetPolicyDataResult{
+		Mock: &MockPolicyData{
+			Approvers: &ApproversData{
+				Teams: m.TeamApprovers,
+				Users: m.UserApprovers,
+			},
+		},
 	}, nil
 }
 

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -30,10 +30,11 @@ type MockPlatform struct {
 	reqMu sync.Mutex
 	Reqs  []*Request
 
-	AssignReviewersErr  error
-	ModifierContentResp string
-	TeamApprovers       []string
-	UserApprovers       []string
+	AssignReviewersErr    error
+	GetLatestApproversErr error
+	ModifierContentResp   string
+	TeamApprovers         []string
+	UserApprovers         []string
 }
 
 func (m *MockPlatform) AssignReviewers(ctx context.Context, input *AssignReviewersInput) (*AssignReviewersResult, error) {
@@ -60,6 +61,10 @@ func (m *MockPlatform) GetLatestApprovers(ctx context.Context) (*GetLatestApprov
 	m.Reqs = append(m.Reqs, &Request{
 		Name: "GetLatestApprovers",
 	})
+
+	if m.GetLatestApproversErr != nil {
+		return nil, m.GetLatestApproversErr
+	}
 
 	return &GetLatestApproversResult{
 		Teams: m.TeamApprovers,

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -33,7 +33,7 @@ type MockPlatform struct {
 	AssignReviewersErr    error
 	GetLatestApproversErr error
 	ModifierContentResp   string
-	ModifierContentErr  error
+	ModifierContentErr    error
 	TeamApprovers         []string
 	UserApprovers         []string
 }

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -30,12 +30,12 @@ type MockPlatform struct {
 	reqMu sync.Mutex
 	Reqs  []*Request
 
-	AssignReviewersErr    error
-	GetLatestApproversErr error
-	ModifierContentResp   string
-	ModifierContentErr    error
-	TeamApprovers         []string
-	UserApprovers         []string
+	AssignReviewersErr  error
+	GetPolicyDataErr    error
+	ModifierContentResp string
+	ModifierContentErr  error
+	TeamApprovers       []string
+	UserApprovers       []string
 }
 
 func (m *MockPlatform) AssignReviewers(ctx context.Context, input *AssignReviewersInput) (*AssignReviewersResult, error) {
@@ -80,8 +80,8 @@ func (m *MockPlatform) GetPolicyData(ctx context.Context) (*GetPolicyDataResult,
 		Name: "GetLatestApprovers",
 	})
 
-	if m.GetLatestApproversErr != nil {
-		return nil, m.GetLatestApproversErr
+	if m.GetPolicyDataErr != nil {
+		return nil, m.GetPolicyDataErr
 	}
 
 	return &GetPolicyDataResult{


### PR DESCRIPTION
This command fetches data used as context for policy evaluation and writes it to a local file named `guardian_policy_context.json`. It currently only aggregates the pull request approvers data.