### PR TITLE
Allow configuring the base URL of GitHub Enterprises

### DIFF
--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	// Enterprise
 	GitHubAPIURL     string
 	GitHubGraphQLURL string
+	GitHubServerURL  string
 
 	// Auth
 	GuardianGitHubToken     string
@@ -46,7 +47,6 @@ type Config struct {
 	Permissions             map[string]string
 
 	GitHubEventName         string
-	GitHubServerURL         string
 	GitHubRunID             int64
 	GitHubRunAttempt        int64
 	GitHubJob               string

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -175,11 +175,12 @@ GITHUB_TOKEN.`,
 	})
 
 	f.StringVar(&cli.StringVar{
-		Name:   "github-server-url",
-		EnvVar: "GITHUB_SERVER_URL",
-		Target: &c.GitHubServerURL,
-		Usage:  "The GitHub server URL.",
-		Hidden: true,
+		Name:    "github-server-url",
+		EnvVar:  "GITHUB_SERVER_URL",
+		Target:  &c.GitHubServerURL,
+		Usage:   "The GitHub server URL.",
+		Default: "https://github.com",
+		Hidden:  true,
 	})
 
 	f.Int64Var(&cli.Int64Var{

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -31,6 +31,10 @@ type Config struct {
 	InitialRetryDelay time.Duration
 	MaxRetryDelay     time.Duration
 
+	// Enterprise
+	GitHubAPIURL     string
+	GitHubGraphQLURL string
+
 	// Auth
 	GuardianGitHubToken     string
 	GitHubToken             string
@@ -108,6 +112,24 @@ GITHUB_TOKEN.`,
 		Target: &c.GitHubToken,
 		Usage:  "The GitHub access token to make GitHub API calls.",
 		Hidden: true,
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "github-api-url",
+		EnvVar:  "GITHUB_API_URL",
+		Target:  &c.GitHubAPIURL,
+		Usage:   "The API URL of the GitHub instance.",
+		Default: "https://api.github.com/",
+		Hidden:  true,
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "github-graphql-url",
+		EnvVar:  "GITHUB_GRAPHQL_URL",
+		Target:  &c.GitHubGraphQLURL,
+		Default: "https://api.github.com/graphql/",
+		Usage:   "The GraphQL API URL of the GitHub instance.",
+		Hidden:  true,
 	})
 
 	f.StringVar(&cli.StringVar{

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -97,8 +97,11 @@ func NewGitHub(ctx context.Context, cfg *gh.Config) (*GitHub, error) {
 
 	tc := oauth2.NewClient(ctx, ts)
 
-	client := github.NewClient(tc)
-	graphqlClient := githubv4.NewClient(tc)
+	client, err := github.NewEnterpriseClient(cfg.GitHubAPIURL, cfg.GitHubServerURL, tc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GitHub client: %w", err)
+	}
+	graphqlClient := githubv4.NewEnterpriseClient(cfg.GitHubGraphQLURL, tc)
 
 	g := &GitHub{
 		cfg:           cfg,


### PR DESCRIPTION
Currently, Guardian is configured to only call the GitHub SaaS API so it can only be run on GitHub Actions within the GitHub.com. This change exposes some options to modify the GitHub base URLs so that it can support GitHub Enterprise instances. Most of these will be inferred from the GitHub Actions environment from the default environment variables set by GitHub.