### PR TITLE
Rename `--dry-run` flag to `--silent`

### DIFF
--- a/pkg/commands/policy/enforce.go
+++ b/pkg/commands/policy/enforce.go
@@ -163,7 +163,7 @@ func (c *EnforceCommand) Process(ctx context.Context) error {
 		if err := c.reporter.Status(ctx, reporter.StatusPolicyViolation, &reporter.StatusParams{
 			Operation: "Policy Violation",
 			Dir:       c.directory,
-			Message:   "The planned resource changes raised policy violations that need to be addressed:",
+			Message:   "The planned resource changes raised policy violations that will need to be addressed:",
 			Details:   b.String(),
 		}); err != nil {
 			return fmt.Errorf("failed to report status: %w", err)
@@ -212,8 +212,8 @@ func (c *EnforceCommand) EnforceMissingApprovals(ctx context.Context, b *strings
 		fmt.Fprintf(b, "\t - Teams: %s\n", strings.Join(teams, ", "))
 	}
 
-	if c.flags.DryRun {
-		logger.DebugContext(ctx, "skipped assigning reviewers", "dry_run", c.flags.DryRun)
+	if c.flags.Silent {
+		logger.DebugContext(ctx, "skipped assigning reviewers", "silent", c.flags.Silent)
 		return merr
 	}
 

--- a/pkg/commands/policy/flags.go
+++ b/pkg/commands/policy/flags.go
@@ -22,7 +22,7 @@ import (
 )
 
 type EnforceFlags struct {
-	DryRun      bool
+	Silent      bool
 	ResultsFile string
 }
 
@@ -30,10 +30,10 @@ func (e *EnforceFlags) Register(set *cli.FlagSet) {
 	f := set.NewSection("ENFORCE OPTIONS")
 
 	f.BoolVar(&cli.BoolVar{
-		Name:    "dry-run",
+		Name:    "silent",
 		Default: false,
-		Target:  &e.DryRun,
-		Usage:   "Skips assigning reviewers and only reports any violations found.",
+		Target:  &e.Silent,
+		Usage:   "Skips any actions and only reports the violations found.",
 	})
 
 	f.StringVar(&cli.StringVar{


### PR DESCRIPTION
This will report the status of violations found but skip all actionable items, e.g. assigning reviewers.