### PR TITLE
Add UserAccessLevel in GetPolicyData result

### DIFF
--- a/pkg/commands/policy/fetch_data_test.go
+++ b/pkg/commands/policy/fetch_data_test.go
@@ -40,11 +40,11 @@ func TestFetchData_Process(t *testing.T) {
 		wantErr          string
 		teams            []string
 		users            []string
+		userAccessLevel  string
 		want             platform.GetPolicyDataResult
 	}{
 		{
-			name: "prints_teams_and_users",
-
+			name:  "prints_teams_and_users",
 			teams: []string{"team1", "team2"},
 			users: []string{"user1", "user2"},
 			want: platform.GetPolicyDataResult{
@@ -53,6 +53,16 @@ func TestFetchData_Process(t *testing.T) {
 						Teams: []string{"team1", "team2"},
 						Users: []string{"user1", "user2"},
 					},
+				},
+			},
+		},
+		{
+			name:            "prints_user_access_level",
+			userAccessLevel: "admin",
+			want: platform.GetPolicyDataResult{
+				Mock: &platform.MockPolicyData{
+					Approvers:       &platform.GetLatestApproversResult{},
+					UserAccessLevel: "admin",
 				},
 			},
 		},
@@ -91,6 +101,7 @@ func TestFetchData_Process(t *testing.T) {
 					GetPolicyDataErr: tc.getPolicyDataErr,
 					TeamApprovers:    tc.teams,
 					UserApprovers:    tc.users,
+					UserAccessLevel:  tc.userAccessLevel,
 				},
 			}
 			outFilepath := path.Join(outDir, policyDataFilename)

