### PR TITLE
Add ListChangeRequestsByCommit skeleton to Platform interface

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -139,9 +139,6 @@ type GitHub interface {
 	// ListIssueComments lists existing comments for an issue or pull request.
 	ListIssueComments(ctx context.Context, owner, repo string, number int, opts *github.IssueListCommentsOptions) (*IssueCommentResponse, error)
 
-	// ListPullRequestsForCommit lists the pull requests associated with a commit.
-	ListPullRequestsForCommit(ctx context.Context, owner, repo, sha string, opts *github.PullRequestListOptions) (*PullRequestResponse, error)
-
 	// RepoUserPermissionLevel gets the repository permission level for a user. The possible permissions values
 	// are admin, write, read, none.
 	RepoUserPermissionLevel(ctx context.Context, owner, repo, user string) (string, error)
@@ -466,38 +463,6 @@ func (g *GitHubClient) ListIssueComments(ctx context.Context, owner, repo string
 	}
 
 	return &IssueCommentResponse{Comments: comments, Pagination: pagination}, nil
-}
-
-// ListPullRequestsForCommit lists the pull requests associated with a commit.
-func (g *GitHubClient) ListPullRequestsForCommit(ctx context.Context, owner, repo, sha string, opts *github.PullRequestListOptions) (*PullRequestResponse, error) {
-	var pullRequests []*PullRequest
-	var pagination *Pagination
-
-	if err := g.withRetries(ctx, func(ctx context.Context) error {
-		ghPullRequests, resp, err := g.client.PullRequests.ListPullRequestsWithCommit(ctx, owner, repo, sha, opts)
-		if err != nil {
-			if resp != nil {
-				if _, ok := ignoredStatusCodes[resp.StatusCode]; !ok {
-					return retry.RetryableError(err)
-				}
-			}
-			return fmt.Errorf("failed to list pull request comments: %w", err)
-		}
-
-		for _, c := range ghPullRequests {
-			pullRequests = append(pullRequests, &PullRequest{ID: c.GetID(), Number: c.GetNumber()})
-		}
-
-		if resp.NextPage != 0 {
-			pagination = &Pagination{NextPage: resp.NextPage}
-		}
-
-		return nil
-	}); err != nil {
-		return nil, fmt.Errorf("failed to list pull request comments: %w", err)
-	}
-
-	return &PullRequestResponse{PullRequests: pullRequests, Pagination: pagination}, nil
 }
 
 // RepoUserPermissionLevel gets the repository permission level for a user. The possible permissions values

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -695,3 +695,8 @@ func (g *GitHub) resolveJobLogsURL(ctx context.Context) (string, error) {
 	}
 	return "", fmt.Errorf("failed to resolve direct URL to job logs: no job found matching name %s", g.cfg.GitHubJobName)
 }
+
+// ListChangeRequestsByCommit lists the merge requests associated with a commit SHA.
+func (g *GitHub) ListChangeRequestsByCommit(ctx context.Context, sha string) (any, error) {
+	return nil, nil
+}

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -696,39 +696,7 @@ func (g *GitHub) resolveJobLogsURL(ctx context.Context) (string, error) {
 	return "", fmt.Errorf("failed to resolve direct URL to job logs: no job found matching name %s", g.cfg.GitHubJobName)
 }
 
