### PR TITLE
Update documentation for CLI commands and remove unused `-destroy` flag in `plan` and `apply` commands

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -34,9 +34,6 @@ These options influence how Guardian interacts with GitHub:
   This option can also be specified with the GITHUB_ACTIONS environment variable.
 * **-github-owner="organization-name"** - The GitHub repository owner.
 * **-github-repo="repository-name"** - The GitHub repository name.
-* **-github-token="string"** - The GitHub access token used for Terraform to make GitHub API calls. This
-  value is automatically set on GitHub Actions. This option can also be specified with
-  the GITHUB_TOKEN environment variable.
 * **-guardian-github-token="string"** - The GitHub access token for Guardian to make GitHub API calls.
   This is separate from GITHUB_TOKEN because Terraform uses GITHUB_TOKEN to
   authenticate to the GitHub APIs also. Splitting this up allows users to

--- a/cli.md
+++ b/cli.md
@@ -136,11 +136,6 @@ Also supports [Platform Options](#platform-options), [GitHub Options](#github-op
   *Supported values:*
     - Local file storage - Format `file://my/absolute/path`
     - Google Cloud Storage Bucket - Format `gcs://my-guardian-state-bucket`
-* **-storage="URL"** - The storage strategy for saving Guardian plan files. Defaults to current working directory of the local filesystem.
-
-  *Supported values:*
-    - Local file storage - Format `file://my/absolute/path`
-    - Google Cloud Storage Bucket - Format `gcs://my-guardian-state-bucket`
 
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".

--- a/cli.md
+++ b/cli.md
@@ -38,8 +38,8 @@ These options influence how Guardian interacts with GitHub:
   value is automatically set on GitHub Actions. This option can also be specified with
   the GITHUB_TOKEN environment variable.
 * **-guardian-github-token="string"** - The GitHub access token for Guardian to make GitHub API calls.
-  This is separate from GITHUB_TOKEN becuse Terraform uses GITHUB_TOKEN to
-  authenticate to the GitHub APIs also. Splitting this up allows use to
+  This is separate from GITHUB_TOKEN because Terraform uses GITHUB_TOKEN to
+  authenticate to the GitHub APIs also. Splitting this up allows users to
   follow least privilege for the caller (e.g. Guardian vs Terraform). If
   not supplied this will default to GITHUB_TOKEN. This option can also be
   specified with the GUARDIAN_GITHUB_TOKEN environment variable.

--- a/cli.md
+++ b/cli.md
@@ -13,7 +13,8 @@ Supported commands:
 | drift                       | [statefiles](#drift-statefiles)                                 | `issues: write`<br> `contents: read`                              | Detect drift for terraform statefiles                         |
 | workflows                   | [plan-status-comment](#workflows-plan-status-comment)           | `pull-requests: write`                                            | Add Guardian plan comment to a pull request                   |
 |                             | [remove-guardian-comments](#workflows-remove-guardian-comments) | `contents: read`<br> `pull-requests: write`                       | Remove previous Guardian comments from a pull request         |
-|                             | [validate-permissions](#workflows-validate-permissions)         | `contents: read`                                                  | Validate required permissions for the current GitHub workflow |
+| policy                      | fetch-data                                                      | `contents: read`                                                  | Fetch data used for policy evaluation   |
+|                             | enforce                                                         | `contents: read` <br> `pull-requests: write`                      | Enforce a set of Guardian policies      |
 
 ## Shared Options
 
@@ -30,6 +31,8 @@ These options influence how Guardian interacts with GitHub:
 * **-github-token="string"** - The GitHub access token to make GitHub API calls. This
   value is automatically set on GitHub Actions. This option can also be specified with
   the GITHUB_TOKEN environment variable.
+* **-github-pull-request-number="100"** - The GitHub pull request number associated with this
+  apply. Only one of pull-request-number and commit-sha can be given. The default value is "0".
 
 ### Retry Options
 
@@ -91,14 +94,12 @@ Also supports [GitHub Options](#github-options) and [Retry Options](#retry-optio
 
 * **-dir** - The Terraform directory to run the apply command. Defaults to the current working directory.
 * **-allow-lockfile-changes** - Allow modification of the Terraform lockfile. The default value is "false".
-* **-bucket-name="my-guardian-state-bucket"** - The Google Cloud Storage bucket name to store Guardian plan files.
+* **-storage="gcs://my-guardian-state-bucket"** - The storage strategy for saving Guardian plan files. Defaults to current working directory. Valid values are ["file" "gcs"].
 * **-commit-sha="e538db9a29f2ff7a404a2ef40bb62a6df88c98c1"** - The commit sha to determine
   the pull request number associated with this apply. Only one of pull-request-number
   and commit-sha can be given.
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
-* **-pull-request-number="100"** - The GitHub pull request number associated with this
-  apply. Only one of pull-request-number and commit-sha can be given. The default value is "0".
 
 ## Plan
 
@@ -359,4 +360,3 @@ Usage: guardian workflows validate-permissions [options]
 Also supports [GitHub Options](#github-options) and [Retry Options](#retry-options).
 
 * **-allowed-permissions="admin, write"** - The list of allowed permissions to validate against.
-        

--- a/cli.md
+++ b/cli.md
@@ -321,12 +321,10 @@ Usage: guardian workflows plan-status-comment [options]
 
 ### Options
 
-Also supports [GitHub Options](#github-options) and [Retry Options](#retry-options).
+Also supports [Platform Options](#platform-options), [GitHub Options](#github-options) and [Retry Options](#retry-options).
 
 * **-init-result="success"** - The Guardian init job result status.
 * **-plan-result="failure"** - The Guardian plan job result status.
-* **-pull-request-number="100"** - The GitHub pull request number to remove plan
-  comments from. The default value is "0".
 
 ## Workflows remove-guardian-comments
 
@@ -340,24 +338,4 @@ Usage: guardian workflows remove-guardian-comments [options]
 
 ### Options
 
-Also supports [GitHub Options](#github-options) and [Retry Options](#retry-options).
-
-* **-pull-request-number="100"** - The GitHub pull request number to remove plan
-  comments from. The default value is "0".
-* **-for-command="plan,apply"** - The Guardian command to remove comments for. Valid values are ["apply", "plan"]
-
-## Workflows validate-permissions
-
-Validate a list of allowed permissions for the actor running the current GitHub workflow.
-
-Usage: guardian workflows validate-permissions [options]
-
-### Prerequisites
-
-* Read permission to the target GitHub repository `content`.
-
-### Options
-
-Also supports [GitHub Options](#github-options) and [Retry Options](#retry-options).
-
-* **-allowed-permissions="admin, write"** - The list of allowed permissions to validate against.
+Supports [Platform Options](#platform-options), [GitHub Options](#github-options) and [Retry Options](#retry-options).

--- a/cli.md
+++ b/cli.md
@@ -13,8 +13,8 @@ Supported commands:
 | drift                       | [statefiles](#drift-statefiles)                                 | `issues: write`<br> `contents: read`                              | Detect drift for terraform statefiles                         |
 | workflows                   | [plan-status-comment](#workflows-plan-status-comment)           | `pull-requests: write`                                            | Add Guardian plan comment to a pull request                   |
 |                             | [remove-guardian-comments](#workflows-remove-guardian-comments) | `contents: read`<br> `pull-requests: write`                       | Remove previous Guardian comments from a pull request         |
-| policy                      | fetch-data                                                      | `contents: read`                                                  | Fetch data used for policy evaluation   |
-|                             | enforce                                                         | `contents: read` <br> `pull-requests: write`                      | Enforce a set of Guardian policies      |
+| policy                      | fetch-data                                                      | See [Policy fetch-data command](#policy-fetch-data)               | Fetch data used for policy evaluation   |
+|                             | enforce                                                         | See [Policy enforce command](#policy-fetch-data)                  | Enforce a set of Guardian policies      |
 
 ## Shared Options
 

--- a/cli.md
+++ b/cli.md
@@ -20,6 +20,12 @@ Supported commands:
 
 These options influence any command run with Guardian.
 
+### Platform Options
+These options sets the code review platform that Guardian should interact with.
+
+- **-platform="github"** - The code review platform for Guardian to integrate with. Allowed values are ["github", "local"].
+- **-reporter="github"** - The reporting strategy for Guardian status updates. Allowed values are ["github", "none"].
+
 ### GitHub Options
 
 These options influence how Guardian interacts with GitHub:
@@ -28,9 +34,15 @@ These options influence how Guardian interacts with GitHub:
   This option can also be specified with the GITHUB_ACTIONS environment variable.
 * **-github-owner="organization-name"** - The GitHub repository owner.
 * **-github-repo="repository-name"** - The GitHub repository name.
-* **-github-token="string"** - The GitHub access token to make GitHub API calls. This
+* **-github-token="string"** - The GitHub access token used for Terraform to make GitHub API calls. This
   value is automatically set on GitHub Actions. This option can also be specified with
   the GITHUB_TOKEN environment variable.
+* **-guardian-github-token="string"** - The GitHub access token for Guardian to make GitHub API calls.
+  This is separate from GITHUB_TOKEN becuse Terraform uses GITHUB_TOKEN to
+  authenticate to the GitHub APIs also. Splitting this up allows use to
+  follow least privilege for the caller (e.g. Guardian vs Terraform). If
+  not supplied this will default to GITHUB_TOKEN. This option can also be
+  specified with the GUARDIAN_GITHUB_TOKEN environment variable.
 * **-github-pull-request-number="100"** - The GitHub pull request number associated with this
   apply. Only one of pull-request-number and commit-sha can be given. The default value is "0".
 
@@ -57,7 +69,7 @@ Usage: guardian entrypoints [options]
 
 ### Options
 
-Also supports [GitHub Options](#github-options) and [Retry Options](#retry-options).
+Also supports [Platform Options](#platform-options), [GitHub Options](#github-options) and [Retry Options](#retry-options).
 
 * **-dir** - The root directory to search for entrypoint directories. Defaults to the current working directory.
 * **-dest-ref="ref-name"** - The destination GitHub ref name for finding file changes.
@@ -69,8 +81,6 @@ Also supports [GitHub Options](#github-options) and [Retry Options](#retry-optio
   formats are: [json text]. The default value is "text".
 * **-max-depth="int"** - How far to traverse the filesystem beneath the target
   directory for entrypoints. The default value is "-1".
-* **-pull-request-number="100"** - The GitHub pull request number associated with
-  this plan. The default value is "0".
 * **-source-ref="ref-name"** - The source GitHub ref name for finding file changes.
 
 ## Apply
@@ -94,12 +104,13 @@ Also supports [GitHub Options](#github-options) and [Retry Options](#retry-optio
 
 * **-dir** - The Terraform directory to run the apply command. Defaults to the current working directory.
 * **-allow-lockfile-changes** - Allow modification of the Terraform lockfile. The default value is "false".
-* **-storage="gcs://my-guardian-state-bucket"** - The storage strategy for saving Guardian plan files. Defaults to current working directory. Valid values are ["file" "gcs"].
+* **-storage="gcs://my-guardian-state-bucket"** - The storage strategy for saving Guardian plan files. Defaults to current working directory. Valid values are ["file", "gcs"].
 * **-commit-sha="e538db9a29f2ff7a404a2ef40bb62a6df88c98c1"** - The commit sha to determine
   the pull request number associated with this apply. Only one of pull-request-number
   and commit-sha can be given.
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
+* **-output-dir="./output/plan"** - Write the plan binary and JSON file to a target local directory.
 
 ## Plan
 
@@ -122,12 +133,10 @@ Also supports [GitHub Options](#github-options) and [Retry Options](#retry-optio
 
 * **-dir** - The Terraform directory to run the plan command. Defaults to the current working directory.
 * **-allow-lockfile-changes** - Allow modification of the Terraform lockfile. The default value is "false".
-* **-bucket-name="my-guardian-state-bucket"** - The Google Cloud Storage bucket name to store Guardian plan files.
+* **-storage="gcs://my-guardian-state-bucket"** - The storage strategy for saving Guardian plan files. Defaults to current working directory. Valid values are ["file", "gcs"].
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
-* **-pull-request-number="100"** - The GitHub pull request number associated with this
-  plan. Only one of pull-request-number and commit-sha can be given. The default value is "0".
-
+* **-output-dir="./output/plan"** - Write the plan binary and JSON file to a target local directory.
 ## Run
 
 Run a Terraform command for a directory.

--- a/cli.md
+++ b/cli.md
@@ -382,7 +382,6 @@ The set of required permissions depends on the the type of policy being enforced
 *Policy types:*
 - `missing_approvals` - Requires `pull-requests: "write"` to assign reviewers to the pull request.
 
-  > [!NOTE]
   > The default workflow token cannot assign **teams** to pull requests. See
     [github-token-minter](https://github.com/abcxyz/github-token-minter) to support assigning team reviewers.
 

--- a/cli.md
+++ b/cli.md
@@ -365,7 +365,18 @@ Usage: guardian policy enforce [options]
 
 ### Prerequisites
 
-* Required GitHub [permissions](#guardian-cli).
+* Requires `pull-requests: "write"` to report any policy violations in a Pull Request comment.
+
+The set of required permissions depends on the the type of policy being enforced.
+
+*Policy types:*
+- `missing_approvals` - Requires `pull-requests: "write"` to assign reviewers to the pull request.
+
+  > [!NOTE]
+  > The default workflow token cannot assign **teams** to pull requests. See
+    [github-token-minter](https://github.com/abcxyz/github-token-minter) to support assigning team reviewers.
+
+- `deny` - No additional permissions required.
 
 ### Options
 

--- a/cli.md
+++ b/cli.md
@@ -100,17 +100,13 @@ Usage: guardian apply [options]
 
 ### Options
 
-Also supports [GitHub Options](#github-options) and [Retry Options](#retry-options).
+Also supports [Platform Options](#platform-options), [GitHub Options](#github-options) and [Retry Options](#retry-options).
 
 * **-dir** - The Terraform directory to run the apply command. Defaults to the current working directory.
 * **-allow-lockfile-changes** - Allow modification of the Terraform lockfile. The default value is "false".
 * **-storage="gcs://my-guardian-state-bucket"** - The storage strategy for saving Guardian plan files. Defaults to current working directory. Valid values are ["file", "gcs"].
-* **-commit-sha="e538db9a29f2ff7a404a2ef40bb62a6df88c98c1"** - The commit sha to determine
-  the pull request number associated with this apply. Only one of pull-request-number
-  and commit-sha can be given.
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
-* **-output-dir="./output/plan"** - Write the plan binary and JSON file to a target local directory.
 
 ## Plan
 
@@ -137,6 +133,7 @@ Also supports [GitHub Options](#github-options) and [Retry Options](#retry-optio
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
 * **-output-dir="./output/plan"** - Write the plan binary and JSON file to a target local directory.
+
 ## Run
 
 Run a Terraform command for a directory.

--- a/cli.md
+++ b/cli.md
@@ -125,7 +125,7 @@ Usage: guardian plan [options]
 
 ### Options
 
-Also supports [GitHub Options](#github-options) and [Retry Options](#retry-options).
+Also supports [Platform Options](#platform-options), [GitHub Options](#github-options) and [Retry Options](#retry-options).
 
 * **-dir** - The Terraform directory to run the plan command. Defaults to the current working directory.
 * **-allow-lockfile-changes** - Allow modification of the Terraform lockfile. The default value is "false".

--- a/cli.md
+++ b/cli.md
@@ -154,14 +154,9 @@ Also supports [GitHub Options](#github-options) and [Retry Options](#retry-optio
 
 * **-dir** - The Terraform directory to run the command. Defaults to the current working directory.
 * **-allow-lockfile-changes** - Allow modification of the Terraform lockfile. The default value is "false".
-* **-bucket-name="my-guardian-state-bucket"** - The Google Cloud Storage bucket name to store Guardian plan files.
-* **-commit-sha="e538db9a29f2ff7a404a2ef40bb62a6df88c98c1"** - The commit sha to determine
-  the pull request number associated with this apply run. Only one of pull-request-number
-  and commit-sha can be given.
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
-* **-pull-request-number="100"** - The GitHub pull request number associated with this
-  apply run. Only one of pull-request-number and commit-sha can be given. The default value is "0".
+* **-allowed-terraform-commands="plan, apply, destroy"** - The list of allowed Terraform commands to be run. Defaults to all commands.
 
 ## IAM cleanup
 

--- a/cli.md
+++ b/cli.md
@@ -101,7 +101,12 @@ Also supports [Platform Options](#platform-options), [GitHub Options](#github-op
 
 * **-dir** - The Terraform directory to run the apply command. Defaults to the current working directory.
 * **-allow-lockfile-changes** - Allow modification of the Terraform lockfile. The default value is "false".
-* **-storage="gcs://my-guardian-state-bucket"** - The storage strategy for saving Guardian plan files. Defaults to current working directory. Valid values are ["file", "gcs"].
+* **-storage="URL"** - The storage strategy for saving Guardian plan files. Defaults to current working directory of the local filesystem.
+
+  *Supported values:*
+    - Local file storage - Format `file://my/absolute/path`
+    - Google Cloud Storage Bucket - Format `gcs://my-guardian-state-bucket`
+
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
 
@@ -126,7 +131,17 @@ Also supports [Platform Options](#platform-options), [GitHub Options](#github-op
 
 * **-dir** - The Terraform directory to run the plan command. Defaults to the current working directory.
 * **-allow-lockfile-changes** - Allow modification of the Terraform lockfile. The default value is "false".
-* **-storage="gcs://my-guardian-state-bucket"** - The storage strategy for saving Guardian plan files. Defaults to current working directory. Valid values are ["file", "gcs"].
+* **-storage="URL"** - The storage strategy for saving Guardian plan files. Defaults to current working directory of the local filesystem.
+
+  *Supported values:*
+    - Local file storage - Format `file://my/absolute/path`
+    - Google Cloud Storage Bucket - Format `gcs://my-guardian-state-bucket`
+* **-storage="URL"** - The storage strategy for saving Guardian plan files. Defaults to current working directory of the local filesystem.
+
+  *Supported values:*
+    - Local file storage - Format `file://my/absolute/path`
+    - Google Cloud Storage Bucket - Format `gcs://my-guardian-state-bucket`
+
 * **-lock-timeout="10m"** - The duration Terraform should wait to obtain a lock when
   running commands that modify state. The default value is "10m".
 * **-output-dir="./output/plan"** - Write the plan binary and JSON file to a target local directory.

--- a/cli.md
+++ b/cli.md
@@ -339,3 +339,40 @@ Usage: guardian workflows remove-guardian-comments [options]
 ### Options
 
 Supports [Platform Options](#platform-options), [GitHub Options](#github-options) and [Retry Options](#retry-options).
+
+## Policy fetch-data
+
+Fetch data used for policy evaluation.
+
+Usage: guardian policy fetch-data [options]
+
+### Prerequisites
+
+* Required GitHub [permissions](#guardian-cli).
+
+* **members: read** is required for `--include-teams` flag.
+
+### Options
+
+Supports [Platform Options](#platform-options), [GitHub Options](#github-options) and [Retry Options](#retry-options).
+
+* **-output-dir="example/dir"** - Write the policy data JSON file to a target local directory.
+* **--include-teams** - If true, includes team data in payload. Requires 'members: read' token permissions."
+
+
+## Policy enforce
+
+Enforce a set of Guardian policies
+
+Usage: guardian policy enforce [options]
+
+### Prerequisites
+
+* Required GitHub [permissions](#guardian-cli).
+
+### Options
+
+Supports [Platform Options](#platform-options), [GitHub Options](#github-options) and [Retry Options](#retry-options).
+
+* **-results-file="results.json"** - The path to a JSON file containing the OPA eval result.
+* **-silent** - Skips any actions and only reports the violations found. The default value is "false".

--- a/pkg/commands/apply/apply.go
+++ b/pkg/commands/apply/apply.go
@@ -68,7 +68,6 @@ type ApplyCommand struct {
 	flags.CommonFlags
 
 	flagStorage              string
-	flagDestroy              bool
 	flagAllowLockfileChanges bool
 	flagLockTimeout          time.Duration
 
@@ -109,13 +108,6 @@ func (c *ApplyCommand) Flags() *cli.FlagSet {
 		Predict: complete.PredictFunc(func(prefix string) []string {
 			return storage.SortedStorageTypes
 		}),
-	})
-
-	f.BoolVar(&cli.BoolVar{
-		Name:    "destroy",
-		Target:  &c.flagDestroy,
-		Example: "true",
-		Usage:   "Use the destroy flag to apply changes to destroy all infrastructure.",
 	})
 
 	f.BoolVar(&cli.BoolVar{
@@ -258,9 +250,6 @@ func (c *ApplyCommand) Process(ctx context.Context) (merr error) {
 	c.planFileLocalPath = planFileLocalPath
 
 	operation := "apply"
-	if c.flagDestroy {
-		operation = "apply (destroy)"
-	}
 
 	rp := &reporter.StatusParams{
 		Operation: operation,

--- a/pkg/commands/apply/apply_test.go
+++ b/pkg/commands/apply/apply_test.go
@@ -72,7 +72,6 @@ func TestApply_Process(t *testing.T) {
 		directory                string
 		flagAllowLockfileChanges bool
 		flagLockTimeout          time.Duration
-		flagDestroy              bool
 		planExitCode             string
 		storageParent            string
 		storagePrefix            string
@@ -97,37 +96,6 @@ func TestApply_Process(t *testing.T) {
 				{
 					Name:   "Status",
 					Params: []any{reporter.StatusSuccess, &reporter.StatusParams{HasDiff: true, Details: "terraform apply success", Dir: "testdir", Operation: "apply"}},
-				},
-			},
-			expStorageClientReqs: []*storage.Request{
-				{
-					Name: "GetObject",
-					Params: []any{
-						"testdir/test-tfplan.binary",
-					},
-				},
-				{
-					Name: "DeleteObject",
-					Params: []any{
-						"testdir/test-tfplan.binary",
-					},
-				},
-			},
-		},
-		{
-			name:      "success_destroy",
-			directory: "testdir",
-
-			storagePrefix:            "",
-			flagAllowLockfileChanges: true,
-			flagLockTimeout:          10 * time.Minute,
-			flagDestroy:              true,
-			planExitCode:             "2",
-			terraformClient:          terraformMock,
-			expReporterClientReqs: []*reporter.Request{
-				{
-					Name:   "Status",
-					Params: []any{reporter.StatusSuccess, &reporter.StatusParams{HasDiff: true, Details: "terraform apply success", Dir: "testdir", Operation: "apply (destroy)"}},
 				},
 			},
 			expStorageClientReqs: []*storage.Request{
@@ -203,40 +171,6 @@ func TestApply_Process(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:      "handles_error_destroy",
-			directory: "testdir",
-
-			storagePrefix:            "",
-			flagAllowLockfileChanges: true,
-			flagLockTimeout:          10 * time.Minute,
-			flagDestroy:              true,
-			planExitCode:             "2",
-			terraformClient:          terraformErrorMock,
-			expStdout:                "terraform apply output",
-			expStderr:                "terraform apply failed",
-			err:                      "failed to run Guardian apply: failed to apply: failed to run terraform apply",
-			expReporterClientReqs: []*reporter.Request{
-				{
-					Name:   "Status",
-					Params: []any{reporter.StatusFailure, &reporter.StatusParams{HasDiff: true, Details: "terraform apply failed", Dir: "testdir", Operation: "apply (destroy)"}},
-				},
-			},
-			expStorageClientReqs: []*storage.Request{
-				{
-					Name: "GetObject",
-					Params: []any{
-						"testdir/test-tfplan.binary",
-					},
-				},
-				{
-					Name: "DeleteObject",
-					Params: []any{
-						"testdir/test-tfplan.binary",
-					},
-				},
-			},
-		},
 	}
 
 	for _, tc := range cases {
@@ -257,7 +191,6 @@ func TestApply_Process(t *testing.T) {
 				childPath:                tc.directory,
 				planFilename:             "test-tfplan.binary",
 				storagePrefix:            tc.storagePrefix,
-				flagDestroy:              tc.flagDestroy,
 				flagAllowLockfileChanges: tc.flagAllowLockfileChanges,
 				flagLockTimeout:          tc.flagLockTimeout,
 				storageClient:            mockStorageClient,

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -72,7 +72,6 @@ type PlanCommand struct {
 	flags.CommonFlags
 
 	flagOutputDir            string
-	flagDestroy              bool
 	flagStorage              string
 	flagAllowLockfileChanges bool
 	flagLockTimeout          time.Duration
@@ -111,13 +110,6 @@ func (c *PlanCommand) Flags() *cli.FlagSet {
 		Predict: complete.PredictFunc(func(prefix string) []string {
 			return storage.SortedStorageTypes
 		}),
-	})
-
-	f.BoolVar(&cli.BoolVar{
-		Name:    "destroy",
-		Target:  &c.flagDestroy,
-		Example: "true",
-		Usage:   "Use the destroy flag to plan changes to destroy all infrastructure.",
 	})
 
 	f.BoolVar(&cli.BoolVar{
@@ -231,9 +223,6 @@ func (c *PlanCommand) Process(ctx context.Context) error {
 	util.Headerf(c.Stdout(), ("Starting Guardian Plan"))
 
 	operation := "plan"
-	if c.flagDestroy {
-		operation = "plan (destroy)"
-	}
 
 	rp := &reporter.StatusParams{
 		Operation: operation,
@@ -338,7 +327,6 @@ func (c *PlanCommand) terraformPlan(ctx context.Context) (*RunResult, error) {
 		Out:              pointer.To(planAbsFilepath),
 		Input:            pointer.To(false),
 		NoColor:          pointer.To(true),
-		Destroy:          pointer.To(c.flagDestroy),
 		DetailedExitcode: pointer.To(true),
 		LockTimeout:      pointer.To(c.flagLockTimeout.String()),
 	})

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -126,7 +126,6 @@ func TestPlan_Process(t *testing.T) {
 		directory                string
 		storageParent            string
 		storagePrefix            string
-		flagDestroy              bool
 		flagAllowLockfileChanges bool
 		flagLockTimeout          time.Duration
 		terraformClient          *terraform.MockTerraformClient
@@ -147,30 +146,6 @@ func TestPlan_Process(t *testing.T) {
 				{
 					Name:   "Status",
 					Params: []any{reporter.StatusSuccess, &reporter.StatusParams{HasDiff: true, Details: "terraform show success with diff", Dir: "testdata", Operation: "plan"}},
-				},
-			},
-			expStorageClientReqs: []*storage.Request{
-				{
-					Name: "CreateObject",
-					Params: []any{
-						"testdata/tfplan.binary",
-						"this is a plan binary",
-					},
-				},
-			},
-		},
-		{
-			name:                     "success_with_diff_destroy",
-			directory:                "testdata",
-			storagePrefix:            "",
-			flagAllowLockfileChanges: true,
-			flagLockTimeout:          10 * time.Minute,
-			flagDestroy:              true,
-			terraformClient:          terraformDiffMock,
-			expReporterClientReqs: []*reporter.Request{
-				{
-					Name:   "Status",
-					Params: []any{reporter.StatusSuccess, &reporter.StatusParams{HasDiff: true, Details: "terraform show success with diff", Dir: "testdata", Operation: "plan (destroy)"}},
 				},
 			},
 			expStorageClientReqs: []*storage.Request{
@@ -239,7 +214,6 @@ func TestPlan_Process(t *testing.T) {
 				childPath:                tc.directory,
 				storagePrefix:            tc.storagePrefix,
 				flagOutputDir:            t.TempDir(),
-				flagDestroy:              tc.flagDestroy,
 				flagAllowLockfileChanges: tc.flagAllowLockfileChanges,
 				flagLockTimeout:          tc.flagLockTimeout,
 				terraformClient:          tc.terraformClient,

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -96,8 +96,8 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 		EnvVar: "GUARDIAN_GITHUB_TOKEN",
 		Target: &c.GuardianGitHubToken,
 		Usage: `The GitHub access token for Guardian to make GitHub API calls.
-This is separate from GITHUB_TOKEN becuse Terraform uses GITHUB_TOKEN to authenticate
-to the GitHub APIs also. Splitting this up allows use to follow least privilege
+This is separate from GITHUB_TOKEN because Terraform uses GITHUB_TOKEN to authenticate
+to the GitHub APIs also. Splitting this up allows users to follow least privilege
 for the caller (e.g. Guardian vs Terraform). If not supplied this will default to
 GITHUB_TOKEN.`,
 	})


### PR DESCRIPTION
This updates the CLI documentation to reflect the new flag names and options for version `>= v2.0.4`. This also removes an unused `destroy` flag in the `plan` and `apply` commands.