--- a/pkg/commands/policy/fetch_data_test.go
+++ b/pkg/commands/policy/fetch_data_test.go
@@ -36,6 +36,7 @@ func TestFetchData_Process(t *testing.T) {
 
 	cases := []struct {
 		name             string
+		isPullRequest    bool
 		getPolicyDataErr error
 		wantErr          string
 		teams            []string
@@ -44,9 +45,10 @@ func TestFetchData_Process(t *testing.T) {
 		want             platform.GetPolicyDataResult
 	}{
 		{
-			name:  "prints_teams_and_users",
-			teams: []string{"team1", "team2"},
-			users: []string{"user1", "user2"},
+			name:          "prints_teams_and_users",
+			isPullRequest: true,
+			teams:         []string{"team1", "team2"},
+			users:         []string{"user1", "user2"},
 			want: platform.GetPolicyDataResult{
 				Mock: &platform.MockPolicyData{
 					Approvers: &platform.GetLatestApproversResult{
@@ -58,6 +60,7 @@ func TestFetchData_Process(t *testing.T) {
 		},
 		{
 			name:            "prints_user_access_level",
+			isPullRequest:   true,
 			userAccessLevel: "admin",
 			want: platform.GetPolicyDataResult{
 				Mock: &platform.MockPolicyData{
@@ -67,15 +70,28 @@ func TestFetchData_Process(t *testing.T) {
 			},
 		},
 		{
-			name:  "prints_no_approvers",
-			teams: []string{},
-			users: []string{},
+			name:          "prints_no_approvers",
+			isPullRequest: true,
+			teams:         []string{},
+			users:         []string{},
 			want: platform.GetPolicyDataResult{
 				Mock: &platform.MockPolicyData{
 					Approvers: &platform.GetLatestApproversResult{
 						Teams: []string{},
 						Users: []string{},
 					},
+				},
+			},
+		},
+		{
+			name:            "prints_no_approvers_outside_of_pull_request",
+			teams:           []string{},
+			users:           []string{},
+			isPullRequest:   false,
+			userAccessLevel: "read_only",
+			want: platform.GetPolicyDataResult{
+				Mock: &platform.MockPolicyData{
+					UserAccessLevel: "read_only",
 				},
 			},
 		},
@@ -102,6 +118,7 @@ func TestFetchData_Process(t *testing.T) {
 					TeamApprovers:    tc.teams,
 					UserApprovers:    tc.users,
 					UserAccessLevel:  tc.userAccessLevel,
+					IsPullRequest:    tc.isPullRequest,
 				},
 			}
 			outFilepath := path.Join(outDir, policyDataFilename)

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -77,6 +77,7 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 		if err := json.Unmarshal(data, &event); err == nil {
 			d.PullRequestNumber = event.GetNumber()
 			d.PullRequestBody = event.GetPullRequest().GetBody()
+			d.WorkflowUser = event.GetSender().GetLogin()
 		}
 	}
 	if githubContext.EventName == "pull_request_target" {
@@ -84,6 +85,7 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 		if err := json.Unmarshal(data, &event); err == nil {
 			d.PullRequestNumber = event.GetNumber()
 			d.PullRequestBody = event.GetPullRequest().GetBody()
+			d.WorkflowUser = event.GetSender().GetLogin()
 		}
 	}
 	if githubContext.EventName == "workflow_dispatch" {
@@ -231,10 +233,11 @@ GITHUB_TOKEN.`,
 	})
 
 	f.StringVar(&cli.StringVar{
-		Name:   "github-workflow-user",
-		EnvVar: "GITHUB_WORKFLOW_USER",
-		Target: &c.GitHubWorkflowUser,
-		Usage:  "The GitHub Login of the user requesting the workflow.",
-		Hidden: true,
+		Name:    "github-workflow-user",
+		EnvVar:  "GITHUB_WORKFLOW_USER",
+		Target:  &c.GitHubWorkflowUser,
+		Default: d.WorkflowUser,
+		Usage:   "The GitHub Login of the user requesting the workflow.",
+		Hidden:  true,
 	})
 }

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	GitHubPullRequestNumber int
 	GitHubPullRequestBody   string
 	GitHubSHA               string
-	GitHubWorkflowUser      string
+	GitHubActor             string
 }
 
 type configDefaults struct {
@@ -58,7 +58,7 @@ type configDefaults struct {
 	Repo              string
 	PullRequestNumber int
 	PullRequestBody   string
-	WorkflowUser      string
+	Actor             string
 }
 
 func (c *Config) RegisterFlags(set *cli.FlagSet) {
@@ -77,7 +77,7 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 		if err := json.Unmarshal(data, &event); err == nil {
 			d.PullRequestNumber = event.GetNumber()
 			d.PullRequestBody = event.GetPullRequest().GetBody()
-			d.WorkflowUser = event.GetSender().GetLogin()
+			d.Actor = event.GetSender().GetLogin()
 		}
 	}
 	if githubContext.EventName == "pull_request_target" {
@@ -85,13 +85,13 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 		if err := json.Unmarshal(data, &event); err == nil {
 			d.PullRequestNumber = event.GetNumber()
 			d.PullRequestBody = event.GetPullRequest().GetBody()
-			d.WorkflowUser = event.GetSender().GetLogin()
+			d.Actor = event.GetSender().GetLogin()
 		}
 	}
 	if githubContext.EventName == "workflow_dispatch" {
 		var event github.WorkflowDispatchEvent
 		if err := json.Unmarshal(data, &event); err == nil {
-			d.WorkflowUser = event.GetSender().GetLogin()
+			d.Actor = event.GetSender().GetLogin()
 		}
 	}
 
@@ -233,10 +233,10 @@ GITHUB_TOKEN.`,
 	})
 
 	f.StringVar(&cli.StringVar{
-		Name:    "github-workflow-user",
-		EnvVar:  "GITHUB_WORKFLOW_USER",
-		Target:  &c.GitHubWorkflowUser,
-		Default: d.WorkflowUser,
+		Name:    "github-actor",
+		EnvVar:  "GITHUB_ACTOR",
+		Target:  &c.GitHubActor,
+		Default: d.Actor,
 		Usage:   "The GitHub Login of the user requesting the workflow.",
 		Hidden:  true,
 	})

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	GitHubPullRequestNumber int
 	GitHubPullRequestBody   string
 	GitHubSHA               string
+	GitHubCaller            string
 }
 
 type configDefaults struct {
@@ -57,6 +58,7 @@ type configDefaults struct {
 	Repo              string
 	PullRequestNumber int
 	PullRequestBody   string
+	Caller            string
 }
 
 func (c *Config) RegisterFlags(set *cli.FlagSet) {
@@ -82,6 +84,12 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 		if err := json.Unmarshal(data, &event); err == nil {
 			d.PullRequestNumber = event.GetNumber()
 			d.PullRequestBody = event.GetPullRequest().GetBody()
+		}
+	}
+	if githubContext.EventName == "workflow_dispatch" {
+		var event github.WorkflowDispatchEvent
+		if err := json.Unmarshal(data, &event); err == nil {
+			d.Caller = event.GetSender().GetLogin()
 		}
 	}
 
@@ -219,6 +227,14 @@ GITHUB_TOKEN.`,
 		EnvVar: "GITHUB_SHA",
 		Target: &c.GitHubSHA,
 		Usage:  "The GitHub SHA.",
+		Hidden: true,
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:   "github-caller",
+		EnvVar: "GITHUB_CALLER",
+		Target: &c.GitHubCaller,
+		Usage:  "The GitHub Login of the user requesting the workflow.",
 		Hidden: true,
 	})
 }

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	GitHubPullRequestNumber int
 	GitHubPullRequestBody   string
 	GitHubSHA               string
-	GitHubCaller            string
+	GitHubWorkflowUser      string
 }
 
 type configDefaults struct {
@@ -58,7 +58,7 @@ type configDefaults struct {
 	Repo              string
 	PullRequestNumber int
 	PullRequestBody   string
-	Caller            string
+	WorkflowUser      string
 }
 
 func (c *Config) RegisterFlags(set *cli.FlagSet) {
@@ -89,7 +89,7 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 	if githubContext.EventName == "workflow_dispatch" {
 		var event github.WorkflowDispatchEvent
 		if err := json.Unmarshal(data, &event); err == nil {
-			d.Caller = event.GetSender().GetLogin()
+			d.WorkflowUser = event.GetSender().GetLogin()
 		}
 	}
 
@@ -231,9 +231,9 @@ GITHUB_TOKEN.`,
 	})
 
 	f.StringVar(&cli.StringVar{
-		Name:   "github-caller",
-		EnvVar: "GITHUB_CALLER",
-		Target: &c.GitHubCaller,
+		Name:   "github-workflow-user",
+		EnvVar: "GITHUB_WORKFLOW_USER",
+		Target: &c.GitHubWorkflowUser,
 		Usage:  "The GitHub Login of the user requesting the workflow.",
 		Hidden: true,
 	})

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -58,7 +58,6 @@ type configDefaults struct {
 	Repo              string
 	PullRequestNumber int
 	PullRequestBody   string
-	Actor             string
 }
 
 func (c *Config) RegisterFlags(set *cli.FlagSet) {
@@ -77,7 +76,6 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 		if err := json.Unmarshal(data, &event); err == nil {
 			d.PullRequestNumber = event.GetNumber()
 			d.PullRequestBody = event.GetPullRequest().GetBody()
-			d.Actor = event.GetSender().GetLogin()
 		}
 	}
 	if githubContext.EventName == "pull_request_target" {
@@ -85,13 +83,6 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 		if err := json.Unmarshal(data, &event); err == nil {
 			d.PullRequestNumber = event.GetNumber()
 			d.PullRequestBody = event.GetPullRequest().GetBody()
-			d.Actor = event.GetSender().GetLogin()
-		}
-	}
-	if githubContext.EventName == "workflow_dispatch" {
-		var event github.WorkflowDispatchEvent
-		if err := json.Unmarshal(data, &event); err == nil {
-			d.Actor = event.GetSender().GetLogin()
 		}
 	}
 
@@ -233,11 +224,10 @@ GITHUB_TOKEN.`,
 	})
 
 	f.StringVar(&cli.StringVar{
-		Name:    "github-actor",
-		EnvVar:  "GITHUB_ACTOR",
-		Target:  &c.GitHubActor,
-		Default: d.Actor,
-		Usage:   "The GitHub Login of the user requesting the workflow.",
-		Hidden:  true,
+		Name:   "github-actor",
+		EnvVar: "GITHUB_ACTOR",
+		Target: &c.GitHubActor,
+		Usage:  "The GitHub Login of the user requesting the workflow.",
+		Hidden: true,
 	})
 }

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -251,12 +251,12 @@ func (g *GitHub) GetUserRepoPermissions(ctx context.Context) (string, error) {
 	logger := logging.FromContext(ctx)
 	logger.DebugContext(ctx, "querying user repo permissions")
 
-	if g.cfg.GitHubWorkflowUser == "" {
-		return "", fmt.Errorf("github-workflow-user is required")
+	if g.cfg.GitHubActor == "" {
+		return "", fmt.Errorf("github-actor is required")
 	}
 	var result string
 	return result, g.withRetries(ctx, func(ctx context.Context) error {
-		permissionLevel, resp, err := g.client.Repositories.GetPermissionLevel(ctx, g.cfg.GitHubOwner, g.cfg.GitHubRepo, g.cfg.GitHubWorkflowUser)
+		permissionLevel, resp, err := g.client.Repositories.GetPermissionLevel(ctx, g.cfg.GitHubOwner, g.cfg.GitHubRepo, g.cfg.GitHubActor)
 		if err != nil {
 			if resp != nil {
 				if _, ok := ignoredStatusCodes[resp.StatusCode]; !ok {

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -285,10 +285,8 @@ func (g *GitHub) GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error
 		return nil, fmt.Errorf("failed to get user repo permissions: %w", err)
 	}
 
-	approvers := &GetLatestApproversResult{
-		Users: []string{},
-		Teams: []string{},
-	}
+	var approvers *GetLatestApproversResult
+	// Skip, if the command is not running in the context of a pull request.
 	if g.cfg.GitHubPullRequestNumber > 0 {
 		approvers, err = g.GetLatestApprovers(ctx)
 		if err != nil {

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -39,6 +39,11 @@ func (l *Local) AssignReviewers(ctx context.Context, inputs *AssignReviewersInpu
 	return &AssignReviewersResult{}, nil
 }
 
+// GetUserRepoPermissions is a no-op and returns an empty string.
+func (l *Local) GetUserRepoPermissions(ctx context.Context) (string, error) {
+	return "", nil
+}
+
 // GetLatestApprovers returns an empty result.
 func (l *Local) GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error) {
 	return &GetLatestApproversResult{}, nil

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -76,7 +76,7 @@ type Platform interface {
 	// AssignReviewers assigns principals to review a change request.
 	AssignReviewers(ctx context.Context, inputs *AssignReviewersInput) (*AssignReviewersResult, error)
 
-	// GetUserRepoPermissions
+	// GetUserRepoPermissions returns a user's access level to a repository.
 	GetUserRepoPermissions(ctx context.Context) (string, error)
 
 	// GetLatestApprovers retrieves the reviewers whose latest review is an

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -64,11 +64,6 @@ type GetLatestApproversResult struct {
 	Teams []string `json:"teams"`
 }
 
-// GetUserAccessLevelResult
-type GetUserAccessLevelResult struct {
-	permission any
-}
-
 // GetPolicyDataResult contains the required data for policy evaluation, by
 // platform.
 type GetPolicyDataResult struct {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -76,6 +76,9 @@ type Platform interface {
 	// AssignReviewers assigns principals to review a change request.
 	AssignReviewers(ctx context.Context, inputs *AssignReviewersInput) (*AssignReviewersResult, error)
 
+	// GetUserRepoPermissions
+	GetUserRepoPermissions(ctx context.Context) (string, error)
+
 	// GetLatestApprovers retrieves the reviewers whose latest review is an
 	// approval.
 	GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -64,6 +64,11 @@ type GetLatestApproversResult struct {
 	Teams []string `json:"teams"`
 }
 
+// GetUserAccessLevelResult
+type GetUserAccessLevelResult struct {
+	permission any
+}
+
 // GetPolicyDataResult contains the required data for policy evaluation, by
 // platform.
 type GetPolicyDataResult struct {

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -30,6 +30,8 @@ type MockPlatform struct {
 	reqMu sync.Mutex
 	Reqs  []*Request
 
+	IsPullRequest bool
+
 	AssignReviewersErr  error
 	GetPolicyDataErr    error
 	ModifierContentResp string
@@ -98,12 +100,17 @@ func (m *MockPlatform) GetPolicyData(ctx context.Context) (*GetPolicyDataResult,
 		return nil, m.GetPolicyDataErr
 	}
 
+	var approvers *GetLatestApproversResult
+	if m.IsPullRequest {
+		approvers = &GetLatestApproversResult{
+			Teams: m.TeamApprovers,
+			Users: m.UserApprovers,
+		}
+	}
+
 	return &GetPolicyDataResult{
 		Mock: &MockPolicyData{
-			Approvers: &GetLatestApproversResult{
-				Teams: m.TeamApprovers,
-				Users: m.UserApprovers,
-			},
+			Approvers:       approvers,
 			UserAccessLevel: m.UserAccessLevel,
 		},
 	}, nil


### PR DESCRIPTION
This change adds `GetUserRepoPermissions` to the Platform interface, which adds the user's access level for a repository as additional context in policy evaluations. This also changes `platform.GetPolicyData()` to skip fetching Pull Request Approvers if a pull request number is not provided.

```javascript
{
  github: {
    pull_request_approvers: {
      // ...
    },
    user_access_level: "admin",
  }
}
```