### PR TITLE
fix: use merge request internal ID for GitLab API

### DIFF
--- a/pkg/platform/gitlab.go
+++ b/pkg/platform/gitlab.go
@@ -71,9 +71,11 @@ type gitLabConfig struct {
 }
 
 type gitLabPredefinedConfig struct {
-	CIJobToken        string
-	CIServerHost      string
-	CIProjectID       int
+	CIJobToken   string
+	CIServerHost string
+	CIProjectID  int
+	// The merge request IID is the number used in the GitLab API, and not ID.
+	// See https://docs.gitlab.com/ee/ci/variables/predefined_variables.html.
 	CIMergeRequestIID int
 }
 


### PR DESCRIPTION
There are two types of ID's for merge request, `CI_MERGE_REQUEST_ID` for instance-level and `CI_MERGE_REQUEST_IID` for project-level.  

According to GitLab's predefined variables documentation, 
> The project-level IID...is the number used in the merge request URL