### PR TITLE
refactor: create config package

### DIFF
--- a/pkg/commands/apply/apply.go
+++ b/pkg/commands/apply/apply.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/abcxyz/guardian/internal/metricswrap"
 	"github.com/abcxyz/guardian/pkg/commands/plan"
+	"github.com/abcxyz/guardian/pkg/config"
 	"github.com/abcxyz/guardian/pkg/flags"
 	"github.com/abcxyz/guardian/pkg/platform"
 	"github.com/abcxyz/guardian/pkg/reporter"
@@ -63,7 +64,7 @@ type ApplyCommand struct {
 	planFileLocalPath string
 	storagePrefix     string
 
-	platformConfig platform.Config
+	platformConfig config.Platform
 
 	flags.CommonFlags
 

--- a/pkg/commands/entrypoints/entrypoints.go
+++ b/pkg/commands/entrypoints/entrypoints.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/abcxyz/guardian/internal/metricswrap"
+	"github.com/abcxyz/guardian/pkg/config"
 	"github.com/abcxyz/guardian/pkg/git"
 	"github.com/abcxyz/guardian/pkg/platform"
 	"github.com/abcxyz/guardian/pkg/reporter"
@@ -41,7 +42,7 @@ var _ cli.Command = (*EntrypointsCommand)(nil)
 type EntrypointsCommand struct {
 	cli.BaseCommand
 
-	platformConfig platform.Config
+	platformConfig config.Platform
 
 	flagDir                     []string
 	flagDestRef                 string

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -31,6 +31,7 @@ import (
 	"github.com/posener/complete/v2"
 
 	"github.com/abcxyz/guardian/internal/metricswrap"
+	"github.com/abcxyz/guardian/pkg/config"
 	"github.com/abcxyz/guardian/pkg/flags"
 	"github.com/abcxyz/guardian/pkg/platform"
 	"github.com/abcxyz/guardian/pkg/reporter"
@@ -67,7 +68,7 @@ type PlanCommand struct {
 	childPath     string
 	storagePrefix string
 
-	platformConfig platform.Config
+	platformConfig config.Platform
 
 	flags.CommonFlags
 

--- a/pkg/commands/policy/enforce.go
+++ b/pkg/commands/policy/enforce.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/abcxyz/guardian/internal/metricswrap"
+	"github.com/abcxyz/guardian/pkg/config"
 	"github.com/abcxyz/guardian/pkg/flags"
 	"github.com/abcxyz/guardian/pkg/platform"
 	"github.com/abcxyz/guardian/pkg/reporter"
@@ -54,7 +55,7 @@ type EnforceCommand struct {
 	cli.BaseCommand
 
 	directory      string
-	platformConfig platform.Config
+	platformConfig config.Platform
 	flags          EnforceFlags
 	commonFlags    flags.CommonFlags
 	platform       platform.Platform

--- a/pkg/commands/policy/fetch_data.go
+++ b/pkg/commands/policy/fetch_data.go
@@ -22,6 +22,7 @@ import (
 	"path"
 
 	"github.com/abcxyz/guardian/internal/metricswrap"
+	"github.com/abcxyz/guardian/pkg/config"
 	"github.com/abcxyz/guardian/pkg/platform"
 	"github.com/abcxyz/guardian/pkg/util"
 	"github.com/abcxyz/pkg/cli"
@@ -39,7 +40,7 @@ const (
 type FetchDataCommand struct {
 	cli.BaseCommand
 
-	platformConfig platform.Config
+	platformConfig config.Platform
 	platform       platform.Platform
 	flags          FetchDataFlags
 }

--- a/pkg/commands/workflows/plan_status_comments.go
+++ b/pkg/commands/workflows/plan_status_comments.go
@@ -22,8 +22,8 @@ import (
 	"slices"
 
 	"github.com/abcxyz/guardian/internal/metricswrap"
+	"github.com/abcxyz/guardian/pkg/config"
 	"github.com/abcxyz/guardian/pkg/github"
-	"github.com/abcxyz/guardian/pkg/platform"
 	"github.com/abcxyz/guardian/pkg/reporter"
 	"github.com/abcxyz/guardian/pkg/util"
 	"github.com/abcxyz/pkg/cli"
@@ -34,7 +34,7 @@ var _ cli.Command = (*PlanStatusCommentCommand)(nil)
 type PlanStatusCommentCommand struct {
 	cli.BaseCommand
 
-	platformConfig platform.Config
+	platformConfig config.Platform
 
 	flagInitResult string
 	flagPlanResult []string

--- a/pkg/commands/workflows/remove_comments.go
+++ b/pkg/commands/workflows/remove_comments.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/abcxyz/guardian/internal/metricswrap"
-	"github.com/abcxyz/guardian/pkg/platform"
+	"github.com/abcxyz/guardian/pkg/config"
 	"github.com/abcxyz/guardian/pkg/reporter"
 	"github.com/abcxyz/pkg/cli"
 )
@@ -30,7 +30,7 @@ var _ cli.Command = (*RemoveGuardianCommentsCommand)(nil)
 type RemoveGuardianCommentsCommand struct {
 	cli.BaseCommand
 
-	platformConfig platform.Config
+	platformConfig config.Platform
 
 	reporterClient reporter.Reporter
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package config defines the configuration options for all supported platform types.
 package config
 
 import (
@@ -59,7 +60,7 @@ var (
 	}()
 )
 
-// Config is the configuration needed to generate different Platform types.
+// Platform is the configuration needed to generate different Platform types.
 type Platform struct {
 	Type     string
 	Reporter string

--- a/pkg/config/gitlab.go
+++ b/pkg/config/gitlab.go
@@ -1,3 +1,18 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
+// GitLab is the configuration options for the GitLab client.
 type GitLab struct{}

--- a/pkg/config/gitlab.go
+++ b/pkg/config/gitlab.go
@@ -1,0 +1,3 @@
+package config
+
+type GitLab struct{}

--- a/pkg/config/local.go
+++ b/pkg/config/local.go
@@ -1,0 +1,5 @@
+package config
+
+type Local struct {
+	LocalModifierContent string
+}

--- a/pkg/config/local.go
+++ b/pkg/config/local.go
@@ -1,5 +1,20 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
+// Local is the configuration for running Guardian locally.
 type Local struct {
 	LocalModifierContent string
 }

--- a/pkg/platform/gitlab.go
+++ b/pkg/platform/gitlab.go
@@ -14,17 +14,19 @@
 
 package platform
 
-import "context"
+import (
+	"context"
+
+	"github.com/abcxyz/guardian/pkg/config"
+)
 
 var _ Platform = (*GitLab)(nil)
 
 // GitLab implements the Platform interface.
 type GitLab struct{}
 
-type gitLabConfig struct{}
-
 // NewGitLab creates a new GitLab client.
-func NewGitLab(ctx context.Context, cfg *gitLabConfig) (*GitLab, error) {
+func NewGitLab(ctx context.Context, cfg *config.GitLab) (*GitLab, error) {
 	return &GitLab{}, nil
 }
 

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -16,21 +16,19 @@ package platform
 
 import (
 	"context"
+
+	"github.com/abcxyz/guardian/pkg/config"
 )
 
 var _ Platform = (*Local)(nil)
 
 // Local implements the Platform interface for running Guardian locally.
 type Local struct {
-	cfg *localConfig
-}
-
-type localConfig struct {
-	LocalModifierContent string
+	cfg *config.Local
 }
 
 // NewLocal creates a new Local instance.
-func NewLocal(ctx context.Context, cfg *localConfig) *Local {
+func NewLocal(ctx context.Context, cfg *config.Local) *Local {
 	return &Local{cfg: cfg}
 }
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -79,11 +79,11 @@ type Platform interface {
 
 // NewPlatform creates a new platform based on the provided type.
 func NewPlatform(ctx context.Context, cfg *config.Platform) (Platform, error) {
-	if strings.EqualFold(cfg.Type, config.TypeLocal) {
+	if strings.EqualFold(cfg.Type, config.PlatformTypeLocal) {
 		return NewLocal(ctx, &cfg.Local), nil
 	}
 
-	if strings.EqualFold(cfg.Type, config.TypeGitHub) {
+	if strings.EqualFold(cfg.Type, config.PlatformTypeGitHub) {
 		gc, err := NewGitHub(ctx, &cfg.GitHub)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create github: %w", err)
@@ -91,7 +91,7 @@ func NewPlatform(ctx context.Context, cfg *config.Platform) (Platform, error) {
 		return gc, nil
 	}
 
-	if strings.EqualFold(cfg.Type, config.TypeGitLab) {
+	if strings.EqualFold(cfg.Type, config.PlatformTypeGitLab) {
 		gl, err := NewGitLab(ctx, &cfg.GitLab)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create gitlab: %w", err)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -19,31 +19,12 @@ package platform
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
+
+	"github.com/abcxyz/guardian/pkg/config"
 )
 
-const (
-	TypeUnspecified = ""
-	TypeLocal       = "local"
-	TypeGitHub      = "github"
-	TypeGitLab      = "gitlab"
-)
-
-var (
-	allowedTypes = map[string]struct{}{
-		TypeLocal:  {},
-		TypeGitHub: {},
-		TypeGitLab: {},
-	}
-	// SortedTypes are the sorted Platform types for printing messages and prediction.
-	SortedTypes = func() []string {
-		allowed := append([]string{}, TypeLocal, TypeGitHub, TypeGitLab)
-		sort.Strings(allowed)
-		return allowed
-	}()
-	_ Platform = (*GitHub)(nil)
-)
+var _ Platform = (*GitHub)(nil)
 
 // AssignReviewersInput defines the principal types that can be assigned to a
 // change request.
@@ -97,12 +78,12 @@ type Platform interface {
 }
 
 // NewPlatform creates a new platform based on the provided type.
-func NewPlatform(ctx context.Context, cfg *Config) (Platform, error) {
-	if strings.EqualFold(cfg.Type, TypeLocal) {
+func NewPlatform(ctx context.Context, cfg *config.Platform) (Platform, error) {
+	if strings.EqualFold(cfg.Type, config.TypeLocal) {
 		return NewLocal(ctx, &cfg.Local), nil
 	}
 
-	if strings.EqualFold(cfg.Type, TypeGitHub) {
+	if strings.EqualFold(cfg.Type, config.TypeGitHub) {
 		gc, err := NewGitHub(ctx, &cfg.GitHub)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create github: %w", err)
@@ -110,7 +91,7 @@ func NewPlatform(ctx context.Context, cfg *Config) (Platform, error) {
 		return gc, nil
 	}
 
-	if strings.EqualFold(cfg.Type, TypeGitLab) {
+	if strings.EqualFold(cfg.Type, config.TypeGitLab) {
 		gl, err := NewGitLab(ctx, &cfg.GitLab)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create gitlab: %w", err)

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -19,24 +19,11 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"sort"
 	"strings"
 
+	"github.com/abcxyz/guardian/pkg/config"
 	"github.com/abcxyz/guardian/pkg/github"
 )
-
-const (
-	TypeNone   string = "none"
-	TypeGitHub string = "github"
-	TypeFile   string = "file"
-)
-
-// SortedReporterTypes are the sorted Reporter types for printing messages and prediction.
-var SortedReporterTypes = func() []string {
-	allowed := append([]string{}, TypeNone, TypeGitHub)
-	sort.Strings(allowed)
-	return allowed
-}()
 
 // Status is the result of the operation Guardian is performing.
 type Status string
@@ -92,15 +79,15 @@ type Config struct {
 
 // NewReporter creates a new reporter based on the provided type.
 func NewReporter(ctx context.Context, t string, c *Config) (Reporter, error) {
-	if strings.EqualFold(t, TypeNone) {
+	if strings.EqualFold(t, config.ReporterTypeNone) {
 		return NewNoopReporter(ctx)
 	}
 
-	if strings.EqualFold(t, TypeFile) {
+	if strings.EqualFold(t, config.ReporterTypeFile) {
 		return NewFileReporter()
 	}
 
-	if strings.EqualFold(t, TypeGitHub) {
+	if strings.EqualFold(t, config.ReporterTypeGitHub) {
 		c.GitHub.Permissions = map[string]string{
 			"contents":      "read",
 			"pull_requests": "write",


### PR DESCRIPTION
This separates all configuration options to a `config` package to avoid cyclical dependencies.