### PR TITLE
add include-teams flag to optionally include team data in policy fetch-data result

### DIFF
--- a/pkg/commands/policy/fetch_data_test.go
+++ b/pkg/commands/policy/fetch_data_test.go
@@ -37,6 +37,7 @@ func TestFetchData_Process(t *testing.T) {
 	cases := []struct {
 		name             string
 		isPullRequest    bool
+		includeTeams     bool
 		getPolicyDataErr error
 		wantErr          string
 		username         string
@@ -49,6 +50,7 @@ func TestFetchData_Process(t *testing.T) {
 		{
 			name:          "prints_teams_and_users",
 			isPullRequest: true,
+			includeTeams:  true,
 			teams:         []string{"team1", "team2"},
 			users:         []string{"user1", "user2"},
 			username:      "test-username",
@@ -69,6 +71,7 @@ func TestFetchData_Process(t *testing.T) {
 		{
 			name:            "prints_user_access_level",
 			isPullRequest:   true,
+			includeTeams:    true,
 			userAccessLevel: "admin",
 			username:        "test-username",
 			want: platform.GetPolicyDataResult{
@@ -82,9 +85,10 @@ func TestFetchData_Process(t *testing.T) {
 			},
 		},
 		{
-			name:      "prints_team_memberships",
-			userTeams: []string{"team1", "team2"},
-			username:  "test-username",
+			name:         "prints_team_memberships",
+			includeTeams: true,
+			userTeams:    []string{"team1", "team2"},
+			username:     "test-username",
 			want: platform.GetPolicyDataResult{
 				Mock: &platform.MockPolicyData{
 					Actor: &platform.MockActorData{
@@ -97,13 +101,13 @@ func TestFetchData_Process(t *testing.T) {
 		{
 			name:          "prints_no_approvers",
 			isPullRequest: true,
+			includeTeams:  true,
 			teams:         []string{},
 			users:         []string{},
 			username:      "test-username",
 			want: platform.GetPolicyDataResult{
 				Mock: &platform.MockPolicyData{
 					Approvers: &platform.GetLatestApproversResult{
-						Teams: []string{},
 						Users: []string{},
 					},
 					Actor: &platform.MockActorData{
@@ -117,6 +121,7 @@ func TestFetchData_Process(t *testing.T) {
 			teams:           []string{},
 			users:           []string{},
 			isPullRequest:   false,
+			includeTeams:    true,
 			userAccessLevel: "read_only",
 			username:        "test-username",
 			want: platform.GetPolicyDataResult{
@@ -124,6 +129,25 @@ func TestFetchData_Process(t *testing.T) {
 					Actor: &platform.MockActorData{
 						Username:    "test-username",
 						AccessLevel: "read_only",
+					},
+				},
+			},
+		},
+		{
+			name:          "excludes_teams",
+			isPullRequest: true,
+			includeTeams:  false,
+			teams:         []string{"team1", "team2"},
+			users:         []string{"user1", "user2"},
+			username:      "test-username",
+			userTeams:     []string{"team1"},
+			want: platform.GetPolicyDataResult{
+				Mock: &platform.MockPolicyData{
+					Approvers: &platform.GetLatestApproversResult{
+						Users: []string{"user1", "user2"},
+					},
+					Actor: &platform.MockActorData{
+						Username: "test-username",
 					},
 				},
 			},
@@ -153,6 +177,7 @@ func TestFetchData_Process(t *testing.T) {
 					UserApprovers:    tc.users,
 					UserAccessLevel:  tc.userAccessLevel,
 					IsPullRequest:    tc.isPullRequest,
+					IncludeTeams:     tc.includeTeams,
 					UserTeams:        tc.userTeams,
 				},
 			}

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -238,7 +238,7 @@ GITHUB_TOKEN.`,
 		Name:    "include-teams",
 		Default: false,
 		Target:  &c.IncludeTeams,
-		Usage:   "If true, includes team data in payload. Requires elevated token permissions.",
+		Usage:   "If true, includes team data in payload. Requires 'members: read' token permissions.",
 		Hidden:  true,
 	})
 }

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -51,6 +51,9 @@ type Config struct {
 	GitHubPullRequestBody   string
 	GitHubSHA               string
 	GitHubActor             string
+
+	// Policy
+	IncludeTeams bool
 }
 
 type configDefaults struct {
@@ -229,5 +232,12 @@ GITHUB_TOKEN.`,
 		Target: &c.GitHubActor,
 		Usage:  "The GitHub Login of the user requesting the workflow.",
 		Hidden: true,
+	})
+
+	f.BoolVar(&cli.BoolVar{
+		Name:    "include-teams",
+		Default: false,
+		Target:  &c.IncludeTeams,
+		Usage:   "If true, includes team data in payload. Requires elevated token permissions.",
 	})
 }

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -239,5 +239,6 @@ GITHUB_TOKEN.`,
 		Default: false,
 		Target:  &c.IncludeTeams,
 		Usage:   "If true, includes team data in payload. Requires elevated token permissions.",
+		Hidden:  true,
 	})
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -61,7 +61,7 @@ type AssignReviewersResult struct {
 // approval.
 type GetLatestApproversResult struct {
 	Users []string `json:"users"`
-	Teams []string `json:"teams"`
+	Teams []string `json:"teams,omitempty"`
 }
 
 // GetPolicyDataResult contains the required data for policy evaluation, by


### PR DESCRIPTION
The default is to exclude teams data because fetching team memberships requires additional permissions that the workflow token cannot access.