### PR TITLE
Decouple reporter from all commands and replace with platform client

### DIFF
--- a/pkg/commands/entrypoints/entrypoints.go
+++ b/pkg/commands/entrypoints/entrypoints.go
@@ -29,7 +29,6 @@ import (
 	"github.com/abcxyz/guardian/internal/metricswrap"
 	"github.com/abcxyz/guardian/pkg/git"
 	"github.com/abcxyz/guardian/pkg/platform"
-	"github.com/abcxyz/guardian/pkg/reporter"
 	"github.com/abcxyz/guardian/pkg/terraform"
 	"github.com/abcxyz/guardian/pkg/util"
 	"github.com/abcxyz/pkg/cli"
@@ -53,7 +52,6 @@ type EntrypointsCommand struct {
 	parsedFlagMaxDepth *int
 
 	platformClient platform.Platform
-	reporterClient reporter.Reporter
 
 	newGitClient func(ctx context.Context, dir string) git.Git
 }
@@ -168,12 +166,6 @@ func (c *EntrypointsCommand) Run(ctx context.Context, args []string) error {
 	}
 	c.platformClient = platform
 
-	rc, err := reporter.NewReporter(ctx, c.platformConfig.Reporter, &reporter.Config{GitHub: c.platformConfig.GitHub})
-	if err != nil {
-		return fmt.Errorf("failed to create reporter client: %w", err)
-	}
-	c.reporterClient = rc
-
 	return c.Process(ctx)
 }
 
