### PR TITLE
Add FileReporter

### DIFF
--- a/pkg/reporter/file_reporter.go
+++ b/pkg/reporter/file_reporter.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package reporter
 
 import (

--- a/pkg/reporter/file_reporter.go
+++ b/pkg/reporter/file_reporter.go
@@ -51,7 +51,7 @@ func (f *FileReporter) Status(ctx context.Context, st Status, p *StatusParams) e
 		return fmt.Errorf("failed to write file")
 	}
 
-	logger.DebugContext(ctx, "wrote status comment to file", "statusFilename", statusFilename)
+	logger.DebugContext(ctx, "wrote status comment to file", "status_filename", statusFilename)
 	return nil
 }
 
@@ -68,7 +68,8 @@ func (f *FileReporter) EntrypointsSummary(ctx context.Context, params *Entrypoin
 		return fmt.Errorf("failed to write file")
 	}
 
-	logger.DebugContext(ctx, "wrote entrypoints summary to file", "entrypointsSummaryFilename", entrypointsSummaryFilename)
+	logger.DebugContext(ctx, "wrote entrypoints summary to file",
+		"entrypoints_summary_filename", entrypointsSummaryFilename)
 	return nil
 }
 

--- a/pkg/reporter/file_reporter.go
+++ b/pkg/reporter/file_reporter.go
@@ -48,7 +48,7 @@ func (f *FileReporter) Status(ctx context.Context, st Status, p *StatusParams) e
 	}
 
 	if err := os.WriteFile(statusFilename, []byte(msg.String()), ownerReadWritePerms); err != nil {
-		return fmt.Errorf("failed to write file")
+		return fmt.Errorf("failed to write status comment file: %w", err)
 	}
 
 	logger.DebugContext(ctx, "wrote status comment to file", "status_filename", statusFilename)
@@ -65,7 +65,7 @@ func (f *FileReporter) EntrypointsSummary(ctx context.Context, params *Entrypoin
 	}
 
 	if err := os.WriteFile(entrypointsSummaryFilename, []byte(msg.String()), ownerReadWritePerms); err != nil {
-		return fmt.Errorf("failed to write file")
+		return fmt.Errorf("failed to write entrypoints summary file: %w", err)
 	}
 
 	logger.DebugContext(ctx, "wrote entrypoints summary to file",

--- a/pkg/reporter/file_reporter.go
+++ b/pkg/reporter/file_reporter.go
@@ -1,0 +1,46 @@
+package reporter
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/abcxyz/pkg/logging"
+)
+
+var _ Reporter = (*FileReporter)(nil)
+
+const (
+	statusFilename      = "status.md"
+	ownerReadWritePerms = 0o600
+)
+
+type FileReporter struct{}
+
+func NewFileReporter() (*FileReporter, error) {
+	return &FileReporter{}, nil
+}
+
+func (f *FileReporter) Status(ctx context.Context, st Status, p *StatusParams) error {
+	logger := logging.FromContext(ctx)
+
+	msg, err := statusMessage(st, p, "", -1)
+	if err != nil {
+		return fmt.Errorf("failed to generate status message: %w", err)
+	}
+
+	if err := os.WriteFile(statusFilename, []byte(msg.String()), ownerReadWritePerms); err != nil {
+		return fmt.Errorf("failed to write file")
+	}
+
+	logger.DebugContext(ctx, "wrote status comment to file", "statusFilename", statusFilename)
+	return nil
+}
+
+func (f *FileReporter) EntrypointsSummary(ctx context.Context, params *EntrypointsSummaryParams) error {
+	return nil
+}
+
+func (f *FileReporter) Clear(ctx context.Context) error {
+	return nil
+}

--- a/pkg/reporter/file_reporter.go
+++ b/pkg/reporter/file_reporter.go
@@ -11,16 +11,20 @@ import (
 var _ Reporter = (*FileReporter)(nil)
 
 const (
-	statusFilename      = "status.md"
-	ownerReadWritePerms = 0o600
+	statusFilename             = "status_comment.md"
+	entrypointsSummaryFilename = "entrypoints_summary.md"
+	ownerReadWritePerms        = 0o600
 )
 
+// FileReporter implements the reporter interface for writing comments to files.
 type FileReporter struct{}
 
+// NewFileReporter creates a new FileReporter.
 func NewFileReporter() (*FileReporter, error) {
 	return &FileReporter{}, nil
 }
 
+// Status implements the reporter Status function by writing the comment to a file.
 func (f *FileReporter) Status(ctx context.Context, st Status, p *StatusParams) error {
 	logger := logging.FromContext(ctx)
 
@@ -37,10 +41,25 @@ func (f *FileReporter) Status(ctx context.Context, st Status, p *StatusParams) e
 	return nil
 }
 
+// EntrypointsSummary implements the reporter EntrypointsSummary function by writing the comment to a file.
 func (f *FileReporter) EntrypointsSummary(ctx context.Context, params *EntrypointsSummaryParams) error {
+	logger := logging.FromContext(ctx)
+
+	msg, err := entrypointsSummaryMessage(params, "")
+	if err != nil {
+		return fmt.Errorf("failed to generate entrypoints summary message: %w", err)
+	}
+
+	if err := os.WriteFile(entrypointsSummaryFilename, []byte(msg.String()), ownerReadWritePerms); err != nil {
+		return fmt.Errorf("failed to write file")
+	}
+
+	logger.DebugContext(ctx, "wrote entrypoints summary to file", "entrypointsSummaryFilename", entrypointsSummaryFilename)
 	return nil
 }
 
+// Clear is a no-op because workflow runners will cleanup the files at the end
+// of execution.
 func (f *FileReporter) Clear(ctx context.Context) error {
 	return nil
 }

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -28,6 +28,7 @@ import (
 const (
 	TypeNone   string = "none"
 	TypeGitHub string = "github"
+	TypeFile   string = "file"
 )
 
 // SortedReporterTypes are the sorted Reporter types for printing messages and prediction.
@@ -94,6 +95,10 @@ type Config struct {
 func NewReporter(ctx context.Context, t string, c *Config) (Reporter, error) {
 	if strings.EqualFold(t, TypeNone) {
 		return NewNoopReporter(ctx)
+	}
+
+	if strings.EqualFold(t, TypeFile) {
+		return NewFileReporter()
 	}
 
 	if strings.EqualFold(t, TypeGitHub) {


### PR DESCRIPTION
This change provides an option to report the status or entrypoints summary comment to a local file on disk.