### PR TITLE
chore: remove lint workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Unit tests - go
   go_test:
     uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main' # ratchet:exclude
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,3 @@ concurrency:
 jobs:
   go_test:
     uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main' # ratchet:exclude
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'lint_test'
+name: 'ci'
 
 on:
   push:
@@ -31,30 +31,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Linting jobs - go, terraform.
-  go_lint:
-    uses: 'abcxyz/pkg/.github/workflows/go-lint.yml@main' # ratchet:exclude
-
-  terraform_lint:
-    uses: 'abcxyz/pkg/.github/workflows/terraform-lint.yml@main' # ratchet:exclude
-    with:
-      directory: 'terraform'
-      terraform_version: '1.6.6'
-
-  yaml_lint:
-    uses: 'abcxyz/pkg/.github/workflows/yaml-lint.yml@main' # ratchet:exclude
-
   # Unit tests - go
   go_test:
     uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main' # ratchet:exclude
 
-  # lint_and_unit is a virtual job that is used as dependencies for later jobs.
-  lint_and_unit:
-    runs-on: 'ubuntu-latest'
-    needs:
-      - 'go_lint'
-      - 'terraform_lint'
-      - 'yaml_lint'
-      - 'go_test'
-    steps:
-      - run: 'echo prechecks complete'


### PR DESCRIPTION
Updating so that we use the lint.yml workflow from pkg https://github.com/abcxyz/pkg/blob/main/.github/workflows/lint.yml. This workflow is required via an org ruleset so that it runs on this repo.