### PR TITLE
fix: draft release sha

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -85,6 +85,7 @@ jobs:
             const releaseNotesResponse = await github.rest.repos.generateReleaseNotes({
               owner: context.repo.owner,
               repo: context.repo.repo,
+              target_commitish: context.sha
               tag_name: `v${process.env.NEXT_VERSION}`,
               previous_tag_name: `v${process.env.CURRENT_VERSION}`,
             });


### PR DESCRIPTION
The next version tag doesn't exist yet, we need to use the current sha from the workflow branch as the diff for generating release notes.