### PR TITLE
Add deny policy enforcement

### DIFF
--- a/pkg/commands/policy/enforce.go
+++ b/pkg/commands/policy/enforce.go
@@ -34,6 +34,7 @@ import (
 // Result defines the expected structure of the OPA policy evaluation result.
 type Result struct {
 	MissingApprovals []*MissingApproval `json:"missing_approvals"`
+	DenyAll          []*DenyAll         `json:"deny_all"`
 }
 
 // MissingApproval defines the missing approvals determined from the policy
@@ -143,6 +144,10 @@ func (c *EnforceCommand) Process(ctx context.Context) error {
 		if err := c.EnforceMissingApprovals(ctx, b, k, v); err != nil {
 			merr = errors.Join(merr, err)
 		}
+
+		if err := c.EnforceDenyAll(ctx, b, k, v); err != nil {
+			merr = errors.Join(merr, err)
+		}
 	}
 
 	if err := c.reporter.Status(ctx, reporter.StatusPolicyViolation, &reporter.StatusParams{
@@ -202,4 +207,25 @@ func (c *EnforceCommand) EnforceMissingApprovals(ctx context.Context, b strings.
 	}
 
 	return merr
+}
+
+// DenyAll defines the expected structure of deny all violations from the policy
+// evaluation result.
+type DenyAll struct {
+	Message string `json:"msg"`
+}
+
+// EnforceDenyAll blocks the action if a deny all violation is found and reports
+// any violations with the detailed error message.
+func (c *EnforceCommand) EnforceDenyAll(ctx context.Context, b strings.Builder, policyName string, r *Result) error {
+	logger := logging.FromContext(ctx)
+
+	fmt.Fprintf(&b, "#### %s\n", policyName)
+	for _, m := range r.DenyAll {
+		return fmt.Errorf("failed: \"%s\" - %s", policyName, m.Message)
+	}
+
+	logger.DebugContext(ctx, "no deny all violation for policy",
+		"policy_name", policyName)
+	return nil
 }

--- a/pkg/commands/policy/enforce.go
+++ b/pkg/commands/policy/enforce.go
@@ -34,7 +34,7 @@ import (
 // Result defines the expected structure of the OPA policy evaluation result.
 type Result struct {
 	MissingApprovals []*MissingApproval `json:"missing_approvals"`
-	DenyAll          []*DenyAll         `json:"deny_all"`
+	Deny             []*Deny            `json:"deny"`
 }
 
 // MissingApproval defines the missing approvals determined from the policy
@@ -147,7 +147,7 @@ func (c *EnforceCommand) Process(ctx context.Context) error {
 			violation = errors.Join(violation, err)
 		}
 
-		if err := c.EnforceDenyAll(ctx, &st, k, v); err != nil {
+		if err := c.EnforceDeny(ctx, &st, k, v); err != nil {
 			violation = errors.Join(violation, err)
 		}
 
@@ -221,25 +221,25 @@ func (c *EnforceCommand) EnforceMissingApprovals(ctx context.Context, b *strings
 	return merr
 }
 
-// DenyAll defines the expected structure of deny all violations from the policy
+// Deny defines the expected structure of deny violations from the policy
 // evaluation result.
-type DenyAll struct {
+type Deny struct {
 	Message string `json:"msg"`
 }
 
-// EnforceDenyAll blocks the action if a deny all violation is found and reports
+// EnforceDeny blocks the action if a deny violation is found and reports
 // any violations with the detailed error message.
-func (c *EnforceCommand) EnforceDenyAll(ctx context.Context, b *strings.Builder, policyName string, r *Result) error {
+func (c *EnforceCommand) EnforceDeny(ctx context.Context, b *strings.Builder, policyName string, r *Result) error {
 	logger := logging.FromContext(ctx)
 
-	if len(r.DenyAll) == 0 {
-		logger.DebugContext(ctx, "no deny all violations for policy",
+	if len(r.Deny) == 0 {
+		logger.DebugContext(ctx, "no deny violations for policy",
 			"policy_name", policyName)
 		return nil
 	}
 
 	fmt.Fprint(b, "- **Action not allowed**:\n")
-	for _, m := range r.DenyAll {
+	for _, m := range r.Deny {
 		fmt.Fprintf(b, "\t - Reason: %s\n", m.Message)
 		return fmt.Errorf("failed: \"%s\" - %s", policyName, m.Message)
 	}

--- a/pkg/commands/policy/enforce.go
+++ b/pkg/commands/policy/enforce.go
@@ -150,13 +150,15 @@ func (c *EnforceCommand) Process(ctx context.Context) error {
 		}
 	}
 
-	if err := c.reporter.Status(ctx, reporter.StatusPolicyViolation, &reporter.StatusParams{
-		Operation: "Policy Violation",
-		Dir:       c.directory,
-		Message:   "**NOTE**: After resolving the policy violations below, re-run the `Guardian Plan` workflow to re-evaluate policy enforcement checks.",
-		Details:   b.String(),
-	}); err != nil {
-		return fmt.Errorf("failed to report status: %w", err)
+	if merr != nil {
+		if err := c.reporter.Status(ctx, reporter.StatusPolicyViolation, &reporter.StatusParams{
+			Operation: "Policy Violation",
+			Dir:       c.directory,
+			Message:   "**NOTE**: After resolving the policy violations below, re-run the `Guardian Plan` workflow to re-evaluate policy enforcement checks.",
+			Details:   b.String(),
+		}); err != nil {
+			return fmt.Errorf("failed to report status: %w", err)
+		}
 	}
 	return merr
 }

--- a/pkg/commands/policy/enforce.go
+++ b/pkg/commands/policy/enforce.go
@@ -172,6 +172,8 @@ func (c *EnforceCommand) Process(ctx context.Context) error {
 	return merr
 }
 
+// EnforceMissingApprovals checks for any missing_approvals violations attempts
+// to assign the missing reviewers, and fails the status.
 func (c *EnforceCommand) EnforceMissingApprovals(ctx context.Context, b *strings.Builder, policyName string, r *Result) error {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/commands/policy/enforce_test.go
+++ b/pkg/commands/policy/enforce_test.go
@@ -56,6 +56,11 @@ func TestEnforce_Process(t *testing.T) {
 			assignReviewersErr: fmt.Errorf("failed to assign reviewers"),
 			wantErr:            "failed to assign reviewers",
 		},
+		{
+			name:        "fails_with_deny_all",
+			resultsFile: "testdata/deny_all.json",
+			wantErr:     "test-error-message",
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/commands/policy/enforce_test.go
+++ b/pkg/commands/policy/enforce_test.go
@@ -57,8 +57,8 @@ func TestEnforce_Process(t *testing.T) {
 			wantErr:            "failed to assign reviewers",
 		},
 		{
-			name:        "fails_with_deny_all",
-			resultsFile: "testdata/deny_all.json",
+			name:        "fails_with_deny",
+			resultsFile: "testdata/deny.json",
 			wantErr:     "test-error-message",
 		},
 	}

--- a/pkg/commands/policy/testdata/deny.json
+++ b/pkg/commands/policy/testdata/deny.json
@@ -1,6 +1,6 @@
 {
   "test_policy_name": {
-    "deny_all": [
+    "deny": [
       {
         "msg": "test-error-message"
       }

--- a/pkg/commands/policy/testdata/deny_all.json
+++ b/pkg/commands/policy/testdata/deny_all.json
@@ -1,0 +1,9 @@
+{
+  "test_policy_name": {
+    "deny_all": [
+      {
+        "msg": "test-error-message"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This change introduces a `deny` policy, which will do nothing, block the status and print a detailed message. This also refactors the `missing_approvals` enforcement into `EnforceMissingApprovals` function, for better readability and error handling. 