### PR TITLE
fix: destroy from modifiers

### DIFF
--- a/pkg/modifiers/modifiers.go
+++ b/pkg/modifiers/modifiers.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	MetaKeyGuardianDestroy = "GUARDIAN_DESTROY"
-	MetaValueAll           = "all"
 )
 
 var (

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	Reporter string
 
 	GitHub gh.Config
+	Local  localConfig
 }
 
 func (c *Config) RegisterFlags(set *cli.FlagSet) {
@@ -64,6 +65,7 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 
 	// leave last to put help under platform options
 	c.GitHub.RegisterFlags(set)
+	c.Local.RegisterFlags(set)
 
 	set.AfterParse(func(merr error) error {
 		c.Type = strings.ToLower(strings.TrimSpace(c.Type))

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -14,16 +14,37 @@
 
 package platform
 
-import "context"
+import (
+	"context"
+
+	"github.com/abcxyz/pkg/cli"
+)
 
 var _ Platform = (*Local)(nil)
 
 // Local implements the Platform interface for running Guardian locally.
-type Local struct{}
+type Local struct {
+	cfg *localConfig
+}
+
+type localConfig struct {
+	LocalModifierContent string
+}
+
+func (l *localConfig) RegisterFlags(set *cli.FlagSet) {
+	f := set.NewSection("LOCAL OPTIONS")
+
+	f.StringVar(&cli.StringVar{
+		Name:    "local-modifier-content",
+		Target:  &l.LocalModifierContent,
+		Example: "GUARDIAN_DESTROY=terraform/target/directory",
+		Usage:   "The modifier content to parse Guardian modifiers from.",
+	})
+}
 
 // NewLocal creates a new Local instance.
-func NewLocal(ctx context.Context) *Local {
-	return &Local{}
+func NewLocal(ctx context.Context, cfg *localConfig) *Local {
+	return &Local{cfg: cfg}
 }
 
 // AssignReviewers is a no-op.
@@ -43,7 +64,7 @@ func (l *Local) GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error)
 
 // ModifierContent is a no-op.
 func (l *Local) ModifierContent(ctx context.Context) (string, error) {
-	return "", nil
+	return l.cfg.LocalModifierContent, nil
 }
 
 // StoragePrefix returns an empty string for the local platform type.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -93,7 +93,7 @@ type Platform interface {
 // NewPlatform creates a new platform based on the provided type.
 func NewPlatform(ctx context.Context, cfg *Config) (Platform, error) {
 	if strings.EqualFold(cfg.Type, TypeLocal) {
-		return NewLocal(ctx), nil
+		return NewLocal(ctx, &cfg.Local), nil
 	}
 
 	if strings.EqualFold(cfg.Type, TypeGitHub) {

--- a/pkg/reporter/github_reporter.go
+++ b/pkg/reporter/github_reporter.go
@@ -288,24 +288,15 @@ func (g *GitHubReporter) entrypointsSummaryMessage(p *EntrypointsSummaryParams) 
 		fmt.Fprintf(&msg, "\n\n**%s**\n%s", "Destroy", strings.Join(p.DestroyDirs, "\n"))
 	}
 
-	if len(p.AbandonedDirs) > 0 {
-		fmt.Fprintf(&msg, "\n\n**%s**\n%s", "Abandon", strings.Join(p.AbandonedDirs, "\n"))
-		abandonedDirsNote := "Abandoned directories are removed from source control without modification.\n" +
-			"\n" +
-			"To delete the resources, add one or more modifier comments to the pull request body instructing Guardian to destroy the directory.\n" +
-			"\n" +
-			"```\n" +
-			"GUARDIAN_DESTROY=path/to/directory\n" +
-			"```\n" +
-			"\n" +
-			"To delete all detected directories, use the special keyword `all`:\n" +
-			"\n" +
-			"```\n" +
-			"GUARDIAN_DESTROY=all\n" +
-			"```"
+	helpNote := "Abandoned directories are removed from source control without modification.\n" +
+		"\n" +
+		"To destroy an entire directory, add one or more modifier comments to the pull request body instructing Guardian to destroy the directory.\n" +
+		"\n" +
+		"```\n" +
+		"GUARDIAN_DESTROY=path/to/directory\n" +
+		"```"
 
-		fmt.Fprintf(&msg, "\n\n%s", g.markdownZippy("Help", abandonedDirsNote))
-	}
+	fmt.Fprintf(&msg, "\n\n%s", g.markdownZippy("Help", helpNote))
 
 	return msg, nil
 }

--- a/pkg/reporter/github_reporter_test.go
+++ b/pkg/reporter/github_reporter_test.go
@@ -182,24 +182,15 @@ func TestGitHubReporterEntrypointsSummary(t *testing.T) {
 							"**Destroy**\n" +
 							"destroy\n" +
 							"\n" +
-							"**Abandon**\n" +
-							"abandoned" +
-							"\n\n" +
 							"<details>\n" +
 							"<summary>Help</summary>\n" +
 							"\n" +
 							"Abandoned directories are removed from source control without modification.\n" +
 							"\n" +
-							"To delete the resources, add one or more modifier comments to the pull request body instructing Guardian to destroy the directory.\n" +
+							"To destroy an entire directory, add one or more modifier comments to the pull request body instructing Guardian to destroy the directory.\n" +
 							"\n" +
 							"```\n" +
 							"GUARDIAN_DESTROY=path/to/directory\n" +
-							"```\n" +
-							"\n" +
-							"To delete all detected directories, use the special keyword `all`:\n" +
-							"\n" +
-							"```\n" +
-							"GUARDIAN_DESTROY=all\n" +
 							"```\n" +
 							"</details>",
 					},
@@ -232,24 +223,15 @@ func TestGitHubReporterEntrypointsSummary(t *testing.T) {
 							"**Destroy**\n" +
 							"destroy\n" +
 							"\n" +
-							"**Abandon**\n" +
-							"abandoned" +
-							"\n\n" +
 							"<details>\n" +
 							"<summary>Help</summary>\n" +
 							"\n" +
 							"Abandoned directories are removed from source control without modification.\n" +
 							"\n" +
-							"To delete the resources, add one or more modifier comments to the pull request body instructing Guardian to destroy the directory.\n" +
+							"To destroy an entire directory, add one or more modifier comments to the pull request body instructing Guardian to destroy the directory.\n" +
 							"\n" +
 							"```\n" +
 							"GUARDIAN_DESTROY=path/to/directory\n" +
-							"```\n" +
-							"\n" +
-							"To delete all detected directories, use the special keyword `all`:\n" +
-							"\n" +
-							"```\n" +
-							"GUARDIAN_DESTROY=all\n" +
 							"```\n" +
 							"</details>",
 					},


### PR DESCRIPTION
Guardian shouldn't care if a directory was removed for destroy, there could be a case where we want to just destroy the resources and then run an apply for a clean slate.

Rather the modifier content will be used to determine a destroy phase using the base branch from a pull request and `HEAD~1` from `main` for apply on push.