### PR TITLE
feat: add merge queue check

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ $ curl https://api.github.com/repos/$OWNER_NAME/$REPO_NAME | jq '. | {"id": .id,
 
 Rulesets are required to enable a safe and secure process. Ensuring
 these values are set properly prevents multiple pull requests from stepping on
-each other. There are two strategies for preventing terraform plan and apply conflicts: 
+each other. There are two strategies for preventing terraform plan and apply conflicts:
 
 1. By enabling `Require branches to be up to date before merging`, pull
    requests merged at the same time will cause one to fail and be forced to pull
@@ -447,8 +447,14 @@ each other. There are two strategies for preventing terraform plan and apply con
    we enable developers to simultaneously work on different terraform
    entrypoints and only require rebasing if there are changes that impact the
    same entrypoints modified in your pull request.
-   * Note: This is the recommended approach for repositories with many terraform
-     entrypoints.
+
+> [!NOTE]
+> The [merge queue check](#merge-check) is the recommended approach for
+> repositories with many terraform entrypoints.
+
+> [!IMPORTANT]
+> You must choose and implement one of either of the above strategies. You
+> cannot implement both.
 
 **Regardless of your choice of strategy, you will need to setup a ruleset with
 the following rules:**

--- a/abc.templates/base-workflows/contents/workflows/guardian-merge-check.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-merge-check.yml
@@ -1,0 +1,141 @@
+# Copyright 2025 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Guardian merge check is used to determine if a PR conflicts with another recent PR
+# directories after a pull request has been created.
+# 
+# NOTE: That this workflow is included by default but only is enabled if you
+# also enable the merge queue in your ruleset. For more details, see:
+# https://github.com/abcxyz/guardian?tab=readme-ov-file#merge-check
+name: 'guardian_merge_check'
+run-name: 'guardian_merge_check - [Merge Queue Ref=${{ github.ref }}]'
+
+on:
+  # This workflow must run in the pull_request in order to be a required status
+  # check and successfully block merges in the merge queue. Note that it will
+  # always have a `skipped` status in the pull request and will only ever
+  # execute the job in the merge queue (when and if the merge queue is enabled).
+  pull_request:
+  merge_group:
+
+# only one check per ref at a time.
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+
+env:
+  GUARDIAN_VERSION: 'REPLACE_GUARDIAN_VERSION_TAG'
+  GUARDIAN_TERRAFORM_VERSION: 'REPLACE_TERRAFORM_VERSION'
+
+jobs:
+  merge_check:
+    # Only runs in the merge queue. Shows a `skipped` status on the
+    # `pull_request`.
+    if: ${{ github.event_name == 'merge_group' }}
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      pull-requests: 'write'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 0 # get everything so we can use git diff
+          ref: '${{ github.event.merge_group.head_sha }}'
+
+      - name: 'Setup Guardian'
+        uses: 'abcxyz/pkg/.github/actions/setup-binary@main' # ratchet:exclude
+        with:
+          download_url: 'https://github.com/abcxyz/guardian/releases/download/v${{ env.GUARDIAN_VERSION }}/guardian_${{ env.GUARDIAN_VERSION }}_linux_amd64.tar.gz'
+          install_path: '${{ runner.temp }}/.guardian'
+          binary_subpath: 'guardian'
+          cache_key: '${{ runner.os }}_${{ runner.arch }}_guardian_${{ env.GUARDIAN_VERSION }}'
+          add_to_path: true
+
+      - name: 'Guardian Changed Entrypoints in Current PR'
+        id: 'entrypoints-changed-in-pr'
+        shell: 'bash'
+        env:
+          GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
+          SOURCE_REF: '${{ github.event.merge_group.base_sha }}'
+          DEST_REF: '${{ github.event.merge_group.head_sha }}'
+          EVENT: '${{ github.event_name }}'
+        run: |-
+          DIRECTORIES=$(guardian entrypoints -skip-reporting -dir="REPLACE_TERRAFORM_DIRECTORY" -detect-changes -source-ref="${SOURCE_REF}" -dest-ref="${DEST_REF}")
+          echo "entrypoints -> ${DIRECTORIES}"
+          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+
+      - name: 'PR info'
+        id: 'pr-info'
+        shell: 'bash'
+        env:
+          GH_TOKEN: '${{ github.token }}'
+        run: |-
+          PR_NUM="$(echo "$GITHUB_REF" | grep -Po 'refs\/heads\/gh-readonly-queue\/(?:.+)\/pr-\K(\d*)')"
+          PR_TARGET_BRANCH_NAME="$(echo "$GITHUB_REF" | grep -Po 'refs\/heads\/gh-readonly-queue\/\K((?!\/pr-)(.))+')"
+          PR_BRANCH_REF="$(gh pr --repo="$GITHUB_REPOSITORY" view "$PR_NUM" --json headRefOid --jq '.headRefOid')"
+          echo "pr_branch_ref=${PR_BRANCH_REF}" >> $GITHUB_OUTPUT
+          echo "pr_number=${PR_NUM}" >> $GITHUB_OUTPUT
+          echo "pr_target_branch_name=${PR_TARGET_BRANCH_NAME}" >> $GITHUB_OUTPUT
+
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 0 # get everything so we can use git diff
+          ref: '${{ steps.pr-info.outputs.pr_branch_ref }}'
+
+      # This checks all commits that are in the merge queue git log that are
+      # NOT in the PR feature branch. This means that this checks commits that
+      # are both in the merge queue and that have been merged to main (but are
+      # not rebased in the feature branch).
+      - name: 'Guardian Changed Entrypoints since PR'
+        id: 'entrypoints-changed-since-pr'
+        shell: 'bash'
+        env:
+          GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
+          BASE_REF: '${{ github.event.merge_group.base_sha }}'
+          PR_REF: '${{ steps.pr-info.outputs.pr_branch_ref }}'
+          EVENT: '${{ github.event_name }}'
+        run: |-
+          # We want to know the intersection between the merge queue base ref
+          # and the PR base ref. This will be the commit on main at the time
+          # of the PR plan.
+          FEATURE_BRANCH_BASE_REF=$(git merge-base $PR_REF $BASE_REF)
+          DIRECTORIES=$(guardian entrypoints -skip-reporting -dir="REPLACE_TERRAFORM_DIRECTORY" -detect-changes -source-ref="${FEATURE_BRANCH_BASE_REF}" -dest-ref="${BASE_REF}")
+          echo "entrypoints -> ${DIRECTORIES}"
+          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+
+      - name: 'Check'
+        id: 'check'
+        shell: 'bash'
+        env:
+          CHANGED_IN_PR: '${{ steps.entrypoints-changed-in-pr.outputs.directories }}'
+          CHANGED_SINCE_PR: '${{ steps.entrypoints-changed-since-pr.outputs.directories }}'
+        run: |-
+          modified_in_both="$(join <(echo "$CHANGED_IN_PR" | jq '.[]') <(echo "$CHANGED_SINCE_PR" | jq '.[]'))"
+          if [[ "$modified_in_both" != "" ]]; then
+            echo "[ERROR] Found entrypoints that have been modified since the plan was created. Please rebase and recreate your plan."
+            echo "$modified_in_both"
+            exit 1
+          fi
+
+      - name: 'Comment Status'
+        if: always()
+        shell: 'bash'
+        env:
+          RESULT: '${{ steps.check.outcome }}'
+          TARGET_BRANCH: '${{ steps.pr-info.outputs.pr_target_branch_name }}'
+          GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
+          PR_NUMBER: '${{ steps.pr-info.outputs.pr_number }}'
+        run: |-
+          guardian workflows merge-queue-comment -result="$RESULT" -target-branch="$TARGET_BRANCH" -github-pull-request-number="$PR_NUMBER"

--- a/abc.templates/base-workflows/contents/workflows/guardian-merge-check.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-merge-check.yml
@@ -14,7 +14,7 @@
 
 # Guardian merge check is used to determine if a PR conflicts with another recent PR
 # directories after a pull request has been created.
-# 
+#
 # NOTE: That this workflow is included by default but only is enabled if you
 # also enable the merge queue in your ruleset. For more details, see:
 # https://github.com/abcxyz/guardian?tab=readme-ov-file#merge-check
@@ -41,7 +41,8 @@ jobs:
   merge_check:
     # Only runs in the merge queue. Shows a `skipped` status on the
     # `pull_request`.
-    if: ${{ github.event_name == 'merge_group' }}
+    if: |
+      github.event_name == 'merge_group'
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'
@@ -130,7 +131,8 @@ jobs:
           fi
 
       - name: 'Comment Status'
-        if: always()
+        if: |
+          always()
         shell: 'bash'
         env:
           RESULT: '${{ steps.check.outcome }}'

--- a/abc.templates/base-workflows/contents/workflows/guardian-plan.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-plan.yml
@@ -26,6 +26,9 @@ on:
       - 'ready_for_review'
     branches:
       - 'main'
+  # Only used if you are using the merge group for the guardian merge check.
+  # https://github.com/abcxyz/guardian?tab=readme-ov-file#merge-check
+  merge_group:
 
 # only one plan, per pr should run at a time
 concurrency:
@@ -40,6 +43,11 @@ env:
 
 jobs:
   init:
+    # We do not run any plan jobs in the merge queue. But these jobs are still
+    # required to run (in a skipped state) in order to block adding to the
+    # merge queue until a plan has been created.
+    if: |
+      github.event_name == 'pull_request_target'
     runs-on: 'ubuntu-latest'
 
     permissions:
@@ -91,7 +99,7 @@ jobs:
 
   plan:
     if: |
-      needs.init.outputs.directories != '[]'
+      github.event_name == 'pull_request_target' && needs.init.outputs.directories != '[]'
     needs:
       - 'init'
     runs-on: 'ubuntu-latest'
@@ -150,7 +158,8 @@ jobs:
           guardian plan -dir="${DIRECTORY}" -storage="gcs://${GUARDIAN_BUCKET_NAME}"
 
   plan_success:
-    if: '${{ always() }}'
+    if: |
+      always() && github.event_name == 'pull_request_target'
     runs-on: 'ubuntu-latest'
     needs:
       - 'init'

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-merge-check.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-merge-check.yml
@@ -1,0 +1,141 @@
+# Copyright 2025 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Guardian merge check is used to determine if a PR conflicts with another recent PR
+# directories after a pull request has been created.
+# 
+# NOTE: That this workflow is included by default but only is enabled if you
+# also enable the merge queue in your ruleset. For more details, see:
+# https://github.com/abcxyz/guardian?tab=readme-ov-file#merge-check
+name: 'guardian_merge_check'
+run-name: 'guardian_merge_check - [Merge Queue Ref=${{ github.ref }}]'
+
+on:
+  # This workflow must run in the pull_request in order to be a required status
+  # check and successfully block merges in the merge queue. Note that it will
+  # always have a `skipped` status in the pull request and will only ever
+  # execute the job in the merge queue (when and if the merge queue is enabled).
+  pull_request:
+  merge_group:
+
+# only one check per ref at a time.
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+
+env:
+  GUARDIAN_VERSION: '1.0.0'
+  GUARDIAN_TERRAFORM_VERSION: '1.7.4'
+
+jobs:
+  merge_check:
+    # Only runs in the merge queue. Shows a `skipped` status on the
+    # `pull_request`.
+    if: ${{ github.event_name == 'merge_group' }}
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      pull-requests: 'write'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 0 # get everything so we can use git diff
+          ref: '${{ github.event.merge_group.head_sha }}'
+
+      - name: 'Setup Guardian'
+        uses: 'abcxyz/pkg/.github/actions/setup-binary@main' # ratchet:exclude
+        with:
+          download_url: 'https://github.com/abcxyz/guardian/releases/download/v${{ env.GUARDIAN_VERSION }}/guardian_${{ env.GUARDIAN_VERSION }}_linux_amd64.tar.gz'
+          install_path: '${{ runner.temp }}/.guardian'
+          binary_subpath: 'guardian'
+          cache_key: '${{ runner.os }}_${{ runner.arch }}_guardian_${{ env.GUARDIAN_VERSION }}'
+          add_to_path: true
+
+      - name: 'Guardian Changed Entrypoints in Current PR'
+        id: 'entrypoints-changed-in-pr'
+        shell: 'bash'
+        env:
+          GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
+          SOURCE_REF: '${{ github.event.merge_group.base_sha }}'
+          DEST_REF: '${{ github.event.merge_group.head_sha }}'
+          EVENT: '${{ github.event_name }}'
+        run: |-
+          DIRECTORIES=$(guardian entrypoints -skip-reporting -dir="." -detect-changes -source-ref="${SOURCE_REF}" -dest-ref="${DEST_REF}")
+          echo "entrypoints -> ${DIRECTORIES}"
+          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+
+      - name: 'PR info'
+        id: 'pr-info'
+        shell: 'bash'
+        env:
+          GH_TOKEN: '${{ github.token }}'
+        run: |-
+          PR_NUM="$(echo "$GITHUB_REF" | grep -Po 'refs\/heads\/gh-readonly-queue\/(?:.+)\/pr-\K(\d*)')"
+          PR_TARGET_BRANCH_NAME="$(echo "$GITHUB_REF" | grep -Po 'refs\/heads\/gh-readonly-queue\/\K((?!\/pr-)(.))+')"
+          PR_BRANCH_REF="$(gh pr --repo="$GITHUB_REPOSITORY" view "$PR_NUM" --json headRefOid --jq '.headRefOid')"
+          echo "pr_branch_ref=${PR_BRANCH_REF}" >> $GITHUB_OUTPUT
+          echo "pr_number=${PR_NUM}" >> $GITHUB_OUTPUT
+          echo "pr_target_branch_name=${PR_TARGET_BRANCH_NAME}" >> $GITHUB_OUTPUT
+
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 0 # get everything so we can use git diff
+          ref: '${{ steps.pr-info.outputs.pr_branch_ref }}'
+
+      # This checks all commits that are in the merge queue git log that are
+      # NOT in the PR feature branch. This means that this checks commits that
+      # are both in the merge queue and that have been merged to main (but are
+      # not rebased in the feature branch).
+      - name: 'Guardian Changed Entrypoints since PR'
+        id: 'entrypoints-changed-since-pr'
+        shell: 'bash'
+        env:
+          GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
+          BASE_REF: '${{ github.event.merge_group.base_sha }}'
+          PR_REF: '${{ steps.pr-info.outputs.pr_branch_ref }}'
+          EVENT: '${{ github.event_name }}'
+        run: |-
+          # We want to know the intersection between the merge queue base ref
+          # and the PR base ref. This will be the commit on main at the time
+          # of the PR plan.
+          FEATURE_BRANCH_BASE_REF=$(git merge-base $PR_REF $BASE_REF)
+          DIRECTORIES=$(guardian entrypoints -skip-reporting -dir="." -detect-changes -source-ref="${FEATURE_BRANCH_BASE_REF}" -dest-ref="${BASE_REF}")
+          echo "entrypoints -> ${DIRECTORIES}"
+          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+
+      - name: 'Check'
+        id: 'check'
+        shell: 'bash'
+        env:
+          CHANGED_IN_PR: '${{ steps.entrypoints-changed-in-pr.outputs.directories }}'
+          CHANGED_SINCE_PR: '${{ steps.entrypoints-changed-since-pr.outputs.directories }}'
+        run: |-
+          modified_in_both="$(join <(echo "$CHANGED_IN_PR" | jq '.[]') <(echo "$CHANGED_SINCE_PR" | jq '.[]'))"
+          if [[ "$modified_in_both" != "" ]]; then
+            echo "[ERROR] Found entrypoints that have been modified since the plan was created. Please rebase and recreate your plan."
+            echo "$modified_in_both"
+            exit 1
+          fi
+
+      - name: 'Comment Status'
+        if: always()
+        shell: 'bash'
+        env:
+          RESULT: '${{ steps.check.outcome }}'
+          TARGET_BRANCH: '${{ steps.pr-info.outputs.pr_target_branch_name }}'
+          GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
+          PR_NUMBER: '${{ steps.pr-info.outputs.pr_number }}'
+        run: |-
+          guardian workflows merge-queue-comment -result="$RESULT" -target-branch="$TARGET_BRANCH" -github-pull-request-number="$PR_NUMBER"

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-merge-check.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-merge-check.yml
@@ -14,7 +14,7 @@
 
 # Guardian merge check is used to determine if a PR conflicts with another recent PR
 # directories after a pull request has been created.
-# 
+#
 # NOTE: That this workflow is included by default but only is enabled if you
 # also enable the merge queue in your ruleset. For more details, see:
 # https://github.com/abcxyz/guardian?tab=readme-ov-file#merge-check
@@ -41,7 +41,8 @@ jobs:
   merge_check:
     # Only runs in the merge queue. Shows a `skipped` status on the
     # `pull_request`.
-    if: ${{ github.event_name == 'merge_group' }}
+    if: |
+      github.event_name == 'merge_group'
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'
@@ -130,7 +131,8 @@ jobs:
           fi
 
       - name: 'Comment Status'
-        if: always()
+        if: |
+          always()
         shell: 'bash'
         env:
           RESULT: '${{ steps.check.outcome }}'

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-plan.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-plan.yml
@@ -26,6 +26,9 @@ on:
       - 'ready_for_review'
     branches:
       - 'main'
+  # Only used if you are using the merge group for the guardian merge check.
+  # https://github.com/abcxyz/guardian?tab=readme-ov-file#merge-check
+  merge_group:
 
 # only one plan, per pr should run at a time
 concurrency:
@@ -40,6 +43,11 @@ env:
 
 jobs:
   init:
+    # We do not run any plan jobs in the merge queue. But these jobs are still
+    # required to run (in a skipped state) in order to block adding to the
+    # merge queue until a plan has been created.
+    if: |
+      github.event_name == 'pull_request_target'
     runs-on: 'ubuntu-latest'
 
     permissions:
@@ -91,7 +99,7 @@ jobs:
 
   plan:
     if: |
-      needs.init.outputs.directories != '[]'
+      github.event_name == 'pull_request_target' && needs.init.outputs.directories != '[]'
     needs:
       - 'init'
     runs-on: 'ubuntu-latest'
@@ -149,7 +157,8 @@ jobs:
           guardian plan -dir="${DIRECTORY}" -storage="gcs://${GUARDIAN_BUCKET_NAME}"
 
   plan_success:
-    if: '${{ always() }}'
+    if: |
+      always() && github.event_name == 'pull_request_target'
     runs-on: 'ubuntu-latest'
     needs:
       - 'init'


### PR DESCRIPTION
See the README changes for full details of what this entails.

I decided to add the merge check to the default set of template workflows since it does not conflict and will only run if you enable the merge queue (note that it will show up as `skipped` on all pull requests).

Note that this change has been tested in https://github.com/abcxyz/infra-gcp/blob/main/.github/workflows/guardian-merge-check.yml

🤖  Also note that the description of the merge queue in the readme was mostly generated with AI.