@@ -181,8 +173,7 @@ func (c *EntrypointsCommand) Run(ctx context.Context, args []string) error {
 func (c *EntrypointsCommand) Process(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 	logger.DebugContext(ctx, "starting entrypoints",
-		"platform", c.platformConfig.Type,
-		"reporter", c.platformConfig.Reporter)
+		"platform", c.platformConfig.Type)
 
 	cwd, err := c.WorkingDir()
 	if err != nil {
@@ -228,7 +219,7 @@ func (c *EntrypointsCommand) Process(ctx context.Context) error {
 		return fmt.Errorf("failed to write output: %w", err)
 	}
 
-	if err := c.reporterClient.EntrypointsSummary(ctx, &reporter.EntrypointsSummaryParams{
+	if err := c.platformClient.ReportEntrypointsSummary(ctx, &platform.EntrypointsSummaryParams{
 		Message: "Guardian will run for the following directories",
 		Dirs:    modifiedEntrypoints,
 	}); err != nil {

--- a/pkg/commands/entrypoints/entrypoints_test.go
+++ b/pkg/commands/entrypoints/entrypoints_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/abcxyz/guardian/pkg/git"
 	"github.com/abcxyz/guardian/pkg/platform"
-	"github.com/abcxyz/guardian/pkg/reporter"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
 )
@@ -48,7 +47,6 @@ func TestEntrypointsProcess(t *testing.T) {
 		flagMaxDepth      int
 		newGitClient      func(ctx context.Context, dir string) git.Git
 		platformClient    *platform.MockPlatform
-		reporterClient    *reporter.MockReporter
 		err               string
 		expStdout         string
 		expStderr         string
@@ -193,7 +191,6 @@ func TestEntrypointsProcess(t *testing.T) {
 			t.Parallel()
 
 			mockPlatformClient := &platform.MockPlatform{}
-			mockReporterClient := &reporter.MockReporter{}
 
 			c := &EntrypointsCommand{
 				flagDir:           tc.flagDir,
@@ -202,7 +199,6 @@ func TestEntrypointsProcess(t *testing.T) {
 				flagDetectChanges: tc.flagDetectChanges,
 				flagMaxDepth:      tc.flagMaxDepth,
 				platformClient:    mockPlatformClient,
-				reporterClient:    mockReporterClient,
 
 				newGitClient: tc.newGitClient,
 			}

--- a/pkg/commands/policy/enforce.go
+++ b/pkg/commands/policy/enforce.go
@@ -26,7 +26,6 @@ import (
 	"github.com/abcxyz/guardian/internal/metricswrap"
 	"github.com/abcxyz/guardian/pkg/flags"
 	"github.com/abcxyz/guardian/pkg/platform"
-	"github.com/abcxyz/guardian/pkg/reporter"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 )
@@ -58,7 +57,6 @@ type EnforceCommand struct {
 	flags          EnforceFlags
 	commonFlags    flags.CommonFlags
 	platform       platform.Platform
-	reporter       reporter.Reporter
 }
 
 // Desc implements cli.Command.
@@ -98,12 +96,6 @@ func (c *EnforceCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to create platform: %w", err)
 	}
 	c.platform = platform
-
-	reporter, err := reporter.NewReporter(ctx, c.platformConfig.Reporter, &reporter.Config{GitHub: c.platformConfig.GitHub})
-	if err != nil {
-		return fmt.Errorf("failed to create reporter: %w", err)
-	}
-	c.reporter = reporter
 
 	cwd, err := c.WorkingDir()
 	if err != nil {
@@ -160,7 +152,7 @@ func (c *EnforceCommand) Process(ctx context.Context) error {
 	}
 
 	if merr != nil {
-		if err := c.reporter.Status(ctx, reporter.StatusPolicyViolation, &reporter.StatusParams{
+		if err := c.platform.ReportStatus(ctx, platform.StatusPolicyViolation, &platform.StatusParams{
 			Operation: "Policy Violation",
 			Dir:       c.directory,
 			Message:   "The planned resource changes raised policy violations that will need to be addressed:",

--- a/pkg/commands/policy/enforce_test.go
+++ b/pkg/commands/policy/enforce_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/abcxyz/guardian/pkg/platform"
-	"github.com/abcxyz/guardian/pkg/reporter"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
 )
@@ -76,7 +75,6 @@ func TestEnforce_Process(t *testing.T) {
 				platform: &platform.MockPlatform{
 					AssignReviewersErr: tc.assignReviewersErr,
 				},
-				reporter: &reporter.MockReporter{},
 			}
 
 			err := c.Process(ctx)

--- a/pkg/commands/workflows/remove_comments.go
+++ b/pkg/commands/workflows/remove_comments.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/abcxyz/guardian/internal/metricswrap"
 	"github.com/abcxyz/guardian/pkg/platform"
-	"github.com/abcxyz/guardian/pkg/reporter"
 	"github.com/abcxyz/pkg/cli"
 )
 
@@ -32,7 +31,7 @@ type RemoveGuardianCommentsCommand struct {
 
 	platformConfig platform.Config
 
-	reporterClient reporter.Reporter
+	platformClient platform.Platform
 }
 
 func (c *RemoveGuardianCommentsCommand) Desc() string {
@@ -68,18 +67,18 @@ func (c *RemoveGuardianCommentsCommand) Run(ctx context.Context, args []string) 
 		return flag.ErrHelp
 	}
 
-	rc, err := reporter.NewReporter(ctx, c.platformConfig.Reporter, &reporter.Config{GitHub: c.platformConfig.GitHub})
+	platform, err := platform.NewPlatform(ctx, &c.platformConfig)
 	if err != nil {
-		return fmt.Errorf("failed to create reporter client: %w", err)
+		return fmt.Errorf("failed to create platform: %w", err)
 	}
-	c.reporterClient = rc
+	c.platformClient = platform
 
 	return c.Process(ctx)
 }
 
 // Process handles the main logic for the Guardian remove plan comments process.
 func (c *RemoveGuardianCommentsCommand) Process(ctx context.Context) error {
-	if err := c.reporterClient.Clear(ctx); err != nil {
+	if err := c.platformClient.ClearReports(ctx); err != nil {
 		return fmt.Errorf("failed to remove comments: %w", err)
 	}
 


### PR DESCRIPTION
The platform client now implements all of the reporter's functions. This change migrates all of the commands to use the platform's implementation of reports instead of the reporter package's implementation. The reporter will be removed completely in a follow-up.