### PR TITLE
Add error message to plan comments

### DIFF
--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -246,6 +246,7 @@ func (c *PlanCommand) Process(ctx context.Context) error {
 	if err != nil {
 		merr = errors.Join(merr, fmt.Errorf("failed to run Guardian plan: %w", err))
 		status = reporter.StatusFailure
+		rp.ErrorMessage = err.Error()
 		rp.Details = result.commentDetails
 	}
 

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -219,7 +219,7 @@ func TestPlan_Process(t *testing.T) {
 			expReporterClientReqs: []*reporter.Request{
 				{
 					Name:   "Status",
-					Params: []any{reporter.StatusFailure, &reporter.StatusParams{HasDiff: false, Details: "terraform init failed", Dir: "testdata", Operation: "plan"}},
+					Params: []any{reporter.StatusFailure, &reporter.StatusParams{HasDiff: false, Details: "terraform init failed", ErrorMessage: "failed to initialize: failed to run terraform init", Dir: "testdata", Operation: "plan"}},
 				},
 			},
 		},

--- a/pkg/platform/reporter.go
+++ b/pkg/platform/reporter.go
@@ -53,11 +53,12 @@ type Status string
 
 // StatusParams are the parameters for writing status reports.
 type StatusParams struct {
-	HasDiff   bool
-	Details   string
-	Dir       string
-	Message   string
-	Operation string
+	HasDiff      bool
+	Details      string
+	Dir          string
+	ErrorMessage string
+	Message      string
+	Operation    string
 }
 
 // EntrypointsSummaryParams are the parameters for writing entrypoints summary reports.
@@ -78,7 +79,7 @@ func markdownURL(text, URL string) string {
 
 // markdownZippy returns a collapsible section with a given title and body.
 func markdownZippy(title, body string) string {
-	return fmt.Sprintf("<details>\n<summary>%s</summary>\n\n%s\n</details>", title, body)
+	return fmt.Sprintf("<details>\n<summary>%s</summary>\n\n`%s`\n</details>", title, body)
 }
 
 // markdonDiffZippy returns a collapsible section with a given title and body.
@@ -128,6 +129,10 @@ func statusMessage(st Status, p *StatusParams, logURL string, maxCommentLength i
 
 	if p.Message != "" {
 		fmt.Fprintf(&msg, "\n\n %s", p.Message)
+	}
+
+	if p.ErrorMessage != "" {
+		fmt.Fprintf(&msg, "\n\n **Error:** `%s`", p.ErrorMessage)
 	}
 
 	if p.Details != "" {

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -60,11 +60,12 @@ var statusText = map[Status]string{
 
 // StatusParams are the parameters for writing status reports.
 type StatusParams struct {
-	HasDiff   bool
-	Details   string
-	Dir       string
-	Message   string
-	Operation string
+	HasDiff      bool
+	Details      string
+	Dir          string
+	ErrorMessage string
+	Message      string
+	Operation    string
 }
 
 // EntrypointsSummaryParams are the parameters for writing entrypoints summary reports.
@@ -201,6 +202,10 @@ func statusMessage(st Status, p *StatusParams, logURL string, maxCommentLength i
 
 	if p.Message != "" {
 		fmt.Fprintf(&msg, "\n\n %s", p.Message)
+	}
+
+	if p.ErrorMessage != "" {
+		fmt.Fprintf(&msg, "\n\n **Error:** `%s`", p.ErrorMessage)
 	}
 
 	if p.Details != "" {


### PR DESCRIPTION
This change adds the error message back to the plan comment, for tracing the source of the failure. 

<img width="837" alt="Screenshot 2024-12-09 at 9 19 22 AM" src="https://github.com/user-attachments/assets/7c071f4d-8472-4fc5-b53f-98e3e5f1fa03">
