### PR TITLE
refactor: generalize status message helpers for Reporter types

### DIFF
--- a/pkg/reporter/github_reporter.go
+++ b/pkg/reporter/github_reporter.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 
 	gh "github.com/google/go-github/v53/github"
@@ -31,18 +30,6 @@ var _ Reporter = (*GitHubReporter)(nil)
 
 const (
 	githubMaxCommentLength = 65536
-)
-
-var (
-	tildeChanged = regexp.MustCompile(
-		"(?m)" + // enable multi-line mode
-			"^([\t ]*)" + // only match tilde at start of line, can lead with tabs or spaces
-			"([~])") // tilde represents changes and needs switched to exclamation for git diff
-
-	swapLeadingWhitespace = regexp.MustCompile(
-		"(?m)" + // enable multi-line mode
-			"^([\t ]*)" + // only match tilde at start of line, can lead with tabs or spaces
-			`((\-(\/\+)*)|(\+(\/\-)*)|(!))`) // match characters to swap whitespace for git diff (+, +/-, -, -/+, !)
 )
 
 // GitHubReporter implements the reporter interface for writing GitHub comments.

--- a/pkg/reporter/github_reporter.go
+++ b/pkg/reporter/github_reporter.go
@@ -141,7 +141,7 @@ func (g *GitHubReporter) Status(ctx context.Context, st Status, p *StatusParams)
 
 // EntrypointsSummary implements the reporter EntrypointsSummary function by writing a GitHub comment.
 func (g *GitHubReporter) EntrypointsSummary(ctx context.Context, p *EntrypointsSummaryParams) error {
-	msg, err := g.entrypointsSummaryMessage(p)
+	msg, err := entrypointsSummaryMessage(p, g.logURL)
 	if err != nil {
 		return fmt.Errorf("failed to generate summary message: %w", err)
 	}
@@ -192,39 +192,4 @@ func (g *GitHubReporter) Clear(ctx context.Context) error {
 		}
 		listOpts.Page = response.Pagination.NextPage
 	}
-}
-
-// entrypointsSummaryMessage generates the entrypoints summary message based on the provided reporter values.
-func (g *GitHubReporter) entrypointsSummaryMessage(p *EntrypointsSummaryParams) (strings.Builder, error) {
-	var msg strings.Builder
-
-	fmt.Fprintf(&msg, "%s", commentPrefix)
-
-	if g.logURL != "" {
-		fmt.Fprintf(&msg, " [%s]", markdownURL("logs", g.logURL))
-	}
-
-	if p.Message != "" {
-		fmt.Fprintf(&msg, "\n\n%s", p.Message)
-	}
-
-	if len(p.UpdateDirs) > 0 {
-		fmt.Fprintf(&msg, "\n\n**%s**\n%s", "Update", strings.Join(p.UpdateDirs, "\n"))
-	}
-
-	if len(p.DestroyDirs) > 0 {
-		fmt.Fprintf(&msg, "\n\n**%s**\n%s", "Destroy", strings.Join(p.DestroyDirs, "\n"))
-	}
-
-	helpNote := "Deleted directories are removed from source control without modification.\n" +
-		"\n" +
-		"To destroy an entire directory, add one or more modifier comments to the pull request body instructing Guardian to destroy the directory.\n" +
-		"\n" +
-		"```\n" +
-		"GUARDIAN_DESTROY=path/to/directory\n" +
-		"```"
-
-	fmt.Fprintf(&msg, "\n\n%s", markdownZippy("Help", helpNote))
-
-	return msg, nil
 }

