### PR TITLE
Add GitLab client and `GitLab.ReportStatus` implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.2.0
 	github.com/sethvargo/go-retry v0.2.4
 	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7
+	gitlab.com/gitlab-org/api/client-go v0.116.0
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
 	golang.org/x/oauth2 v0.21.0
 	google.golang.org/api v0.184.0
@@ -51,6 +52,8 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
+github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -102,10 +104,18 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.4 h1:9gWcmF85Wvq4ryPFvGFaOgPIs1AQX0d0bcbGw4Z96qg=
 github.com/googleapis/gax-go/v2 v2.12.4/go.mod h1:KYEYLorsnIGDi/rPC8b5TdlB9kbKoFubselGIoBMCwI=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
+github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
+github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/hcl/v2 v2.20.1 h1:M6hgdyz7HYt1UN9e61j+qKJBqR3orTWbI1HKBJEdxtc=
 github.com/hashicorp/hcl/v2 v2.20.1/go.mod h1:TZDqQ4kNKCbh1iJp99FdPiUaVDDUPivbqxZulxDYqL4=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -142,6 +152,8 @@ github.com/zclconf/go-cty v1.14.4 h1:uXXczd9QDGsgu0i/QFR/hzI5NYCHLf6NQw/atrbnhq8
 github.com/zclconf/go-cty v1.14.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b h1:FosyBZYxY34Wul7O/MSKey3txpPYyCqVO5ZyceuQJEI=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
+gitlab.com/gitlab-org/api/client-go v0.116.0 h1:Dy534gtZPMrnm3fAcmQRMadrcoUyFO4FQ4rXlSAdHAw=
+gitlab.com/gitlab-org/api/client-go v0.116.0/go.mod h1:B29OfnZklmaoiR7uHANh9jTyfWEgmXvZLVEnosw2Dx0=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.52.0 h1:vS1Ao/R55RNV4O7TA2Qopok8yN+X0LIP6RVWLFkprck=

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -54,6 +54,7 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 
 	// leave last to put help under platform options
 	c.GitHub.RegisterFlags(set)
+	c.GitLab.RegisterFlags(set)
 
 	set.AfterParse(func(merr error) error {
 		c.Type = strings.ToLower(strings.TrimSpace(c.Type))
@@ -66,6 +67,9 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 			c.Type = TypeLocal
 			if v, _ := strconv.ParseBool(set.GetEnv("GITHUB_ACTIONS")); v {
 				c.Type = TypeGitHub
+			}
+			if v, _ := strconv.ParseBool(set.GetEnv("GITLAB_CI")); v {
+				c.Type = TypeGitLab
 			}
 		}
 

--- a/pkg/platform/gitlab.go
+++ b/pkg/platform/gitlab.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
@@ -48,8 +49,10 @@ type gitLabConfig struct {
 }
 
 type gitLabPredefinedConfig struct {
-	CIJobToken   string
-	CIServerHost string
+	CIJobToken       string
+	CIServerHost     string
+	CIProjectID      int
+	CIMergeRequestID int
 }
 
 // Load retrieves the predefined GitLab CI/CD variables from environment. See
@@ -61,6 +64,14 @@ func (c *gitLabPredefinedConfig) Load() {
 
 	if v := os.Getenv("CI_SERVER_URL"); v != "" {
 		c.CIServerHost = fmt.Sprintf("%s/api/v4", v)
+	}
+
+	if v, err := strconv.Atoi(os.Getenv("CI_PROJECT_ID")); err == nil {
+		c.CIProjectID = v
+	}
+
+	if v, err := strconv.Atoi(os.Getenv("CI_MERGE_REQUEST_ID")); err == nil {
+		c.CIMergeRequestID = v
 	}
 }
 
@@ -86,6 +97,24 @@ func (c *gitLabConfig) RegisterFlags(set *cli.FlagSet) {
 		Example: "https://git.mydomain.com/api/v4",
 		Default: cfgDefaults.CIServerHost,
 		Usage:   "The base URL of the GitLab instance API.",
+		Hidden:  true,
+	})
+
+	f.IntVar(&cli.IntVar{
+		Name:    "gitlab-project-id",
+		EnvVar:  "GITLAB_PROJECT_ID",
+		Target:  &c.GitLabProjectID,
+		Default: cfgDefaults.CIProjectID,
+		Usage:   "The GitLab project ID.",
+		Hidden:  true,
+	})
+
+	f.IntVar(&cli.IntVar{
+		Name:    "gitlab-merge-request-id",
+		EnvVar:  "GITLAB_MERGE_REQUEST_ID",
+		Target:  &c.GitLabMergeRequestID,
+		Default: cfgDefaults.CIMergeRequestID,
+		Usage:   "The GitLab merge request ID.",
 		Hidden:  true,
 	})
 }

--- a/pkg/platform/gitlab.go
+++ b/pkg/platform/gitlab.go
@@ -21,9 +21,10 @@ import (
 	"os"
 	"strconv"
 
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
-	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
 var _ Platform = (*GitLab)(nil)

--- a/pkg/platform/reporter.go
+++ b/pkg/platform/reporter.go
@@ -79,7 +79,7 @@ func markdownURL(text, URL string) string {
 
 // markdownZippy returns a collapsible section with a given title and body.
 func markdownZippy(title, body string) string {
-	return fmt.Sprintf("<details>\n<summary>%s</summary>\n\n`%s`\n</details>", title, body)
+	return fmt.Sprintf("<details>\n<summary>%s</summary>\n\n```%s```\n</details>", title, body)
 }
 
 // markdonDiffZippy returns a collapsible section with a given title and body.


### PR DESCRIPTION
This change defines two sets of configs, one used for Guardian command flags and the other for loading the default predefined GitLab variables that are injected in the environment in CI pipelines. These values are used to instantiate the GitLab client and make API calls to the target GitLab instance for writing notes on a merge request.