-type PullRequest struct {
-	ID     int64
-	Number int
-}
-
 // ListChangeRequestsByCommit lists the merge requests associated with a commit SHA.
 func (g *GitHub) ListChangeRequestsByCommit(ctx context.Context, sha string, opts *ListChangeRequestsByCommitOptions) (any, error) {
-	var pullRequests []*PullRequest
-	var pagination *Pagination
-
-	if err := g.withRetries(ctx, func(ctx context.Context) error {
-		ghPullRequests, resp, err := g.client.PullRequests.ListPullRequestsWithCommit(ctx, g.cfg.GitHubOwner, g.cfg.GitHubRepo, sha, opts.GitHub)
-		if err != nil {
-			if resp != nil {
-				if _, ok := ignoredStatusCodes[resp.StatusCode]; !ok {
-					return retry.RetryableError(err)
-				}
-			}
-			return fmt.Errorf("failed to list pull request comments: %w", err)
-		}
-
-		for _, c := range ghPullRequests {
-			pullRequests = append(pullRequests, &PullRequest{ID: c.GetID(), Number: c.GetNumber()})
-		}
-
-		if resp.NextPage != 0 {
-			pagination = &Pagination{NextPage: resp.NextPage}
-		}
-
-		return nil
-	}); err != nil {
-		return nil, fmt.Errorf("failed to list pull request comments: %w", err)
-	}
-
-	return &ListChangeRequestsByCommitResponse{PullRequests: pullRequests, Pagination: pagination}, nil
+	return nil, nil
 }

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -696,7 +696,39 @@ func (g *GitHub) resolveJobLogsURL(ctx context.Context) (string, error) {
 	return "", fmt.Errorf("failed to resolve direct URL to job logs: no job found matching name %s", g.cfg.GitHubJobName)
 }
 
+type PullRequest struct {
+	ID     int64
+	Number int
+}
+
 // ListChangeRequestsByCommit lists the merge requests associated with a commit SHA.
-func (g *GitHub) ListChangeRequestsByCommit(ctx context.Context, sha string) (any, error) {
-	return nil, nil
+func (g *GitHub) ListChangeRequestsByCommit(ctx context.Context, sha string, opts *ListChangeRequestsByCommitOptions) (any, error) {
+	var pullRequests []*PullRequest
+	var pagination *Pagination
+
+	if err := g.withRetries(ctx, func(ctx context.Context) error {
+		ghPullRequests, resp, err := g.client.PullRequests.ListPullRequestsWithCommit(ctx, g.cfg.GitHubOwner, g.cfg.GitHubRepo, sha, opts.GitHub)
+		if err != nil {
+			if resp != nil {
+				if _, ok := ignoredStatusCodes[resp.StatusCode]; !ok {
+					return retry.RetryableError(err)
+				}
+			}
+			return fmt.Errorf("failed to list pull request comments: %w", err)
+		}
+
+		for _, c := range ghPullRequests {
+			pullRequests = append(pullRequests, &PullRequest{ID: c.GetID(), Number: c.GetNumber()})
+		}
+
+		if resp.NextPage != 0 {
+			pagination = &Pagination{NextPage: resp.NextPage}
+		}
+
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list pull request comments: %w", err)
+	}
+
+	return &ListChangeRequestsByCommitResponse{PullRequests: pullRequests, Pagination: pagination}, nil
 }

--- a/pkg/platform/gitlab.go
+++ b/pkg/platform/gitlab.go
@@ -385,3 +385,8 @@ func (g *GitLab) withRetries(ctx context.Context, retryFunc retry.RetryFunc) err
 	}
 	return nil
 }
+
+// ListChangeRequestsByCommit lists the merge requests associated with a commit SHA.
+func (g *GitLab) ListChangeRequestsByCommit(ctx context.Context, sha string) (any, error) {
+	return nil, nil
+}

--- a/pkg/platform/gitlab.go
+++ b/pkg/platform/gitlab.go
@@ -387,6 +387,6 @@ func (g *GitLab) withRetries(ctx context.Context, retryFunc retry.RetryFunc) err
 }
 
 // ListChangeRequestsByCommit lists the merge requests associated with a commit SHA.
