### PR TITLE
Add CommentStatus to Platform interface with GitHub implementation

### DIFF
--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -54,6 +54,8 @@ type Config struct {
 
 	// Policy
 	IncludeTeams bool
+
+	SkipReporting bool
 }
 
 type configDefaults struct {

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -54,8 +54,6 @@ type Config struct {
 
 	// Policy
 	IncludeTeams bool
-
-	SkipReporting bool
 }
 
 type configDefaults struct {

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -493,16 +493,6 @@ func (g *GitHub) CommentStatus(ctx context.Context, st Status, p *StatusParams) 
 	return nil
 }
 
-// CommentEntrypointsSummary reports the summary for the entrypionts command.
-func (g *GitHub) CommentEntrypointsSummary(ctx context.Context, params *EntrypointsSummaryParams) error {
-	return nil
-}
-
-// ClearComments clears any existing reports that can be removed.
-func (g *GitHub) ClearComments(ctx context.Context) error {
-	return nil
-}
-
 // createIssueComment creates a comment for an issue or pull request.
 func (g *GitHub) createIssueComment(ctx context.Context, owner, repo string, number int, body string) error {
 	if err := g.withRetries(ctx, func(ctx context.Context) error {

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -97,7 +97,9 @@ func NewGitHub(ctx context.Context, cfg *gh.Config) (*GitHub, error) {
 	graphqlClient := githubv4.NewClient(tc)
 
 	if err := validateGitHubReporterInputs(cfg); err != nil {
-		logger.WarnContext(ctx, "skipping comment reporting", "skip_reporting", cfg.SkipReporting, "err", err)
+		logger.WarnContext(ctx, "skipping comment reporting",
+			"skip_reporting", cfg.SkipReporting,
+			"err", err)
 		cfg.SkipReporting = true
 	}
 

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -94,10 +94,18 @@ func NewGitHub(ctx context.Context, cfg *gh.Config) (*GitHub, error) {
 	client := github.NewClient(tc)
 	graphqlClient := githubv4.NewClient(tc)
 
+	var logURL string
+	if cfg.GitHubServerURL != "" || cfg.GitHubRunID > 0 || cfg.GitHubRunAttempt > 0 {
+		logURL = fmt.Sprintf("%s/%s/%s/actions/runs/%d/attempts/%d", cfg.GitHubServerURL, cfg.GitHubOwner, cfg.GitHubRepo, cfg.GitHubRunID, cfg.GitHubRunAttempt)
+	}
+
+	// TODO: Resolve Job URL with GitHub API.
+
 	g := &GitHub{
 		cfg:           cfg,
 		client:        client,
 		graphqlClient: graphqlClient,
+		logURL:        logURL,
 	}
 
 	return g, nil

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -461,3 +461,18 @@ func (g *GitHub) StoragePrefix(ctx context.Context) (string, error) {
 	logger.DebugContext(ctx, "returning no storage prefix")
 	return "", nil
 }
+
+// CommentStatus reports the status of a run.
+func (g *GitHub) CommentStatus(ctx context.Context, status Status, params *StatusParams) error {
+	return nil
+}
+
+// CommentEntrypointsSummary reports the summary for the entrypionts command.
+func (g *GitHub) CommentEntrypointsSummary(ctx context.Context, params *EntrypointsSummaryParams) error {
+	return nil
+}
+
+// ClearComments clears any existing reports that can be removed.
+func (g *GitHub) ClearComments(ctx context.Context) error {
+	return nil
+}

--- a/pkg/platform/gitlab.go
+++ b/pkg/platform/gitlab.go
@@ -64,13 +64,3 @@ func (g *GitLab) StoragePrefix(ctx context.Context) (string, error) {
 func (g *GitLab) CommentStatus(ctx context.Context, status Status, params *StatusParams) error {
 	return nil
 }
-
-// CommentEntrypointsSummary reports the summary for the entrypionts command.
-func (g *GitLab) CommentEntrypointsSummary(ctx context.Context, params *EntrypointsSummaryParams) error {
-	return nil
-}
-
-// ClearComments clears any existing reports that can be removed.
-func (g *GitLab) ClearComments(ctx context.Context) error {
-	return nil
-}

--- a/pkg/platform/gitlab.go
+++ b/pkg/platform/gitlab.go
@@ -59,3 +59,18 @@ func (g *GitLab) GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error
 func (g *GitLab) StoragePrefix(ctx context.Context) (string, error) {
 	return "", nil
 }
+
+// CommentStatus reports the status of a run.
+func (g *GitLab) CommentStatus(ctx context.Context, status Status, params *StatusParams) error {
+	return nil
+}
+
+// CommentEntrypointsSummary reports the summary for the entrypionts command.
+func (g *GitLab) CommentEntrypointsSummary(ctx context.Context, params *EntrypointsSummaryParams) error {
+	return nil
+}
+
+// ClearComments clears any existing reports that can be removed.
+func (g *GitLab) ClearComments(ctx context.Context) error {
+	return nil
+}

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -73,13 +73,3 @@ func (l *Local) StoragePrefix(ctx context.Context) (string, error) {
 func (l *Local) CommentStatus(ctx context.Context, status Status, params *StatusParams) error {
 	return nil
 }
-
-// CommentEntrypointsSummary is a no-op.
-func (l *Local) CommentEntrypointsSummary(ctx context.Context, params *EntrypointsSummaryParams) error {
-	return nil
-}
-
-// ClearComments is a no-op.
-func (l *Local) ClearComments(ctx context.Context) error {
-	return nil
-}

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -68,3 +68,18 @@ func (l *Local) ModifierContent(ctx context.Context) (string, error) {
 func (l *Local) StoragePrefix(ctx context.Context) (string, error) {
 	return "", nil
 }
+
+// CommentStatus is a no-op.
+func (l *Local) CommentStatus(ctx context.Context, status Status, params *StatusParams) error {
+	return nil
+}
+
+// CommentEntrypointsSummary is a no-op.
+func (l *Local) CommentEntrypointsSummary(ctx context.Context, params *EntrypointsSummaryParams) error {
+	return nil
+}
+
+// ClearComments is a no-op.
+func (l *Local) ClearComments(ctx context.Context) error {
+	return nil
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -98,12 +98,6 @@ type Platform interface {
 
 	// CommentStatus reports the status of a run.
 	CommentStatus(ctx context.Context, status Status, params *StatusParams) error
-
-	// CommentEntrypointsSummary reports the summary for the entrypionts command.
-	CommentEntrypointsSummary(ctx context.Context, params *EntrypointsSummaryParams) error
-
-	// ClearComments clears any existing reports that can be removed.
-	ClearComments(ctx context.Context) error
 }
 
 // NewPlatform creates a new platform based on the provided type.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -28,12 +28,6 @@ const (
 	TypeLocal       = "local"
 	TypeGitHub      = "github"
 	TypeGitLab      = "gitlab"
-
-	StatusSuccess         Status = Status("SUCCESS")          //nolint:errname // Not an error
-	StatusFailure         Status = Status("FAILURE")          //nolint:errname // Not an error
-	StatusNoOperation     Status = Status("NO CHANGES")       //nolint:errname // Not an error
-	StatusPolicyViolation Status = Status("POLICY VIOLATION") //nolint:errname // Not an error
-	StatusUnknown         Status = Status("UNKNOWN")          //nolint:errname // Not an error
 )
 
 var (
@@ -49,34 +43,8 @@ var (
 		return allowed
 	}()
 
-	statusText = map[Status]string{
-		StatusSuccess:         "🟩 SUCCESS",
-		StatusNoOperation:     "🟦 NO CHANGES",
-		StatusFailure:         "🟥 FAILED",
-		StatusUnknown:         "⛔️ UNKNOWN",
-		StatusPolicyViolation: "🚨 ATTENTION REQUIRED",
-	}
-
 	_ Platform = (*GitHub)(nil)
 )
-
-// Status is the result of the operation Guardian is performing.
-type Status string
-
-// StatusParams are the parameters for writing status reports.
-type StatusParams struct {
-	HasDiff   bool
-	Details   string
-	Dir       string
-	Message   string
-	Operation string
-}
-
-// EntrypointsSummaryParams are the parameters for writing entrypoints summary reports.
-type EntrypointsSummaryParams struct {
-	Message string
-	Dirs    []string
-}
 
 // AssignReviewersInput defines the principal types that can be assigned to a
 // change request.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -28,6 +28,12 @@ const (
 	TypeLocal       = "local"
 	TypeGitHub      = "github"
 	TypeGitLab      = "gitlab"
+
+	StatusSuccess         Status = Status("SUCCESS")          //nolint:errname // Not an error
+	StatusFailure         Status = Status("FAILURE")          //nolint:errname // Not an error
+	StatusNoOperation     Status = Status("NO CHANGES")       //nolint:errname // Not an error
+	StatusPolicyViolation Status = Status("POLICY VIOLATION") //nolint:errname // Not an error
+	StatusUnknown         Status = Status("UNKNOWN")          //nolint:errname // Not an error
 )
 
 var (
@@ -42,8 +48,35 @@ var (
 		sort.Strings(allowed)
 		return allowed
 	}()
+
+	statusText = map[Status]string{
+		StatusSuccess:         "🟩 SUCCESS",
+		StatusNoOperation:     "🟦 NO CHANGES",
+		StatusFailure:         "🟥 FAILED",
+		StatusUnknown:         "⛔️ UNKNOWN",
+		StatusPolicyViolation: "🚨 ATTENTION REQUIRED",
+	}
+
 	_ Platform = (*GitHub)(nil)
 )
+
+// Status is the result of the operation Guardian is performing.
+type Status string
+
+// StatusParams are the parameters for writing status reports.
+type StatusParams struct {
+	HasDiff   bool
+	Details   string
+	Dir       string
+	Message   string
+	Operation string
+}
+
+// EntrypointsSummaryParams are the parameters for writing entrypoints summary reports.
+type EntrypointsSummaryParams struct {
+	Message string
+	Dirs    []string
+}
 
 // AssignReviewersInput defines the principal types that can be assigned to a
 // change request.
@@ -94,6 +127,15 @@ type Platform interface {
 
 	// StoragePrefix generates the unique storage prefix for the platform type.
 	StoragePrefix(ctx context.Context) (string, error)
+
+	// CommentStatus reports the status of a run.
+	CommentStatus(ctx context.Context, status Status, params *StatusParams) error
+
+	// CommentEntrypointsSummary reports the summary for the entrypionts command.
+	CommentEntrypointsSummary(ctx context.Context, params *EntrypointsSummaryParams) error
+
+	// ClearComments clears any existing reports that can be removed.
+	ClearComments(ctx context.Context) error
 }
 
 // NewPlatform creates a new platform based on the provided type.

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -161,3 +161,18 @@ func (m *MockPlatform) StoragePrefix(ctx context.Context) (string, error) {
 
 	return m.StoragePrefixResp, m.StoragePrefixErr
 }
+
+// CommentStatus reports the status of a run.
+func (m *MockPlatform) CommentStatus(ctx context.Context, status Status, params *StatusParams) error {
+	return nil
+}
+
+// CommentEntrypointsSummary reports the summary for the entrypionts command.
+func (m *MockPlatform) CommentEntrypointsSummary(ctx context.Context, params *EntrypointsSummaryParams) error {
+	return nil
+}
+
+// ClearComments clears any existing reports that can be removed.
+func (m *MockPlatform) ClearComments(ctx context.Context) error {
+	return nil
+}

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -166,13 +166,3 @@ func (m *MockPlatform) StoragePrefix(ctx context.Context) (string, error) {
 func (m *MockPlatform) CommentStatus(ctx context.Context, status Status, params *StatusParams) error {
 	return nil
 }
-
-// CommentEntrypointsSummary reports the summary for the entrypionts command.
-func (m *MockPlatform) CommentEntrypointsSummary(ctx context.Context, params *EntrypointsSummaryParams) error {
-	return nil
-}
-
-// ClearComments clears any existing reports that can be removed.
-func (m *MockPlatform) ClearComments(ctx context.Context) error {
-	return nil
-}

--- a/pkg/platform/reporter.go
+++ b/pkg/platform/reporter.go
@@ -21,11 +21,11 @@ import (
 )
 
 const (
-	StatusSuccess         Status = Status("SUCCESS")          //nolint:errname // Not an error
-	StatusFailure         Status = Status("FAILURE")          //nolint:errname // Not an error
-	StatusNoOperation     Status = Status("NO CHANGES")       //nolint:errname // Not an error
-	StatusPolicyViolation Status = Status("POLICY VIOLATION") //nolint:errname // Not an error
-	StatusUnknown         Status = Status("UNKNOWN")          //nolint:errname // Not an error
+	StatusSuccess         Status = Status("SUCCESS")
+	StatusFailure         Status = Status("FAILURE")
+	StatusNoOperation     Status = Status("NO CHANGES")
+	StatusPolicyViolation Status = Status("POLICY VIOLATION")
+	StatusUnknown         Status = Status("UNKNOWN")
 )
 
 var statusText = map[Status]string{
@@ -46,12 +46,6 @@ type StatusParams struct {
 	Dir       string
 	Message   string
 	Operation string
-}
-
-// EntrypointsSummaryParams are the parameters for writing entrypoints summary reports.
-type EntrypointsSummaryParams struct {
-	Message string
-	Dirs    []string
 }
 
 // markdownPill returns a markdown element that is bolded and wraped in a inline code block.
@@ -145,27 +139,6 @@ func statusMessage(st Status, p *StatusParams, logURL string, maxCommentLength i
 		}
 
 		fmt.Fprintf(&msg, "%s", detailsText)
-	}
-
-	return msg, nil
-}
-
-// entrypointsSummaryMessage generates the entrypoints summary message based on the provided reporter values.
-func entrypointsSummaryMessage(p *EntrypointsSummaryParams, logURL string) (strings.Builder, error) {
-	var msg strings.Builder
-
-	fmt.Fprintf(&msg, "%s", commentPrefix)
-
-	if logURL != "" {
-		fmt.Fprintf(&msg, " [%s]", markdownURL("logs", logURL))
-	}
-
-	if p.Message != "" {
-		fmt.Fprintf(&msg, "\n\n%s", p.Message)
-	}
-
-	if len(p.Dirs) > 0 {
-		fmt.Fprintf(&msg, "\n\n**%s**\n%s", "Directories", strings.Join(p.Dirs, "\n"))
 	}
 
 	return msg, nil

--- a/pkg/platform/reporter.go
+++ b/pkg/platform/reporter.go
@@ -1,0 +1,172 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	StatusSuccess         Status = Status("SUCCESS")          //nolint:errname // Not an error
+	StatusFailure         Status = Status("FAILURE")          //nolint:errname // Not an error
+	StatusNoOperation     Status = Status("NO CHANGES")       //nolint:errname // Not an error
+	StatusPolicyViolation Status = Status("POLICY VIOLATION") //nolint:errname // Not an error
+	StatusUnknown         Status = Status("UNKNOWN")          //nolint:errname // Not an error
+)
+
+var statusText = map[Status]string{
+	StatusSuccess:         "🟩 SUCCESS",
+	StatusNoOperation:     "🟦 NO CHANGES",
+	StatusFailure:         "🟥 FAILED",
+	StatusUnknown:         "⛔️ UNKNOWN",
+	StatusPolicyViolation: "🚨 ATTENTION REQUIRED",
+}
+
+// Status is the result of the operation Guardian is performing.
+type Status string
+
+// StatusParams are the parameters for writing status reports.
+type StatusParams struct {
+	HasDiff   bool
+	Details   string
+	Dir       string
+	Message   string
+	Operation string
+}
+
+// EntrypointsSummaryParams are the parameters for writing entrypoints summary reports.
+type EntrypointsSummaryParams struct {
+	Message string
+	Dirs    []string
+}
+
+// markdownPill returns a markdown element that is bolded and wraped in a inline code block.
+func markdownPill(text string) string {
+	return fmt.Sprintf("**`%s`**", text)
+}
+
+// markdownURL returns a markdown URL string given a title and a URL.
+func markdownURL(text, URL string) string {
+	return fmt.Sprintf("[%s](%s)", text, URL)
+}
+
+// markdonZippy returns a collapsible section with a given title and body.
+func markdownZippy(title, body string) string {
+	return fmt.Sprintf("<details>\n<summary>%s</summary>\n\n%s\n</details>", title, body)
+}
+
+// markdonDiffZippy returns a collapsible section with a given title and body.
+func markdownDiffZippy(title, body string) string {
+	return fmt.Sprintf("<details>\n<summary>%s</summary>\n\n```diff\n\n%s\n```\n</details>", title, body)
+}
+
+var (
+	tildeChanged = regexp.MustCompile(
+		"(?m)" + // enable multi-line mode
+			"^([\t ]*)" + // only match tilde at start of line, can lead with tabs or spaces
+			"([~])") // tilde represents changes and needs switched to exclamation for git diff
+
+	swapLeadingWhitespace = regexp.MustCompile(
+		"(?m)" + // enable multi-line mode
+			"^([\t ]*)" + // only match tilde at start of line, can lead with tabs or spaces
+			`((\-(\/\+)*)|(\+(\/\-)*)|(!))`) // match characters to swap whitespace for git diff (+, +/-, -, -/+, !)
+)
+
+// formatOutputForDiff formats the Terraform diff output for use with
+// diff markdown formatting.
+func formatOutputForDiff(content string) string {
+	content = tildeChanged.ReplaceAllString(content, `$1!`)
+	content = swapLeadingWhitespace.ReplaceAllString(content, "$2$1")
+
+	return content
+}
+
+const (
+	commentPrefix    = "#### 🔱 Guardian 🔱"
+	truncatedMessage = "\n\n> Message has been truncated. See workflow logs to view the full message."
+)
+
+// statusMessage generates the status message based on the provided reporter values.
+func statusMessage(st Status, p *StatusParams, logURL string, maxCommentLength int) (strings.Builder, error) {
+	var msg strings.Builder
+
+	fmt.Fprintf(&msg, "%s", commentPrefix)
+
+	operationText := strings.ToUpper(strings.TrimSpace(p.Operation))
+	if operationText != "" {
+		fmt.Fprintf(&msg, " %s", markdownPill(operationText))
+	}
+
+	stText, ok := statusText[st]
+	if !ok {
+		stText = statusText[StatusUnknown]
+	}
+
+	fmt.Fprintf(&msg, " %s", markdownPill(stText))
+
+	if logURL != "" {
+		fmt.Fprintf(&msg, " [%s]", markdownURL("logs", logURL))
+	}
+
+	if p.Dir != "" {
+		fmt.Fprintf(&msg, "\n\n**Entrypoint:** %s", p.Dir)
+	}
+
+	if p.Message != "" {
+		fmt.Fprintf(&msg, "\n\n %s", p.Message)
+	}
+
+	if p.Details != "" {
+		detailsText := fmt.Sprintf("\n\n%s", markdownZippy("Details", p.Details))
+
+		if p.HasDiff {
+			detailsText = fmt.Sprintf("\n\n%s", markdownDiffZippy("Details", formatOutputForDiff(p.Details)))
+		}
+
+		// if the length of the entire message would exceed the max length
+		// append a truncated message instead of the details text.
+		totalLength := len([]rune(msg.String())) + len([]rune(detailsText))
+		if maxCommentLength >= 0 && totalLength > maxCommentLength {
+			detailsText = truncatedMessage
+		}
+
+		fmt.Fprintf(&msg, "%s", detailsText)
+	}
+
+	return msg, nil
+}
+
+// entrypointsSummaryMessage generates the entrypoints summary message based on the provided reporter values.
+func entrypointsSummaryMessage(p *EntrypointsSummaryParams, logURL string) (strings.Builder, error) {
+	var msg strings.Builder
+
+	fmt.Fprintf(&msg, "%s", commentPrefix)
+
+	if logURL != "" {
+		fmt.Fprintf(&msg, " [%s]", markdownURL("logs", logURL))
+	}
+
+	if p.Message != "" {
+		fmt.Fprintf(&msg, "\n\n%s", p.Message)
+	}
+
+	if len(p.Dirs) > 0 {
+		fmt.Fprintf(&msg, "\n\n**%s**\n%s", "Directories", strings.Join(p.Dirs, "\n"))
+	}
+
+	return msg, nil
+}

--- a/pkg/platform/reporter.go
+++ b/pkg/platform/reporter.go
@@ -28,13 +28,25 @@ const (
 	StatusUnknown         Status = Status("UNKNOWN")
 )
 
-var statusText = map[Status]string{
-	StatusSuccess:         "🟩 SUCCESS",
-	StatusNoOperation:     "🟦 NO CHANGES",
-	StatusFailure:         "🟥 FAILED",
-	StatusUnknown:         "⛔️ UNKNOWN",
-	StatusPolicyViolation: "🚨 ATTENTION REQUIRED",
-}
+var (
+	tildeChanged = regexp.MustCompile(
+		"(?m)" + // enable multi-line mode
+			"^([\t ]*)" + // only match tilde at start of line, can lead with tabs or spaces
+			"([~])") // tilde represents changes and needs switched to exclamation for git diff
+
+	swapLeadingWhitespace = regexp.MustCompile(
+		"(?m)" + // enable multi-line mode
+			"^([\t ]*)" + // only match tilde at start of line, can lead with tabs or spaces
+			`((\-(\/\+)*)|(\+(\/\-)*)|(!))`) // match characters to swap whitespace for git diff (+, +/-, -, -/+, !)
+
+	statusText = map[Status]string{
+		StatusSuccess:         "🟩 SUCCESS",
+		StatusNoOperation:     "🟦 NO CHANGES",
+		StatusFailure:         "🟥 FAILED",
+		StatusUnknown:         "⛔️ UNKNOWN",
+		StatusPolicyViolation: "🚨 ATTENTION REQUIRED",
+	}
+)
 
 // Status is the result of the operation Guardian is performing.
 type Status string
@@ -58,7 +70,7 @@ func markdownURL(text, URL string) string {
 	return fmt.Sprintf("[%s](%s)", text, URL)
 }
 
-// markdonZippy returns a collapsible section with a given title and body.
+// markdownZippy returns a collapsible section with a given title and body.
 func markdownZippy(title, body string) string {
 	return fmt.Sprintf("<details>\n<summary>%s</summary>\n\n%s\n</details>", title, body)
 }
@@ -67,18 +79,6 @@ func markdownZippy(title, body string) string {
 func markdownDiffZippy(title, body string) string {
 	return fmt.Sprintf("<details>\n<summary>%s</summary>\n\n```diff\n\n%s\n```\n</details>", title, body)
 }
-
-var (
-	tildeChanged = regexp.MustCompile(
-		"(?m)" + // enable multi-line mode
-			"^([\t ]*)" + // only match tilde at start of line, can lead with tabs or spaces
-			"([~])") // tilde represents changes and needs switched to exclamation for git diff
-
-	swapLeadingWhitespace = regexp.MustCompile(
-		"(?m)" + // enable multi-line mode
-			"^([\t ]*)" + // only match tilde at start of line, can lead with tabs or spaces
-			`((\-(\/\+)*)|(\+(\/\-)*)|(!))`) // match characters to swap whitespace for git diff (+, +/-, -, -/+, !)
-)
 
 // formatOutputForDiff formats the Terraform diff output for use with
 // diff markdown formatting.


### PR DESCRIPTION
This change is part of a multi-PR change to migrate all Reporter functionality to the Platform interface. 

The motivation is to report based on the platform type, instead of allowing a mix and match between the platform type and reporter type. This will also help avoid cyclical dependencies stemmed from sharing configs.