### PR TITLE
refactor: Policy Fetch-Data command returns only teams that the user is a member of

### DIFF
--- a/pkg/commands/policy/fetch_data_test.go
+++ b/pkg/commands/policy/fetch_data_test.go
@@ -157,7 +157,6 @@ func TestFetchData_Process(t *testing.T) {
 					UserApprovers:    tc.users,
 					UserAccessLevel:  tc.userAccessLevel,
 					IsPullRequest:    tc.isPullRequest,
-					TeamMemberships:  tc.teamMappings,
 				},
 			}
 			outFilepath := path.Join(outDir, policyDataFilename)

--- a/pkg/commands/policy/fetch_data_test.go
+++ b/pkg/commands/policy/fetch_data_test.go
@@ -43,7 +43,7 @@ func TestFetchData_Process(t *testing.T) {
 		teams            []string
 		users            []string
 		userAccessLevel  string
-		teamMappings     map[string][]string
+		userTeams        []string
 		want             platform.GetPolicyDataResult
 	}{
 		{
@@ -52,6 +52,7 @@ func TestFetchData_Process(t *testing.T) {
 			teams:         []string{"team1", "team2"},
 			users:         []string{"user1", "user2"},
 			username:      "test-username",
+			userTeams:     []string{"team1"},
 			want: platform.GetPolicyDataResult{
 				Mock: &platform.MockPolicyData{
 					Approvers: &platform.GetLatestApproversResult{
@@ -60,6 +61,7 @@ func TestFetchData_Process(t *testing.T) {
 					},
 					Actor: &platform.MockActorData{
 						Username: "test-username",
+						Teams:    []string{"team1"},
 					},
 				},
 			},
@@ -80,20 +82,14 @@ func TestFetchData_Process(t *testing.T) {
 			},
 		},
 		{
-			name: "prints_team_memberships",
-			teamMappings: map[string][]string{
-				"team1": {"user1", "user2"},
-				"team2": {"user3", "user4"},
-			},
-			username: "test-username",
+			name:      "prints_team_memberships",
+			userTeams: []string{"team1", "team2"},
+			username:  "test-username",
 			want: platform.GetPolicyDataResult{
 				Mock: &platform.MockPolicyData{
-					TeamMemberships: map[string][]string{
-						"team1": {"user1", "user2"},
-						"team2": {"user3", "user4"},
-					},
 					Actor: &platform.MockActorData{
 						Username: "test-username",
+						Teams:    []string{"team1", "team2"},
 					},
 				},
 			},
@@ -157,6 +153,7 @@ func TestFetchData_Process(t *testing.T) {
 					UserApprovers:    tc.users,
 					UserAccessLevel:  tc.userAccessLevel,
 					IsPullRequest:    tc.isPullRequest,
+					UserTeams:        tc.userTeams,
 				},
 			}
 			outFilepath := path.Join(outDir, policyDataFilename)

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -256,8 +256,8 @@ func (g *GitHub) GetTeamMemberships(ctx context.Context) (map[string][]string, e
 	res := make(map[string][]string, len(teamQuery.Organization.Teams.Nodes))
 	for _, team := range teamQuery.Organization.Teams.Nodes {
 		res[team.Name] = make([]string, len(team.Members.Nodes))
-		for _, member := range team.Members.Nodes {
-			res[team.Name] = append(res[team.Name], member.Login)
+		for i, member := range team.Members.Nodes {
+			res[team.Name][i] = member.Login
 		}
 	}
 

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -50,7 +50,7 @@ func (l *Local) GetUserTeamMemberships(ctx context.Context, username string) ([]
 }
 
 // GetLatestApprovers returns an empty result.
-func (l *Local) GetLatestApprovers(ctx context.Context, teamMemberships map[string][]string) (*GetLatestApproversResult, error) {
+func (l *Local) GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error) {
 	return &GetLatestApproversResult{}, nil
 }
 

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -44,9 +44,9 @@ func (l *Local) GetUserRepoPermissions(ctx context.Context) (string, error) {
 	return "", nil
 }
 
-// GetTeamMemberships is a no-op and returns an empty map.
-func (l *Local) GetTeamMemberships(ctx context.Context) (map[string][]string, error) {
-	return map[string][]string{}, nil
+// GetUserTeamMemberships is a no-op and returns an empty slice.
+func (l *Local) GetUserTeamMemberships(ctx context.Context, username string) ([]string, error) {
+	return []string{}, nil
 }
 
 // GetLatestApprovers returns an empty result.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -81,10 +81,11 @@ type Platform interface {
 
 	// GetLatestApprovers retrieves the reviewers whose latest review is an
 	// approval.
-	GetLatestApprovers(ctx context.Context, teamMemberships map[string][]string) (*GetLatestApproversResult, error)
+	GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error)
 
-	// GetTeamMemberships retrieves a mapping of each team to list of members.
-	GetTeamMemberships(ctx context.Context) (map[string][]string, error)
+	// GetUserTeamMemberships retrieves a list of teams that a user is a member
+	// of, within the given organization.
+	GetUserTeamMemberships(ctx context.Context, username string) ([]string, error)
 
 	// GetPolicyData retrieves the required data for policy evaluation.
 	GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error)

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -97,14 +97,14 @@ func (m *MockPlatform) GetLatestApprovers(ctx context.Context, teamMemberships m
 	}, nil
 }
 
-func (m *MockPlatform) GetTeamMemberships(ctx context.Context) (map[string][]string, error) {
+func (m *MockPlatform) GetUserTeamMemberships(ctx context.Context, username string) ([]string, error) {
 	m.reqMu.Lock()
 	defer m.reqMu.Unlock()
 	m.Reqs = append(m.Reqs, &Request{
 		Name: "GetTeamMemberships",
 	})
 
-	return m.TeamMemberships, nil
+	return []string{}, nil
 }
 
 func (m *MockPlatform) GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error) {

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -42,7 +42,7 @@ type MockPlatform struct {
 	TeamApprovers       []string
 	UserApprovers       []string
 	UserAccessLevel     string
-	TeamMemberships     map[string][]string
+	TeamMemberships     []string
 }
 
 func (m *MockPlatform) AssignReviewers(ctx context.Context, input *AssignReviewersInput) (*AssignReviewersResult, error) {
@@ -84,7 +84,7 @@ func (m *MockPlatform) GetUserRepoPermissions(ctx context.Context) (string, erro
 	return m.UserAccessLevel, nil
 }
 
-func (m *MockPlatform) GetLatestApprovers(ctx context.Context, teamMemberships map[string][]string) (*GetLatestApproversResult, error) {
+func (m *MockPlatform) GetLatestApprovers(ctx context.Context) (*GetLatestApproversResult, error) {
 	m.reqMu.Lock()
 	defer m.reqMu.Unlock()
 	m.Reqs = append(m.Reqs, &Request{

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -42,7 +42,7 @@ type MockPlatform struct {
 	TeamApprovers       []string
 	UserApprovers       []string
 	UserAccessLevel     string
-	TeamMemberships     []string
+	UserTeams           []string
 }
 
 func (m *MockPlatform) AssignReviewers(ctx context.Context, input *AssignReviewersInput) (*AssignReviewersResult, error) {
@@ -64,14 +64,14 @@ func (m *MockPlatform) AssignReviewers(ctx context.Context, input *AssignReviewe
 }
 
 type MockActorData struct {
-	Username    string `json:"username"`
-	AccessLevel string `json:"access_level"`
+	Username    string   `json:"username"`
+	AccessLevel string   `json:"access_level"`
+	Teams       []string `json:"teams"`
 }
 
 type MockPolicyData struct {
-	Approvers       *GetLatestApproversResult `json:"approvers"`
-	Actor           *MockActorData            `json:"actor"`
-	TeamMemberships map[string][]string       `json:"team_memberships"`
+	Approvers *GetLatestApproversResult `json:"approvers"`
+	Actor     *MockActorData            `json:"actor"`
 }
 
 func (m *MockPlatform) GetUserRepoPermissions(ctx context.Context) (string, error) {
@@ -134,8 +134,8 @@ func (m *MockPlatform) GetPolicyData(ctx context.Context) (*GetPolicyDataResult,
 			Actor: &MockActorData{
 				Username:    m.ActorUsername,
 				AccessLevel: m.UserAccessLevel,
+				Teams:       m.UserTeams,
 			},
-			TeamMemberships: m.TeamMemberships,
 		},
 	}, nil
 }


### PR DESCRIPTION
This change improves the structure of the data available for authoring new policies. 

Now, the user's teams are included in the payload of the `github.actor`, instead of previously all teams and members of the org.
```
{
  "github": {
    "actor": {
      "username": "abcdefg",
      "teams": ["team1", "team2"]
    }
  }
}
```

To make this possible, instead of a single big query, `GetTeamMemberships` was refactored into `GetUserTeamMemberships`, invoked once per user.