-func (g *GitLab) ListChangeRequestsByCommit(ctx context.Context, sha string) (any, error) {
+func (g *GitLab) ListChangeRequestsByCommit(ctx context.Context, sha string, opts *ListChangeRequestsByCommitOptions) (any, error) {
 	return nil, nil
 }

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -93,3 +93,8 @@ func (l *Local) ReportEntrypointsSummary(ctx context.Context, params *Entrypoint
 func (l *Local) ClearReports(ctx context.Context) error {
 	return nil
 }
+
+// ListChangeRequestsByCommit is a no-op.
+func (l *Local) ListChangeRequestsByCommit(ctx context.Context, sha string) (any, error) {
+	return nil, nil
+}

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -95,6 +95,6 @@ func (l *Local) ClearReports(ctx context.Context) error {
 }
 
 // ListChangeRequestsByCommit is a no-op.
-func (l *Local) ListChangeRequestsByCommit(ctx context.Context, sha string) (any, error) {
+func (l *Local) ListChangeRequestsByCommit(ctx context.Context, sha string, opts *ListChangeRequestsByCommitOptions) (any, error) {
 	return nil, nil
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -122,6 +122,9 @@ type Platform interface {
 	// ListReports lists existing reports for an issue or change request.
 	ListReports(ctx context.Context, opts *ListReportsOptions) (*ListReportsResult, error)
 
+	// ListChangeRequestsByCommit lists the change requests associated with a commit SHA.
+	ListChangeRequestsByCommit(ctx context.Context, sha string) (any, error)
+
 	// DeleteReport deletes an existing comment from an issue or change request.
 	DeleteReport(ctx context.Context, id any) error
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -104,8 +104,7 @@ type ListChangeRequestsByCommitOptions struct {
 // ListChangeRequestsByCommitResponse contains the changes requests and
 // pagination options return by the platform.
 type ListChangeRequestsByCommitResponse struct {
-	PullRequests []*PullRequest
-	Pagination   *Pagination
+	Pagination *Pagination
 }
 
 // Pagination is the paging details for a list response.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -95,6 +95,15 @@ type ListReportsResult struct {
 	Pagination *Pagination
 }
 
+type ListChangeRequestsByCommitOptions struct {
+	GitHub *github.PullRequestListOptions
+}
+
+type ListChangeRequestsByCommitResponse struct {
+	PullRequests []*PullRequest
+	Pagination   *Pagination
+}
+
 // Pagination is the paging details for a list response.
 type Pagination struct {
 	NextPage int
@@ -123,7 +132,7 @@ type Platform interface {
 	ListReports(ctx context.Context, opts *ListReportsOptions) (*ListReportsResult, error)
 
 	// ListChangeRequestsByCommit lists the change requests associated with a commit SHA.
-	ListChangeRequestsByCommit(ctx context.Context, sha string) (any, error)
+	ListChangeRequestsByCommit(ctx context.Context, sha string, opts *ListChangeRequestsByCommitOptions) (any, error)
 
 	// DeleteReport deletes an existing comment from an issue or change request.
 	DeleteReport(ctx context.Context, id any) error

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -95,10 +95,14 @@ type ListReportsResult struct {
 	Pagination *Pagination
 }
 
+// ListChangeRequestsByCommitOptions contains embedded client options for each
+// platform.
 type ListChangeRequestsByCommitOptions struct {
 	GitHub *github.PullRequestListOptions
 }
 
+// ListChangeRequestsByCommitResponse contains the changes requests and
+// pagination options return by the platform.
 type ListChangeRequestsByCommitResponse struct {
 	PullRequests []*PullRequest
 	Pagination   *Pagination

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -244,3 +244,8 @@ func (m *MockPlatform) ClearReports(ctx context.Context) error {
 
 	return m.ClearReportsErr
 }
+
+// ListChangeRequestsByCommit lists the change requests associated with a commit SHA.
+func (m *MockPlatform) ListChangeRequestsByCommit(ctx context.Context, sha string) (any, error) {
+	return nil, nil
+}

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -246,6 +246,6 @@ func (m *MockPlatform) ClearReports(ctx context.Context) error {
 }
 
 // ListChangeRequestsByCommit lists the change requests associated with a commit SHA.
-func (m *MockPlatform) ListChangeRequestsByCommit(ctx context.Context, sha string) (any, error) {
+func (m *MockPlatform) ListChangeRequestsByCommit(ctx context.Context, sha string, opts *ListChangeRequestsByCommitOptions) (any, error) {
 	return nil, nil
 }


### PR DESCRIPTION
This method is required for Guardian Apply to report its status on a change request. For GitHub and Guardian, the PR/MR ID will not be available from the GitHub Action/GitLab Pipeline environment when merging, so the ID needs to be looked up based on the SHA of the commit.