--- a/pkg/reporter/github_reporter_test.go
+++ b/pkg/reporter/github_reporter_test.go
@@ -319,9 +319,9 @@ func TestGitHubReporterClearStatus(t *testing.T) {
 			gitHubClient := &github.MockGitHubClient{
 				ListIssueCommentResponse: &github.IssueCommentResponse{
 					Comments: []*github.IssueComment{
-						{ID: 1, Body: githubCommentPrefix + " guardian comment"},
+						{ID: 1, Body: commentPrefix + " guardian comment"},
 						{ID: 2, Body: "Not a guardian comment"},
-						{ID: 3, Body: githubCommentPrefix + " guardian comment"},
+						{ID: 3, Body: commentPrefix + " guardian comment"},
 					},
 				},
 				ListIssueCommentsErr: tc.listIssueCommentsErr,
@@ -416,12 +416,12 @@ first section !
     second section +
     second section ~
     second section !
-	
+
 - third section
 + third section
 ~ third section
 ! third section
-	
+
     - fourth section
     + fourth section
     -/+ fourth section
@@ -438,12 +438,12 @@ first section !
     second section +
     second section ~
     second section !
-	
+
 - third section
 + third section
 ! third section
 ! third section
-	
+
 -     fourth section
 +     fourth section
 -/+     fourth section
@@ -459,7 +459,7 @@ first section !
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			output := formatOutputForGitHubDiff(tc.content)
+			output := formatOutputForDiff(tc.content)
 			if got, want := strings.TrimSpace(output), strings.TrimSpace(tc.exp); got != want {
 				t.Errorf("expected\n\n%s\n\nto be\n\n%s\n\n", got, want)
 			}

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -218,3 +218,38 @@ func statusMessage(st Status, p *StatusParams, logURL string, maxCommentLength i
 
 	return msg, nil
 }
+
+// entrypointsSummaryMessage generates the entrypoints summary message based on the provided reporter values.
+func entrypointsSummaryMessage(p *EntrypointsSummaryParams, logURL string) (strings.Builder, error) {
+	var msg strings.Builder
+
+	fmt.Fprintf(&msg, "%s", commentPrefix)
+
+	if logURL != "" {
+		fmt.Fprintf(&msg, " [%s]", markdownURL("logs", logURL))
+	}
+
+	if p.Message != "" {
+		fmt.Fprintf(&msg, "\n\n%s", p.Message)
+	}
+
+	if len(p.UpdateDirs) > 0 {
+		fmt.Fprintf(&msg, "\n\n**%s**\n%s", "Update", strings.Join(p.UpdateDirs, "\n"))
+	}
+
+	if len(p.DestroyDirs) > 0 {
+		fmt.Fprintf(&msg, "\n\n**%s**\n%s", "Destroy", strings.Join(p.DestroyDirs, "\n"))
+	}
+
+	helpNote := "Deleted directories are removed from source control without modification.\n" +
+		"\n" +
+		"To destroy an entire directory, add one or more modifier comments to the pull request body instructing Guardian to destroy the directory.\n" +
+		"\n" +
+		"```\n" +
+		"GUARDIAN_DESTROY=path/to/directory\n" +
+		"```"
+
+	fmt.Fprintf(&msg, "\n\n%s", markdownZippy("Help", helpNote))
+
+	return msg, nil
+}

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -18,6 +18,7 @@ package reporter
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -141,6 +142,18 @@ func markdownZippy(title, body string) string {
 func markdownDiffZippy(title, body string) string {
 	return fmt.Sprintf("<details>\n<summary>%s</summary>\n\n```diff\n\n%s\n```\n</details>", title, body)
 }
+
+var (
+	tildeChanged = regexp.MustCompile(
+		"(?m)" + // enable multi-line mode
+			"^([\t ]*)" + // only match tilde at start of line, can lead with tabs or spaces
+			"([~])") // tilde represents changes and needs switched to exclamation for git diff
+
+	swapLeadingWhitespace = regexp.MustCompile(
+		"(?m)" + // enable multi-line mode
+			"^([\t ]*)" + // only match tilde at start of line, can lead with tabs or spaces
+			`((\-(\/\+)*)|(\+(\/\-)*)|(!))`) // match characters to swap whitespace for git diff (+, +/-, -, -/+, !)
+)
 
 // formatOutputForDiff formats the Terraform diff output for use with
 // diff markdown formatting.


### PR DESCRIPTION
This change moves helper methods and common types out from `github_reporter.go` to `reporter.go`. They were previously tied to the GitHubReporter type, but made more sense as common types/methods that shouldn't change between platforms. This will allow us to generate status messages that are consistent across different code review platforms, instead of reimplementing them each time.