### PR TITLE
Remove shadowed loop variables

### DIFF
--- a/pkg/assetinventory/assetinventory_test.go
+++ b/pkg/assetinventory/assetinventory_test.go
@@ -178,8 +178,6 @@ func TestNewHierarchyGraph(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -238,8 +236,6 @@ func TestFoldersBeneath(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/child/child_test.go
+++ b/pkg/child/child_test.go
@@ -66,8 +66,6 @@ func TestRun(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -81,7 +79,7 @@ func TestRun(t *testing.T) {
 			})
 			if err != nil {
 				if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-					t.Errorf(diff)
+					t.Error(diff)
 				}
 				return
 			}
@@ -136,8 +134,6 @@ func TestRun_Cancel(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -159,7 +155,7 @@ func TestRun_Cancel(t *testing.T) {
 			})
 			if err != nil {
 				if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-					t.Errorf(diff)
+					t.Error(diff)
 				}
 				return
 			}
@@ -290,8 +286,6 @@ func TestEnviron(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/commands/apply/apply_test.go
+++ b/pkg/commands/apply/apply_test.go
@@ -174,8 +174,6 @@ func TestApply_Process(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -202,7 +200,7 @@ func TestApply_Process(t *testing.T) {
 
 			err := c.Process(ctx)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if diff := cmp.Diff(mockPlatformClient.Reqs, tc.expPlatformClientReqs); diff != "" {

--- a/pkg/commands/cleanup/cleanup_test.go
+++ b/pkg/commands/cleanup/cleanup_test.go
@@ -94,8 +94,6 @@ func TestEntrypointsProcess(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -117,7 +115,7 @@ func TestEntrypointsProcess(t *testing.T) {
 
 			err := c.Process(ctx)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 			less := func(a, b *storage.Request) bool {
 				return fmt.Sprintf("%s-%s", a.Name, a.Params) < fmt.Sprintf("%s-%s", b.Name, b.Params)

--- a/pkg/commands/drift/drift_test.go
+++ b/pkg/commands/drift/drift_test.go
@@ -183,8 +183,6 @@ func TestDrift_DetectDrift(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -288,8 +286,6 @@ func TestDrift_driftMessage(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := driftMessage(tc.drift)

--- a/pkg/commands/entrypoints/entrypoints_test.go
+++ b/pkg/commands/entrypoints/entrypoints_test.go
@@ -185,8 +185,6 @@ func TestEntrypointsProcess(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -207,7 +205,7 @@ func TestEntrypointsProcess(t *testing.T) {
 
 			err := c.Process(ctx)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if got, want := strings.TrimSpace(stdout.String()), strings.TrimSpace(tc.expStdout); !strings.Contains(got, want) {
@@ -236,8 +234,6 @@ func TestAfterParse(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -246,7 +242,7 @@ func TestAfterParse(t *testing.T) {
 			f := c.Flags()
 			err := f.Parse(tc.args)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/commands/iamcleanup/iamcleanup_test.go
+++ b/pkg/commands/iamcleanup/iamcleanup_test.go
@@ -55,8 +55,6 @@ func Test_evaluateIAMConditionExpression(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/commands/plan/plan_test.go
+++ b/pkg/commands/plan/plan_test.go
@@ -201,8 +201,6 @@ func TestPlan_Process(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -225,7 +223,7 @@ func TestPlan_Process(t *testing.T) {
 
 			err := c.Process(ctx)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if diff := cmp.Diff(mockPlatformClient.Reqs, tc.expPlatformClientReqs); diff != "" {

--- a/pkg/commands/policy/enforce_test.go
+++ b/pkg/commands/policy/enforce_test.go
@@ -63,8 +63,6 @@ func TestEnforce_Process(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/commands/policy/fetch_data_test.go
+++ b/pkg/commands/policy/fetch_data_test.go
@@ -160,8 +160,6 @@ func TestFetchData_Process(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/commands/run/run_test.go
+++ b/pkg/commands/run/run_test.go
@@ -109,8 +109,6 @@ func TestPlan_Process(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -130,7 +128,7 @@ func TestPlan_Process(t *testing.T) {
 
 			err := c.Process(ctx)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if got, want := strings.TrimSpace(stdout.String()), strings.TrimSpace(tc.expStdout); !strings.Contains(got, want) {

--- a/pkg/commands/workflows/plan_status_comments_test.go
+++ b/pkg/commands/workflows/plan_status_comments_test.go
@@ -83,8 +83,6 @@ func TestPlanStatusCommentsProcess(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -100,7 +98,7 @@ func TestPlanStatusCommentsProcess(t *testing.T) {
 
 			err := c.Process(ctx)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if diff := cmp.Diff(mockPlatformClient.Reqs, tc.expPlatformClientReqs); diff != "" {

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -86,18 +86,16 @@ testdata/third`,
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			dirs, err := parseSortedDiffDirsAbs(context.Background(), tc.value)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if diff := cmp.Diff(dirs, tc.exp); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/iam/iam_test.go
+++ b/pkg/iam/iam_test.go
@@ -152,8 +152,6 @@ func Test_removeFromPolicy(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/storage/google_cloud_storage_test.go
+++ b/pkg/storage/google_cloud_storage_test.go
@@ -89,14 +89,12 @@ func TestMakeCreateConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			cfg := makeCreateConfig(tc.length, tc.opts)
 			if diff := cmp.Diff(cfg, tc.exp, cmp.Options{cmp.AllowUnexported(createConfig{})}); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/terraform/apply_test.go
+++ b/pkg/terraform/apply_test.go
@@ -82,14 +82,12 @@ func TestApplyArgsFromOptions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			args := applyArgsFromOptions(tc.opts)
 			if diff := cmp.Diff(args, tc.exp); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/terraform/format_test.go
+++ b/pkg/terraform/format_test.go
@@ -77,14 +77,12 @@ func TestFormatArgsFromOptions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			args := formatArgsFromOptions(tc.opts)
 			if diff := cmp.Diff(args, tc.exp); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/terraform/init_test.go
+++ b/pkg/terraform/init_test.go
@@ -80,14 +80,12 @@ func TestInitArgsFromOptions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			args := initArgsFromOptions(tc.opts)
 			if diff := cmp.Diff(args, tc.exp); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/terraform/parser/parser_test.go
+++ b/pkg/terraform/parser/parser_test.go
@@ -64,8 +64,6 @@ func TestParser_StateFileURIs(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -211,8 +209,6 @@ func TestParser_ProcessStates(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -222,7 +218,7 @@ func TestParser_ProcessStates(t *testing.T) {
 			}
 			var downloadErr error
 			if tc.wantErr != "" {
-				downloadErr = fmt.Errorf(tc.wantErr)
+				downloadErr = fmt.Errorf("%s", tc.wantErr)
 			}
 
 			p := &TerraformParser{

--- a/pkg/terraform/plan_test.go
+++ b/pkg/terraform/plan_test.go
@@ -85,14 +85,12 @@ func TestPlanArgsFromOptions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			args := planArgsFromOptions(tc.opts)
 			if diff := cmp.Diff(args, tc.exp); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/terraform/show_test.go
+++ b/pkg/terraform/show_test.go
@@ -65,14 +65,12 @@ func TestShowArgsFromOptions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			args := showArgsFromOptions(tc.opts)
 			if diff := cmp.Diff(args, tc.exp); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/terraform/terraform_test.go
+++ b/pkg/terraform/terraform_test.go
@@ -47,12 +47,12 @@ first section !
     second section +
     second section ~
     second section !
-	
+
 - third section
 + third section
 ~ third section
 ! third section
-	
+
     - fourth section
     + fourth section
     -/+ fourth section
@@ -69,12 +69,12 @@ first section !
     second section +
     second section ~
     second section !
-	
+
 - third section
 + third section
 ! third section
 ! third section
-	
+
 -     fourth section
 +     fourth section
 -/+     fourth section
@@ -85,8 +85,6 @@ first section !
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -155,14 +153,12 @@ func TestGetEntrypointDirectories(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			dirs, err := GetEntrypointDirectories(tc.dir, tc.maxDepth)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if diff := cmp.Diff(dirs, tc.exp); diff != "" {
@@ -200,14 +196,12 @@ func TestHasBackendConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			found, _, err := hasBackendConfig(tc.file)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if got, want := found, tc.exp; got != want {
@@ -245,14 +239,12 @@ func TestExtractBackendConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			got, _, err := ExtractBackendConfig(tc.file)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
@@ -295,14 +287,12 @@ func Test_extractBackendConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			got, _, err := extractBackendConfig(tc.data, "filename.tf")
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
@@ -368,14 +358,12 @@ func TestModules(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			dirs, err := modules(context.Background(), tc.dir, true)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if diff := cmp.Diff(dirs, tc.exp); diff != "" {
@@ -470,14 +458,12 @@ func TestModuleUsage(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			graph, err := ModuleUsage(context.Background(), tc.dir, tc.maxDepth, true)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if diff := cmp.Diff(graph, tc.exp); diff != "" {

--- a/pkg/terraform/validate_test.go
+++ b/pkg/terraform/validate_test.go
@@ -62,14 +62,12 @@ func TestValidateArgsFromOptions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			args := validateArgsFromOptions(tc.opts)
 			if diff := cmp.Diff(args, tc.exp); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -57,8 +57,6 @@ func TestSliceContainsOnly(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -113,14 +111,12 @@ func TestChildPath(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			d, err := ChildPath(tc.base, tc.target)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if got, want := d, tc.exp; got != want {
@@ -162,14 +158,12 @@ func TestPathEvalAbs(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			dir, err := PathEvalAbs(tc.dir)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if got, want := dir, tc.exp; got != want {


### PR DESCRIPTION
This is no longer required as of Go 1.22+
