### PR TITLE
Add a GitHub Organization's team memberships in policy fetch-data subcommand

### DIFF
--- a/pkg/commands/policy/fetch_data_test.go
+++ b/pkg/commands/policy/fetch_data_test.go
@@ -42,6 +42,7 @@ func TestFetchData_Process(t *testing.T) {
 		teams            []string
 		users            []string
 		userAccessLevel  string
+		teamMappings     map[string][]string
 		want             platform.GetPolicyDataResult
 	}{
 		{
@@ -66,6 +67,21 @@ func TestFetchData_Process(t *testing.T) {
 				Mock: &platform.MockPolicyData{
 					Approvers:       &platform.GetLatestApproversResult{},
 					UserAccessLevel: "admin",
+				},
+			},
+		},
+		{
+			name: "prints_team_memberships",
+			teamMappings: map[string][]string{
+				"team1": {"user1", "user2"},
+				"team2": {"user3", "user4"},
+			},
+			want: platform.GetPolicyDataResult{
+				Mock: &platform.MockPolicyData{
+					TeamMemberships: map[string][]string{
+						"team1": {"user1", "user2"},
+						"team2": {"user3", "user4"},
+					},
 				},
 			},
 		},
@@ -119,6 +135,7 @@ func TestFetchData_Process(t *testing.T) {
 					UserApprovers:    tc.users,
 					UserAccessLevel:  tc.userAccessLevel,
 					IsPullRequest:    tc.isPullRequest,
+					TeamMemberships:  tc.teamMappings,
 				},
 			}
 			outFilepath := path.Join(outDir, policyDataFilename)

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -180,7 +180,7 @@ type latestApproverQuery struct {
 // a comment following a previous approval by the same user will still keep the
 // APPROVED state. However, if a reviewer previously approved the PR and
 // requests changes/dismisses the review, then the approval is not counted.
-func (g *GitHub) GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error) {
+func (g *GitHub) GetLatestApprovers(ctx context.Context, teamMemberships map[string][]string) (*GetLatestApproversResult, error) {
 	logger := logging.FromContext(ctx)
 	logger.DebugContext(ctx, "querying latest approvers")
 
@@ -207,10 +207,6 @@ func (g *GitHub) GetLatestApprovers(ctx context.Context) (*GetLatestApproversRes
 		}
 	}
 
-	teamMemberships, err := g.GetTeamMemberships(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get team memberships: %w", err)
-	}
 	for t, members := range teamMemberships {
 		for _, m := range members {
 			if _, ok := hasApproved[m]; ok {
@@ -316,7 +312,7 @@ func (g *GitHub) GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error
 	var approvers *GetLatestApproversResult
 	// Skip, if the command is not running in the context of a pull request.
 	if g.cfg.GitHubPullRequestNumber > 0 {
-		approvers, err = g.GetLatestApprovers(ctx)
+		approvers, err = g.GetLatestApprovers(ctx, teamMembers)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get latest approvers: %w", err)
 		}

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -245,6 +245,12 @@ func (g *GitHub) GetLatestApprovers(ctx context.Context) (*GetLatestApproversRes
 	return result, nil
 }
 
+// GetTeamMemberships returns a mapping of each team to list of members for the
+// given GitHub organization.
+func (l *GitHub) GetTeamMemberships(ctx context.Context) (map[string][]string, error) {
+	return map[string][]string{}, nil
+}
+
 // GetUserRepoPermissions returns the repo permission for the user that
 // triggered the workflow.
 func (g *GitHub) GetUserRepoPermissions(ctx context.Context) (string, error) {

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -255,6 +255,7 @@ func (g *GitHub) GetTeamMemberships(ctx context.Context) (map[string][]string, e
 
 	res := make(map[string][]string, len(teamQuery.Organization.Teams.Nodes))
 	for _, team := range teamQuery.Organization.Teams.Nodes {
+		res[team.Name] = make([]string, len(team.Members.Nodes))
 		for _, member := range team.Members.Nodes {
 			res[team.Name] = append(res[team.Name], member.Login)
 		}

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -44,6 +44,11 @@ func (l *Local) GetUserRepoPermissions(ctx context.Context) (string, error) {
 	return "", nil
 }
 
+// GetTeamMemberships is a no-op and returns an empty map.
+func (l *Local) GetTeamMemberships(ctx context.Context) (map[string][]string, error) {
+	return map[string][]string{}, nil
+}
+
 // GetLatestApprovers returns an empty result.
 func (l *Local) GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error) {
 	return &GetLatestApproversResult{}, nil

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -50,7 +50,7 @@ func (l *Local) GetTeamMemberships(ctx context.Context) (map[string][]string, er
 }
 
 // GetLatestApprovers returns an empty result.
-func (l *Local) GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error) {
+func (l *Local) GetLatestApprovers(ctx context.Context, teamMemberships map[string][]string) (*GetLatestApproversResult, error) {
 	return &GetLatestApproversResult{}, nil
 }
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -83,6 +83,9 @@ type Platform interface {
 	// approval.
 	GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error)
 
+	// GetTeamMemberships retrieves a mapping of each team to list of members.
+	GetTeamMemberships(ctx context.Context) (map[string][]string, error)
+
 	// GetPolicyData retrieves the required data for policy evaluation.
 	GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error)
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -81,7 +81,7 @@ type Platform interface {
 
 	// GetLatestApprovers retrieves the reviewers whose latest review is an
 	// approval.
-	GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error)
+	GetLatestApprovers(ctx context.Context, teamMemberships map[string][]string) (*GetLatestApproversResult, error)
 
 	// GetTeamMemberships retrieves a mapping of each team to list of members.
 	GetTeamMemberships(ctx context.Context) (map[string][]string, error)

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -105,8 +105,10 @@ func (m *MockPlatform) GetPolicyData(ctx context.Context) (*GetPolicyDataResult,
 	m.reqMu.Lock()
 	defer m.reqMu.Unlock()
 	m.Reqs = append(m.Reqs,
+		&Request{Name: "GetTeamMemberships"},
 		&Request{Name: "GetLatestApprovers"},
-		&Request{Name: "GetUserRepoPermissions"})
+		&Request{Name: "GetUserRepoPermissions"},
+	)
 
 	if m.GetPolicyDataErr != nil {
 		return nil, m.GetPolicyDataErr

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -76,7 +76,7 @@ func (m *MockPlatform) GetUserRepoPermissions(ctx context.Context) (string, erro
 	return m.UserAccessLevel, nil
 }
 
-func (m *MockPlatform) GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error) {
+func (m *MockPlatform) GetLatestApprovers(ctx context.Context, teamMemberships map[string][]string) (*GetLatestApproversResult, error) {
 	m.reqMu.Lock()
 	defer m.reqMu.Unlock()
 	m.Reqs = append(m.Reqs, &Request{

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -41,6 +41,7 @@ type MockPlatform struct {
 	TeamApprovers       []string
 	UserApprovers       []string
 	UserAccessLevel     string
+	TeamMemberships     map[string][]string
 }
 
 func (m *MockPlatform) AssignReviewers(ctx context.Context, input *AssignReviewersInput) (*AssignReviewersResult, error) {
@@ -64,6 +65,7 @@ func (m *MockPlatform) AssignReviewers(ctx context.Context, input *AssignReviewe
 type MockPolicyData struct {
 	Approvers       *GetLatestApproversResult `json:"approvers"`
 	UserAccessLevel string                    `json:"user_access_level"`
+	TeamMemberships map[string][]string       `json:"team_memberships"`
 }
 
 func (m *MockPlatform) GetUserRepoPermissions(ctx context.Context) (string, error) {
@@ -89,8 +91,14 @@ func (m *MockPlatform) GetLatestApprovers(ctx context.Context, teamMemberships m
 	}, nil
 }
 
-func (l *MockPlatform) GetTeamMemberships(ctx context.Context) (map[string][]string, error) {
-	return map[string][]string{}, nil
+func (m *MockPlatform) GetTeamMemberships(ctx context.Context) (map[string][]string, error) {
+	m.reqMu.Lock()
+	defer m.reqMu.Unlock()
+	m.Reqs = append(m.Reqs, &Request{
+		Name: "GetTeamMemberships",
+	})
+
+	return m.TeamMemberships, nil
 }
 
 func (m *MockPlatform) GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error) {
@@ -116,6 +124,7 @@ func (m *MockPlatform) GetPolicyData(ctx context.Context) (*GetPolicyDataResult,
 		Mock: &MockPolicyData{
 			Approvers:       approvers,
 			UserAccessLevel: m.UserAccessLevel,
+			TeamMemberships: m.TeamMemberships,
 		},
 	}, nil
 }

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -89,6 +89,10 @@ func (m *MockPlatform) GetLatestApprovers(ctx context.Context) (*GetLatestApprov
 	}, nil
 }
 
+func (l *MockPlatform) GetTeamMemberships(ctx context.Context) (map[string][]string, error) {
+	return map[string][]string{}, nil
+}
+
 func (m *MockPlatform) GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error) {
 	m.reqMu.Lock()
 	defer m.reqMu.Unlock()


### PR DESCRIPTION
This includes a refactoring of the team memberships query, which was originally embedded inside `GetLatestApprovers`, into its own Platform interface method, `GetTeamMemberships`. This is to expose the team membership mappings of an organization in the result of the `guardian policy fetch-data` command, under the `github.team_memberships` key, so that the team memberships can be reused for writing policy definitions.