### PR TITLE
chore: add linting for template workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,94 @@ concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+env:
+  ABC_CLI_VERSION: ''
+  GUARDIAN_WIF_PROVIDER: 'projects/1098665030124/locations/global/workloadIdentityPools/guardian-automation/providers/guardian-ci-i'
+  GUARDIAN_WIF_SERVICE_ACCOUNT: 'guardian-automation-bot@ghg-guardian-ci-i-6ad437.iam.gserviceaccount.com'
+  GUARDIAN_BUCKET_NAME: 'guardian-ci-i-guardian-state-c79e1f4759'
+  GUARDIAN_TERRAFORM_VERSION: '1.7.1'
+  GUARDIAN_TAGREP_VERSION: '0.0.7'
+
 jobs:
   go_test:
     uses: 'abcxyz/actions/.github/workflows/go-test.yml@main' # ratchet:exclude
+
+  ratchet_lint_templates:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 1 # shallow clone
+
+      - name: 'Setup abc'
+        uses: 'abcxyz/pkg/.github/actions/setup-binary@90acbb7e25e72c3c7ae2c040244d8468f74f8d96' # ratchet:abcxyz/pkg/.github/actions/setup-binary@main
+        with:
+          download_url: 'https://github.com/abcxyz/abc/releases/download/v${{ env.ABC_CLI_VERSION }}/abc_${{ env.ABC_CLI_VERSION }}_linux_amd64.tar.gz'
+          install_path: '${{ runner.temp }}/.abc'
+          binary_subpath: 'abc'
+          cache_key: '${{ runner.os }}_${{ runner.arch }}_abc_${{ env.ABC_CLI_VERSION }}'
+          add_to_path: true
+
+      - name: 'render templates'
+        shell: 'bash'
+        run: |
+          rm -f ./.github/workflow/*
+          abc templates render \
+            -input=terraform_version="${{ env.GUARDIAN_TERRAFORM_VERSION }}" \
+            -input=tagrep_version="${{ env.GUARDIAN_TAGREP_VERSION }}" \
+            -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
+            -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
+            -input=guardian_state_bucket="${{ env.GUARDIAN_BUCKET_NAME }}" \
+            -accept-defaults \
+            github.com/abcxyz/guardian/abc.templates/base-workflows@latest
+          abc templates render \
+            -input=gcp_organization_id="00000000" \
+            -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
+            -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
+            -accept-defaults \
+            github.com/abcxyz/guardian/abc.templates/drift-workflows@latest
+
+      - name: 'lint ratchet'
+        uses: 'sethvargo/ratchet@main' # ratchet:exclude
+        with:
+          files: './.github/workflows/*.yml'
+ 
+  actions_lint_templates:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 1 # shallow clone
+
+      - name: 'Setup abc'
+        uses: 'abcxyz/pkg/.github/actions/setup-binary@90acbb7e25e72c3c7ae2c040244d8468f74f8d96' # ratchet:abcxyz/pkg/.github/actions/setup-binary@main
+        with:
+          download_url: 'https://github.com/abcxyz/abc/releases/download/v${{ env.ABC_CLI_VERSION }}/abc_${{ env.ABC_CLI_VERSION }}_linux_amd64.tar.gz'
+          install_path: '${{ runner.temp }}/.abc'
+          binary_subpath: 'abc'
+          cache_key: '${{ runner.os }}_${{ runner.arch }}_abc_${{ env.ABC_CLI_VERSION }}'
+          add_to_path: true
+
+      - name: 'render templates'
+        shell: 'bash'
+        run: |
+          rm -f ./.github/workflow/*
+          abc templates render \
+            -input=terraform_version="${{ env.GUARDIAN_TERRAFORM_VERSION }}" \
+            -input=tagrep_version="${{ env.GUARDIAN_TAGREP_VERSION }}" \
+            -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
+            -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
+            -input=guardian_state_bucket="${{ env.GUARDIAN_BUCKET_NAME }}" \
+            -accept-defaults \
+            github.com/abcxyz/guardian/abc.templates/base-workflows@latest
+          abc templates render \
+            -input=gcp_organization_id="00000000" \
+            -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
+            -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
+            -accept-defaults \
+            github.com/abcxyz/guardian/abc.templates/drift-workflows@latest
+
+      - name: 'lint actions'
+        uses: 'abcxyz/actions/.github/actions/lint-github-actions@main' # ratchet:exclude

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
 
       - name: 'render templates'
         shell: 'bash'
+        env:
+          REF: '${{ github.sha }}'
         run: |
           rm -f ./.github/workflow/*
           abc templates render \
@@ -70,13 +72,13 @@ jobs:
             -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
             -input=guardian_state_bucket="${{ env.GUARDIAN_BUCKET_NAME }}" \
             -accept-defaults \
-            github.com/abcxyz/guardian/abc.templates/base-workflows@latest
+            "github.com/abcxyz/guardian/abc.templates/base-workflows@${REF}"
           abc templates render \
             -input=gcp_organization_id="00000000" \
             -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
             -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
             -accept-defaults \
-            github.com/abcxyz/guardian/abc.templates/drift-workflows@latest
+            "github.com/abcxyz/guardian/abc.templates/drift-workflows@${REF}"
 
       - name: 'lint ratchet'
         uses: 'sethvargo/ratchet@main' # ratchet:exclude
@@ -102,6 +104,8 @@ jobs:
 
       - name: 'render templates'
         shell: 'bash'
+        env:
+          REF: '${{ github.sha }}'
         run: |
           rm -f ./.github/workflow/*
           abc templates render \
@@ -111,13 +115,13 @@ jobs:
             -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
             -input=guardian_state_bucket="${{ env.GUARDIAN_BUCKET_NAME }}" \
             -accept-defaults \
-            github.com/abcxyz/guardian/abc.templates/base-workflows@latest
+            "github.com/abcxyz/guardian/abc.templates/base-workflows@${REF}"
           abc templates render \
             -input=gcp_organization_id="00000000" \
             -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
             -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
             -accept-defaults \
-            github.com/abcxyz/guardian/abc.templates/drift-workflows@latest
+            "github.com/abcxyz/guardian/abc.templates/drift-workflows@${REF}"
 
       - name: 'lint actions'
         uses: 'abcxyz/actions/.github/actions/lint-github-actions@main' # ratchet:exclude

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
         run: |
           rm -f ./.github/workflow/*
           abc templates render \
+            -skip-manifest \
             -input=terraform_version="${{ env.GUARDIAN_TERRAFORM_VERSION }}" \
             -input=tagrep_version="${{ env.GUARDIAN_TAGREP_VERSION }}" \
             -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
@@ -74,6 +75,7 @@ jobs:
             -accept-defaults \
             "github.com/abcxyz/guardian/abc.templates/base-workflows@${REF}"
           abc templates render \
+            -skip-manifest \
             -input=gcp_organization_id="00000000" \
             -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
             -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
@@ -109,6 +111,7 @@ jobs:
         run: |
           rm -f ./.github/workflow/*
           abc templates render \
+            -skip-manifest \
             -input=terraform_version="${{ env.GUARDIAN_TERRAFORM_VERSION }}" \
             -input=tagrep_version="${{ env.GUARDIAN_TAGREP_VERSION }}" \
             -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
@@ -117,6 +120,7 @@ jobs:
             -accept-defaults \
             "github.com/abcxyz/guardian/abc.templates/base-workflows@${REF}"
           abc templates render \
+            -skip-manifest \
             -input=gcp_organization_id="00000000" \
             -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
             -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
   go_test:
     uses: 'abcxyz/actions/.github/workflows/go-test.yml@main' # ratchet:exclude
 
-  ratchet_lint_templates:
+  lint_templates:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
@@ -81,47 +81,25 @@ jobs:
             ./abc.templates/drift-workflows
 
       - name: 'lint ratchet'
+        if: |
+          always()
         uses: 'sethvargo/ratchet@main' # ratchet:exclude
         with:
           files: './.github/workflows/*.yml'
 
-  actions_lint_templates:
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: 'Checkout'
-        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
-        with:
-          fetch-depth: 1 # shallow clone
-
-      - name: 'Setup abc'
-        uses: 'abcxyz/pkg/.github/actions/setup-binary@1d1cedf7768d17dde23bb2cda24bc1fb950e9f92' # ratchet:abcxyz/pkg/.github/actions/setup-binary@main
-        with:
-          download_url: 'https://github.com/abcxyz/abc/releases/download/v${{ env.ABC_CLI_VERSION }}/abc_${{ env.ABC_CLI_VERSION }}_linux_amd64.tar.gz'
-          install_path: '${{ runner.temp }}/.abc'
-          binary_subpath: 'abc'
-          cache_key: '${{ runner.os }}_${{ runner.arch }}_abc_${{ env.ABC_CLI_VERSION }}'
-          add_to_path: true
-
-      - name: 'render templates'
-        shell: 'bash'
-        run: |
-          rm -f ./.github/workflow/*
-          abc templates render \
-            -skip-manifest \
-            -input=terraform_version="${{ env.GUARDIAN_TERRAFORM_VERSION }}" \
-            -input=tagrep_version="${{ env.GUARDIAN_TAGREP_VERSION }}" \
-            -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
-            -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
-            -input=guardian_state_bucket="${{ env.GUARDIAN_BUCKET_NAME }}" \
-            -accept-defaults \
-            ./abc.templates/base-workflows
-          abc templates render \
-            -skip-manifest \
-            -input=gcp_organization_id="00000000" \
-            -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
-            -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
-            -accept-defaults \
-            ./abc.templates/drift-workflows
-
       - name: 'lint actions'
+        if: |
+          always()
         uses: 'abcxyz/actions/.github/actions/lint-github-actions@main' # ratchet:exclude
+
+      - name: 'Verify golden tests base-workflows'
+        if: |
+          always()
+        run: |
+          abc golden-test verify ./abc.templates/base-workflows/
+
+      - name: 'Verify golden tests drift-workflows'
+        if: |
+          always()
+        run: |
+          abc golden-test verify ./abc.templates/drift-workflows/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 1 # shallow clone
 
       - name: 'Setup abc'
-        uses: 'abcxyz/pkg/.github/actions/setup-binary@90acbb7e25e72c3c7ae2c040244d8468f74f8d96' # ratchet:abcxyz/pkg/.github/actions/setup-binary@main
+        uses: 'abcxyz/pkg/.github/actions/setup-binary@1d1cedf7768d17dde23bb2cda24bc1fb950e9f92' # ratchet:abcxyz/pkg/.github/actions/setup-binary@main
         with:
           download_url: 'https://github.com/abcxyz/abc/releases/download/v${{ env.ABC_CLI_VERSION }}/abc_${{ env.ABC_CLI_VERSION }}_linux_amd64.tar.gz'
           install_path: '${{ runner.temp }}/.abc'
@@ -82,7 +82,7 @@ jobs:
         uses: 'sethvargo/ratchet@main' # ratchet:exclude
         with:
           files: './.github/workflows/*.yml'
- 
+
   actions_lint_templates:
     runs-on: 'ubuntu-latest'
     steps:
@@ -92,7 +92,7 @@ jobs:
           fetch-depth: 1 # shallow clone
 
       - name: 'Setup abc'
-        uses: 'abcxyz/pkg/.github/actions/setup-binary@90acbb7e25e72c3c7ae2c040244d8468f74f8d96' # ratchet:abcxyz/pkg/.github/actions/setup-binary@main
+        uses: 'abcxyz/pkg/.github/actions/setup-binary@1d1cedf7768d17dde23bb2cda24bc1fb950e9f92' # ratchet:abcxyz/pkg/.github/actions/setup-binary@main
         with:
           download_url: 'https://github.com/abcxyz/abc/releases/download/v${{ env.ABC_CLI_VERSION }}/abc_${{ env.ABC_CLI_VERSION }}_linux_amd64.tar.gz'
           install_path: '${{ runner.temp }}/.abc'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ABC_CLI_VERSION: ''
+  ABC_CLI_VERSION: '0.10.1'
   GUARDIAN_WIF_PROVIDER: 'projects/1098665030124/locations/global/workloadIdentityPools/guardian-automation/providers/guardian-ci-i'
   GUARDIAN_WIF_SERVICE_ACCOUNT: 'guardian-automation-bot@ghg-guardian-ci-i-6ad437.iam.gserviceaccount.com'
   GUARDIAN_BUCKET_NAME: 'guardian-ci-i-guardian-state-c79e1f4759'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,6 @@ jobs:
 
       - name: 'render templates'
         shell: 'bash'
-        env:
-          REF: '${{ github.sha }}'
         run: |
           rm -f ./.github/workflow/*
           abc templates render \
@@ -73,14 +71,14 @@ jobs:
             -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
             -input=guardian_state_bucket="${{ env.GUARDIAN_BUCKET_NAME }}" \
             -accept-defaults \
-            "github.com/abcxyz/guardian/abc.templates/base-workflows@${REF}"
+            ./abc.templates/base-workflows
           abc templates render \
             -skip-manifest \
             -input=gcp_organization_id="00000000" \
             -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
             -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
             -accept-defaults \
-            "github.com/abcxyz/guardian/abc.templates/drift-workflows@${REF}"
+            ./abc.templates/drift-workflows
 
       - name: 'lint ratchet'
         uses: 'sethvargo/ratchet@main' # ratchet:exclude
@@ -106,8 +104,6 @@ jobs:
 
       - name: 'render templates'
         shell: 'bash'
-        env:
-          REF: '${{ github.sha }}'
         run: |
           rm -f ./.github/workflow/*
           abc templates render \
@@ -118,14 +114,14 @@ jobs:
             -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
             -input=guardian_state_bucket="${{ env.GUARDIAN_BUCKET_NAME }}" \
             -accept-defaults \
-            "github.com/abcxyz/guardian/abc.templates/base-workflows@${REF}"
+            ./abc.templates/base-workflows
           abc templates render \
             -skip-manifest \
             -input=gcp_organization_id="00000000" \
             -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
             -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
             -accept-defaults \
-            "github.com/abcxyz/guardian/abc.templates/drift-workflows@${REF}"
+            ./abc.templates/drift-workflows
 
       - name: 'lint actions'
         uses: 'abcxyz/actions/.github/actions/lint-github-actions@main' # ratchet:exclude

--- a/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
@@ -88,13 +88,13 @@ jobs:
         id: 'opa_eval'
         shell: 'bash'
         run: |-
-          DECISION=$(opa eval \
+          DECISION="$(opa eval \
             --format raw \
             --input ./workflow_dispatch_inputs.json \
             --data ./policy/guardian/admin \
             --data ./guardian_policy_context.json \
-            "data.guardian.admin")
-          echo "$DECISION" > policy_results.json
+            "data.guardian.admin")"
+          echo "${DECISION}" > policy_results.json
 
       - name: 'Enforce Policy'
         shell: 'bash'
@@ -103,7 +103,7 @@ jobs:
         run: |-
           guardian policy enforce \
             -reporter=none \
-            -dir=${DIRECTORY} \
+            -dir="${DIRECTORY}" \
             -results-file=policy_results.json
 
       - name: 'Guardian Directories'
@@ -115,7 +115,7 @@ jobs:
         run: |-
           DIRECTORIES=$(guardian entrypoints -dir="${ENTRYPOINT}" -reporter=none)
           echo "entrypoints -> ${DIRECTORIES}"
-          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+          echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 
   admin:
     if: |

--- a/abc.templates/base-workflows/contents/workflows/guardian-apply.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-apply.yml
@@ -67,7 +67,7 @@ jobs:
         run: |-
           DIRECTORIES=$(guardian entrypoints -dir="REPLACE_TERRAFORM_DIRECTORY" -detect-changes -source-ref=HEAD~1 -dest-ref=HEAD)
           echo "entrypoints -> ${DIRECTORIES}"
-          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+          echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 
   apply:
     if: |

--- a/abc.templates/base-workflows/contents/workflows/guardian-merge-check.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-merge-check.yml
@@ -82,8 +82,8 @@ jobs:
         run: |
           tags="$(tagrep parse -type=request -format=raw -array-tags=GUARDIAN_DIRS 2> tagrep.log)"
           cat tagrep.log
-          echo "tags -> $tags"
-          echo "$tags" >> "$GITHUB_ENV"
+          echo "tags -> ${tags}"
+          echo "${tags}" >> "${GITHUB_ENV}"
 
       - name: 'Guardian Changed Entrypoints in Current PR'
         id: 'entrypoints-changed-in-pr'
@@ -96,7 +96,7 @@ jobs:
         run: |-
           DIRECTORIES=$(guardian entrypoints -skip-reporting -dir="REPLACE_TERRAFORM_DIRECTORY" -detect-changes -source-ref="${SOURCE_REF}" -dest-ref="${DEST_REF}")
           echo "entrypoints -> ${DIRECTORIES}"
-          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+          echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 
       - name: 'PR info'
         id: 'pr-info'
@@ -104,12 +104,14 @@ jobs:
         env:
           GH_TOKEN: '${{ github.token }}'
         run: |-
-          PR_NUM="$(echo "$GITHUB_REF" | grep -Po 'refs\/heads\/gh-readonly-queue\/(?:.+)\/pr-\K(\d*)')"
-          PR_TARGET_BRANCH_NAME="$(echo "$GITHUB_REF" | grep -Po 'refs\/heads\/gh-readonly-queue\/\K((?!\/pr-)(.))+')"
-          PR_BRANCH_REF="$(gh pr --repo="$GITHUB_REPOSITORY" view "$PR_NUM" --json headRefOid --jq '.headRefOid')"
-          echo "pr_branch_ref=${PR_BRANCH_REF}" >> $GITHUB_OUTPUT
-          echo "pr_number=${PR_NUM}" >> $GITHUB_OUTPUT
-          echo "pr_target_branch_name=${PR_TARGET_BRANCH_NAME}" >> $GITHUB_OUTPUT
+          PR_NUM="$(echo "${GITHUB_REF}" | grep -Po 'refs\/heads\/gh-readonly-queue\/(?:.+)\/pr-\K(\d*)')"
+          PR_TARGET_BRANCH_NAME="$(echo "${GITHUB_REF}" | grep -Po 'refs\/heads\/gh-readonly-queue\/\K((?!\/pr-)(.))+')"
+          PR_BRANCH_REF="$(gh pr --repo="${GITHUB_REPOSITORY}" view "${PR_NUM}" --json headRefOid --jq '.headRefOid')"
+          {
+            echo "pr_branch_ref=${PR_BRANCH_REF}"
+            echo "pr_number=${PR_NUM}"
+            echo "pr_target_branch_name=${PR_TARGET_BRANCH_NAME}" 
+          } >> "${GITHUB_OUTPUT}"
 
       - name: 'Checkout'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
@@ -134,10 +136,10 @@ jobs:
           # We want to know the intersection between the merge queue base ref
           # and the PR base ref. This will be the commit on main at the time
           # of the PR plan.
-          FEATURE_BRANCH_BASE_REF=$(git merge-base $PR_REF $BASE_REF)
+          FEATURE_BRANCH_BASE_REF="$(git merge-base "${PR_REF}" "${BASE_REF}")"
           DIRECTORIES=$(guardian entrypoints -skip-reporting -dir="REPLACE_TERRAFORM_DIRECTORY" -detect-changes -source-ref="${FEATURE_BRANCH_BASE_REF}" -dest-ref="${BASE_REF}")
           echo "entrypoints -> ${DIRECTORIES}"
-          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+          echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Check'
         id: 'check'
@@ -146,10 +148,10 @@ jobs:
           CHANGED_IN_PR: '${{ steps.entrypoints-changed-in-pr.outputs.directories }}'
           CHANGED_SINCE_PR: '${{ steps.entrypoints-changed-since-pr.outputs.directories }}'
         run: |-
-          modified_in_both="$(join <(echo "$CHANGED_IN_PR" | jq '.[]') <(echo "$CHANGED_SINCE_PR" | jq '.[]'))"
-          if [[ "$modified_in_both" != "" ]]; then
+          modified_in_both="$(join <(echo "${CHANGED_IN_PR}" | jq '.[]') <(echo "${CHANGED_SINCE_PR}" | jq '.[]'))"
+          if [[ "${modified_in_both}" != "" ]]; then
             echo "[ERROR] Found entrypoints that have been modified since the plan was created. Please rebase and recreate your plan."
-            echo "$modified_in_both"
+            echo "${modified_in_both}"
             exit 1
           fi
 
@@ -163,4 +165,4 @@ jobs:
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
           PR_NUMBER: '${{ steps.pr-info.outputs.pr_number }}'
         run: |-
-          guardian workflows merge-queue-comment -result="$RESULT" -target-branch="$TARGET_BRANCH" -github-pull-request-number="$PR_NUMBER"
+          guardian workflows merge-queue-comment -result="${RESULT}" -target-branch="${TARGET_BRANCH}" -github-pull-request-number="${PR_NUMBER}"

--- a/abc.templates/base-workflows/contents/workflows/guardian-merge-check.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-merge-check.yml
@@ -110,7 +110,7 @@ jobs:
           {
             echo "pr_branch_ref=${PR_BRANCH_REF}"
             echo "pr_number=${PR_NUM}"
-            echo "pr_target_branch_name=${PR_TARGET_BRANCH_NAME}" 
+            echo "pr_target_branch_name=${PR_TARGET_BRANCH_NAME}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: 'Checkout'

--- a/abc.templates/base-workflows/contents/workflows/guardian-nightly.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-nightly.yml
@@ -47,11 +47,11 @@ jobs:
           LABEL="bug"
 
           # Check for existing issues with the given title
-          existing_issue=$(gh issue list -R $GITHUB_REPOSITORY --search "$TITLE in:title" --state open --limit 1)
+          existing_issue=$(gh issue list -R "${GITHUB_REPOSITORY}" --search "${TITLE} in:title" --state open --limit 1)
 
           # Create a new issue if no existing issue matches the title
-          if [[ -z "$existing_issue" ]]; then
-              gh issue create -R $GITHUB_REPOSITORY -t "$TITLE" -b "$BODY" -l "$LABEL"
+          if [[ -z "${existing_issue}" ]]; then
+              gh issue create -R "${GITHUB_REPOSITORY}" -t "${TITLE}" -b "${BODY}" -l "${LABEL}"
           else
               echo "An issue already exists. No new issue created."
           fi

--- a/abc.templates/base-workflows/contents/workflows/guardian-plan.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-plan.yml
@@ -99,8 +99,8 @@ jobs:
         run: |
           tags="$(tagrep parse -type=request -format=raw -array-tags=GUARDIAN_DIRS 2> tagrep.log)"
           cat tagrep.log
-          echo "tags -> $tags"
-          echo "$tags" >> "$GITHUB_ENV"
+          echo "tags -> ${tags}"
+          echo "${tags}" >> "${GITHUB_ENV}"
 
       - name: 'Guardian Directories'
         id: 'dirs'
@@ -114,10 +114,10 @@ jobs:
           # The BASE_REF on github is sometimes only in the main branch.
           # We can use git merge-base to find the intersection between the
           # main branch and PR (feature) branch.
-          FEATURE_BRANCH_BASE_REF=$(git merge-base $PR_REF $BASE_REF)
+          FEATURE_BRANCH_BASE_REF="$(git merge-base "${PR_REF}" "${BASE_REF}")"
           DIRECTORIES=$(guardian entrypoints -dir="REPLACE_TERRAFORM_DIRECTORY" -detect-changes -source-ref="${FEATURE_BRANCH_BASE_REF}" -dest-ref="${PR_REF}")
           echo "entrypoints -> ${DIRECTORIES}"
-          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+          echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 
   plan:
     if: |

--- a/abc.templates/base-workflows/contents/workflows/guardian-run.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-run.yml
@@ -43,7 +43,7 @@ on:
     inputs:
       command:
         description: 'COMMAND - The Terraform command to run.'
-        required: true
+        required: false
         type: 'string'
         default: 'plan'
       entrypoint:
@@ -161,7 +161,7 @@ jobs:
           DETAILED_EXITCODE: '${{ inputs.detailed-exitcode }}'
         shell: 'bash'
         run: |-
-          guardian run -dir="${DIRECTORY}" -- plan -input=false -detailed-exitcode=${DETAILED_EXITCODE}
+          guardian run -dir="${DIRECTORY}" -- plan -input=false -detailed-exitcode="${DETAILED_EXITCODE}"
 
       - name: 'Guardian Apply'
         if: |

--- a/abc.templates/base-workflows/contents/workflows/guardian-run.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-run.yml
@@ -97,7 +97,7 @@ jobs:
         run: |-
           DIRECTORIES=$(guardian entrypoints -dir="${ENTRYPOINT}" -reporter=none)
           echo "entrypoints -> ${DIRECTORIES}"
-          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+          echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 
   run:
     if: |

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
@@ -12,51 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Guardian run is used to run Terraform commands that are most often used
-# to fix state after a failed workflow or get outputs for a given module
-# directory. Any user with write permissions on the repo can run this workflow.
-name: 'guardian_run'
-run-name: 'guardian_run - [${{ inputs.command }}] [${{ inputs.entrypoint }}]'
+# Guardian admin is used to run Terraform commands as the privileged service account.
+# Due to the sensitive nature of the access this account has, this workflow is restricted
+# to only repository administrators to prevent misuse.
+name: 'guardian_admin'
+run-name: 'guardian_admin - [${{ inputs.command }}] [${{ inputs.entrypoint }}]'
 
 on:
   workflow_dispatch:
     inputs:
       command:
-        description: 'COMMAND - The Terraform command to run.'
+        description: 'COMMAND - The Terraform command to run along with any arguments, e.g. plan -input=false, apply -auto-approve, etc.'
         required: true
-        type: 'choice'
-        default: 'plan'
-        options:
-          - 'plan'
-          - 'apply'
-          - 'output'
       entrypoint:
         description: 'ENTRYPOINT - The directory to search for all child directories containing Terraform configurations. If left blank, the Terraform command will run for all configured directories.'
         default: '.'
         type: 'string'
-      detailed-exitcode:
-        description: 'DETAILED-EXITCODE (usually false) - The value of the -detailed-exitcode flag for "terraform plan", which causes a nonempty diff to return a status code of 2; ignored for other commands besides "plan".'
-        type: 'boolean'
-        default: false
-        required: false
-  workflow_call:
-    inputs:
-      command:
-        description: 'COMMAND - The Terraform command to run.'
-        required: false
-        type: 'string'
-        default: 'plan'
-      entrypoint:
-        description: 'ENTRYPOINT - The directory to search for all child directories containing Terraform configurations. If left blank, the Terraform command will run for all configured directories.'
-        default: '.'
-        type: 'string'
-      detailed-exitcode:
-        description: 'DETAILED-EXITCODE (usually false) - The value of the -detailed-exitcode flag for "terraform plan", which causes a nonempty diff to return a status code of 2; ignored for other commands besides "plan".'
-        type: 'boolean'
-        default: false
-        required: false
 
-# only one fix should run at a time
+# only one admin should run at a time
 concurrency:
   group: '${{ github.workflow }}'
 
@@ -88,6 +61,51 @@ jobs:
           cache_key: '${{ runner.os }}_${{ runner.arch }}_guardian_${{ env.GUARDIAN_VERSION }}'
           add_to_path: true
 
+      - name: 'Create Inputs File'
+        shell: 'bash'
+        run: |-
+          cat << EOF > workflow_dispatch_inputs.json
+          {
+            "command": "${{ inputs.command }}",
+            "entrypoint": "${{ inputs.entrypoint }}"
+          }
+          EOF
+
+      - name: 'Aggregate Policy Data'
+        shell: 'bash'
+        env:
+          # used to call GitHub API's for data aggregation
+          GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
+        run: |-
+          guardian policy fetch-data
+
+      - name: 'Setup OPA'
+        uses: 'open-policy-agent/setup-opa@34a30e8a924d1b03ce2cf7abe97250bbb1f332b5' # ratchet:open-policy-agent/setup-opa@v2
+        with:
+          version: 'latest'
+
+      - name: 'Evaluate Policy'
+        id: 'opa_eval'
+        shell: 'bash'
+        run: |-
+          DECISION="$(opa eval \
+            --format raw \
+            --input ./workflow_dispatch_inputs.json \
+            --data ./policy/guardian/admin \
+            --data ./guardian_policy_context.json \
+            "data.guardian.admin")"
+          echo "${DECISION}" > policy_results.json
+
+      - name: 'Enforce Policy'
+        shell: 'bash'
+        env:
+          GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
+        run: |-
+          guardian policy enforce \
+            -reporter=none \
+            -dir="${DIRECTORY}" \
+            -results-file=policy_results.json
+
       - name: 'Guardian Directories'
         id: 'dirs'
         shell: 'bash'
@@ -99,7 +117,7 @@ jobs:
           echo "entrypoints -> ${DIRECTORIES}"
           echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 
-  run:
+  admin:
     if: |
       needs.init.outputs.directories != '[]'
     needs:
@@ -115,10 +133,6 @@ jobs:
       max-parallel: 100
       matrix:
         working_directory: '${{ fromJSON(needs.init.outputs.directories) }}'
-
-    env:
-      DIRECTORY: '${{ matrix.working_directory }}'
-
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
@@ -147,25 +161,9 @@ jobs:
           cache_key: '${{ runner.os }}_${{ runner.arch }}_guardian_${{ env.GUARDIAN_VERSION }}'
           add_to_path: true
 
-      - name: 'Guardian Output'
-        if: |
-          inputs.command == 'output'
-        shell: 'bash'
-        run: |-
-          guardian run -dir="${DIRECTORY}" -- output
-
-      - name: 'Guardian Plan'
-        if: |
-          inputs.command == 'plan'
+      - name: 'Guardian Admin'
         env:
-          DETAILED_EXITCODE: '${{ inputs.detailed-exitcode }}'
+          DIRECTORY: '${{ matrix.working_directory }}'
         shell: 'bash'
         run: |-
-          guardian run -dir="${DIRECTORY}" -- plan -input=false -detailed-exitcode="${DETAILED_EXITCODE}"
-
-      - name: 'Guardian Apply'
-        if: |
-          inputs.command == 'apply'
-        shell: 'bash'
-        run: |-
-          guardian run -dir="${DIRECTORY}" -- apply -input=false -auto-approve
+          guardian run -dir="${DIRECTORY}" -- ${{ inputs.command }}

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-apply.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-apply.yml
@@ -67,7 +67,7 @@ jobs:
         run: |-
           DIRECTORIES=$(guardian entrypoints -dir="." -detect-changes -source-ref=HEAD~1 -dest-ref=HEAD)
           echo "entrypoints -> ${DIRECTORIES}"
-          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+          echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 
   apply:
     if: |

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-apply.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-apply.yml
@@ -86,6 +86,11 @@ jobs:
       max-parallel: 100
       matrix:
         working_directory: '${{ fromJSON(needs.init.outputs.directories) }}'
+
+    env:
+      DIRECTORY: '${{ matrix.working_directory }}'
+      GITHUB_JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
+
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
@@ -119,6 +124,5 @@ jobs:
         env:
           # used to create comments on pull requests (access to only this repo)
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
-          DIRECTORY: '${{ matrix.working_directory }}'
         run: |-
           guardian apply -dir="${DIRECTORY}" -storage="gcs://${GUARDIAN_BUCKET_NAME}"

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-merge-check.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-merge-check.yml
@@ -82,8 +82,8 @@ jobs:
         run: |
           tags="$(tagrep parse -type=request -format=raw -array-tags=GUARDIAN_DIRS 2> tagrep.log)"
           cat tagrep.log
-          echo "tags -> $tags"
-          echo "$tags" >> "$GITHUB_ENV"
+          echo "tags -> ${tags}"
+          echo "${tags}" >> "${GITHUB_ENV}"
 
       - name: 'Guardian Changed Entrypoints in Current PR'
         id: 'entrypoints-changed-in-pr'
@@ -96,7 +96,7 @@ jobs:
         run: |-
           DIRECTORIES=$(guardian entrypoints -skip-reporting -dir="." -detect-changes -source-ref="${SOURCE_REF}" -dest-ref="${DEST_REF}")
           echo "entrypoints -> ${DIRECTORIES}"
-          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+          echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 
       - name: 'PR info'
         id: 'pr-info'
@@ -104,12 +104,14 @@ jobs:
         env:
           GH_TOKEN: '${{ github.token }}'
         run: |-
-          PR_NUM="$(echo "$GITHUB_REF" | grep -Po 'refs\/heads\/gh-readonly-queue\/(?:.+)\/pr-\K(\d*)')"
-          PR_TARGET_BRANCH_NAME="$(echo "$GITHUB_REF" | grep -Po 'refs\/heads\/gh-readonly-queue\/\K((?!\/pr-)(.))+')"
-          PR_BRANCH_REF="$(gh pr --repo="$GITHUB_REPOSITORY" view "$PR_NUM" --json headRefOid --jq '.headRefOid')"
-          echo "pr_branch_ref=${PR_BRANCH_REF}" >> $GITHUB_OUTPUT
-          echo "pr_number=${PR_NUM}" >> $GITHUB_OUTPUT
-          echo "pr_target_branch_name=${PR_TARGET_BRANCH_NAME}" >> $GITHUB_OUTPUT
+          PR_NUM="$(echo "${GITHUB_REF}" | grep -Po 'refs\/heads\/gh-readonly-queue\/(?:.+)\/pr-\K(\d*)')"
+          PR_TARGET_BRANCH_NAME="$(echo "${GITHUB_REF}" | grep -Po 'refs\/heads\/gh-readonly-queue\/\K((?!\/pr-)(.))+')"
+          PR_BRANCH_REF="$(gh pr --repo="${GITHUB_REPOSITORY}" view "${PR_NUM}" --json headRefOid --jq '.headRefOid')"
+          {
+            echo "pr_branch_ref=${PR_BRANCH_REF}"
+            echo "pr_number=${PR_NUM}"
+            echo "pr_target_branch_name=${PR_TARGET_BRANCH_NAME}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: 'Checkout'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
@@ -134,10 +136,10 @@ jobs:
           # We want to know the intersection between the merge queue base ref
           # and the PR base ref. This will be the commit on main at the time
           # of the PR plan.
-          FEATURE_BRANCH_BASE_REF=$(git merge-base $PR_REF $BASE_REF)
+          FEATURE_BRANCH_BASE_REF="$(git merge-base "${PR_REF}" "${BASE_REF}")"
           DIRECTORIES=$(guardian entrypoints -skip-reporting -dir="." -detect-changes -source-ref="${FEATURE_BRANCH_BASE_REF}" -dest-ref="${BASE_REF}")
           echo "entrypoints -> ${DIRECTORIES}"
-          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+          echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Check'
         id: 'check'
@@ -146,10 +148,10 @@ jobs:
           CHANGED_IN_PR: '${{ steps.entrypoints-changed-in-pr.outputs.directories }}'
           CHANGED_SINCE_PR: '${{ steps.entrypoints-changed-since-pr.outputs.directories }}'
         run: |-
-          modified_in_both="$(join <(echo "$CHANGED_IN_PR" | jq '.[]') <(echo "$CHANGED_SINCE_PR" | jq '.[]'))"
-          if [[ "$modified_in_both" != "" ]]; then
+          modified_in_both="$(join <(echo "${CHANGED_IN_PR}" | jq '.[]') <(echo "${CHANGED_SINCE_PR}" | jq '.[]'))"
+          if [[ "${modified_in_both}" != "" ]]; then
             echo "[ERROR] Found entrypoints that have been modified since the plan was created. Please rebase and recreate your plan."
-            echo "$modified_in_both"
+            echo "${modified_in_both}"
             exit 1
           fi
 
@@ -163,4 +165,4 @@ jobs:
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
           PR_NUMBER: '${{ steps.pr-info.outputs.pr_number }}'
         run: |-
-          guardian workflows merge-queue-comment -result="$RESULT" -target-branch="$TARGET_BRANCH" -github-pull-request-number="$PR_NUMBER"
+          guardian workflows merge-queue-comment -result="${RESULT}" -target-branch="${TARGET_BRANCH}" -github-pull-request-number="${PR_NUMBER}"

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-merge-check.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-merge-check.yml
@@ -110,7 +110,7 @@ jobs:
           {
             echo "pr_branch_ref=${PR_BRANCH_REF}"
             echo "pr_number=${PR_NUM}"
-            echo "pr_target_branch_name=${PR_TARGET_BRANCH_NAME}" 
+            echo "pr_target_branch_name=${PR_TARGET_BRANCH_NAME}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: 'Checkout'

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-merge-check.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-merge-check.yml
@@ -110,7 +110,7 @@ jobs:
           {
             echo "pr_branch_ref=${PR_BRANCH_REF}"
             echo "pr_number=${PR_NUM}"
-            echo "pr_target_branch_name=${PR_TARGET_BRANCH_NAME}"
+            echo "pr_target_branch_name=${PR_TARGET_BRANCH_NAME}" 
           } >> "${GITHUB_OUTPUT}"
 
       - name: 'Checkout'

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-nightly.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-nightly.yml
@@ -46,11 +46,11 @@ jobs:
           LABEL="bug"
 
           # Check for existing issues with the given title
-          existing_issue=$(gh issue list -R $GITHUB_REPOSITORY --search "$TITLE in:title" --state open --limit 1)
+          existing_issue=$(gh issue list -R "${GITHUB_REPOSITORY}" --search "${TITLE} in:title" --state open --limit 1)
 
           # Create a new issue if no existing issue matches the title
-          if [[ -z "$existing_issue" ]]; then
-              gh issue create -R $GITHUB_REPOSITORY -t "$TITLE" -b "$BODY" -l "$LABEL"
+          if [[ -z "${existing_issue}" ]]; then
+              gh issue create -R "${GITHUB_REPOSITORY}" -t "${TITLE}" -b "${BODY}" -l "${LABEL}"
           else
               echo "An issue already exists. No new issue created."
           fi

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-nightly.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-nightly.yml
@@ -27,8 +27,9 @@ jobs:
     name: 'Guardian run plan'
     uses: './.github/workflows/guardian-run.yml'
     with:
-      command: 'plan --detailed-exitcode'
+      command: 'plan'
       entrypoint: '.'
+      detailed-exitcode: true
 
   nightly-plan:
     runs-on: 'ubuntu-latest'

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-plan.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-plan.yml
@@ -99,8 +99,8 @@ jobs:
         run: |
           tags="$(tagrep parse -type=request -format=raw -array-tags=GUARDIAN_DIRS 2> tagrep.log)"
           cat tagrep.log
-          echo "tags -> $tags"
-          echo "$tags" >> "$GITHUB_ENV"
+          echo "tags -> ${tags}"
+          echo "${tags}" >> "${GITHUB_ENV}"
 
       - name: 'Guardian Directories'
         id: 'dirs'
@@ -114,10 +114,10 @@ jobs:
           # The BASE_REF on github is sometimes only in the main branch.
           # We can use git merge-base to find the intersection between the
           # main branch and PR (feature) branch.
-          FEATURE_BRANCH_BASE_REF=$(git merge-base $PR_REF $BASE_REF)
+          FEATURE_BRANCH_BASE_REF="$(git merge-base "${PR_REF}" "${BASE_REF}")"
           DIRECTORIES=$(guardian entrypoints -dir="." -detect-changes -source-ref="${FEATURE_BRANCH_BASE_REF}" -dest-ref="${PR_REF}")
           echo "entrypoints -> ${DIRECTORIES}"
-          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+          echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 
   plan:
     if: |

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-plan.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-plan.yml
@@ -139,6 +139,7 @@ jobs:
 
     env:
       DIRECTORY: '${{ matrix.working_directory }}'
+      GITHUB_JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
 
     steps:
       - name: 'Checkout'

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-run.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-run.yml
@@ -98,13 +98,13 @@ jobs:
         id: 'opa_eval'
         shell: 'bash'
         run: |-
-          DECISION=$(opa eval \
+          DECISION="$(opa eval \
             --format raw \
             --input ./workflow_dispatch_inputs.json \
             --data ./policy/guardian/run \
             --data ./guardian_policy_context.json \
-            "data.guardian.run")
-          echo "$DECISION" > policy_results.json
+            "data.guardian.run")"
+          echo "${DECISION}" > policy_results.json
 
       - name: 'Enforce Policy'
         shell: 'bash'
@@ -125,7 +125,7 @@ jobs:
         run: |-
           DIRECTORIES=$(guardian entrypoints -dir="${ENTRYPOINT}" -reporter=none)
           echo "entrypoints -> ${DIRECTORIES}"
-          echo "directories=${DIRECTORIES}" >> $GITHUB_OUTPUT
+          echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 
   run:
     if: |

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-run.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-run.yml
@@ -32,7 +32,7 @@ on:
     inputs:
       command:
         description: 'COMMAND - The Terraform command to run.'
-        required: true
+        required: false
         type: 'string'
         default: 'plan'
       entrypoint:

--- a/abc.templates/base-workflows/testdata/golden/basic/data/policy/guardian/admin/workflow_permissions.rego
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/policy/guardian/admin/workflow_permissions.rego
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package guardian.run.workflow_permissions
+package guardian.admin.workflow_permissions
 
 import rego.v1
 import data.github as github
 import input
 
 # Configuration
-default_allowed_commands := ["plan", "apply", "output"]
 # Replace with team name. Requires GitHub Token Minter and `--include-teams`
 # flag on `guardian policy fetch-data` command.
 privileged_teams := []
@@ -30,10 +29,6 @@ command := split(input.command, " ")[0]
 
 # Start of policy
 default authorized := false
-
-authorized if {
-  command in default_allowed_commands
-}
 
 authorized if {
   github.actor.access_level in privileged_roles

--- a/abc.templates/drift-workflows/contents/guardian-drift-detection.yml
+++ b/abc.templates/drift-workflows/contents/guardian-drift-detection.yml
@@ -67,13 +67,13 @@ jobs:
         run: |
           DRIFTIGNORE_FILE="$(pwd)/.driftignore"
           guardian iam detect-drift \
-            -organization-id="$ORGANIZATION_ID" \
+            -organization-id="${ORGANIZATION_ID}" \
             -gcs-bucket-query="labels:terraform" \
-            -github-token="$REPO_TOKEN" \
-            -github-owner="$GITHUB_OWNER_NAME" \
-            -github-repo="$GITHUB_REPO_NAME" \
+            -github-token="${REPO_TOKEN}" \
+            -github-owner="${GITHUB_OWNER_NAME}" \
+            -github-repo="${GITHUB_REPO_NAME}" \
             -github-issue-labels="guardian-iam-drift,security" \
-            -driftignore-file="$DRIFTIGNORE_FILE"
+            -driftignore-file="${DRIFTIGNORE_FILE}"
 
   statefile_drift:
     name: 'Statefile drift detection'
@@ -104,11 +104,11 @@ jobs:
         run: |
           guardian drift statefiles \
             -dir="./" \
-            -organization-id="$ORGANIZATION_ID" \
+            -organization-id="${ORGANIZATION_ID}" \
             -gcs-bucket-query="labels:terraform" \
-            -github-token="$GITHUB_TOKEN" \
-            -github-owner="$GITHUB_OWNER_NAME" \
-            -github-repo="$GITHUB_REPO_NAME" \
+            -github-token="${GITHUB_TOKEN}" \
+            -github-owner="${GITHUB_OWNER_NAME}" \
+            -github-repo="${GITHUB_REPO_NAME}" \
             -github-issue-labels="guardian-statefile-drift,security" \
             -github-repo-terraform-topics="terraform,guardian" \
             -ignore-dir-patterns="REPLACE_GUARDIAN_IGNORE_DIR_PATTERNS"

--- a/abc.templates/drift-workflows/testdata/golden/basic/data/.github/workflows/guardian-drift-detection.yml
+++ b/abc.templates/drift-workflows/testdata/golden/basic/data/.github/workflows/guardian-drift-detection.yml
@@ -43,13 +43,14 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v3
+        uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4
 
       - name: 'Setup Guardian'
-        uses: 'abcxyz/pkg/.github/actions/setup-binary@00353d11b4931aca33574bd674d85fafc547972c' # ratchet:abcxyz/pkg/.github/actions/setup-binary@main
+        uses: 'abcxyz/pkg/.github/actions/setup-binary@e6295e3016161bf062cabbf9b245603652923669' # ratchet:abcxyz/pkg/.github/actions/setup-binary@main
         with:
           download_url: 'https://github.com/abcxyz/guardian/releases/download/v${{ env.GUARDIAN_VERSION }}/guardian_${{ env.GUARDIAN_VERSION }}_linux_amd64.tar.gz'
           install_path: '${{ runner.temp }}/.guardian'
+          binary_subpath: 'guardian'
           cache_key: '${{ runner.os }}_${{ runner.arch }}_guardian_${{ env.GUARDIAN_VERSION }}'
           add_to_path: true
 
@@ -79,13 +80,14 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v3
+        uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4
 
       - name: 'Setup Guardian'
-        uses: 'abcxyz/pkg/.github/actions/setup-binary@00353d11b4931aca33574bd674d85fafc547972c' # ratchet:abcxyz/pkg/.github/actions/setup-binary@main
+        uses: 'abcxyz/pkg/.github/actions/setup-binary@e6295e3016161bf062cabbf9b245603652923669' # ratchet:abcxyz/pkg/.github/actions/setup-binary@main
         with:
           download_url: 'https://github.com/abcxyz/guardian/releases/download/v${{ env.GUARDIAN_VERSION }}/guardian_${{ env.GUARDIAN_VERSION }}_linux_amd64.tar.gz'
           install_path: '${{ runner.temp }}/.guardian'
+          binary_subpath: 'guardian'
           cache_key: '${{ runner.os }}_${{ runner.arch }}_guardian_${{ env.GUARDIAN_VERSION }}'
           add_to_path: true
 
@@ -98,13 +100,13 @@ jobs:
       - name: 'Guardian Statefile Drift Detection'
         shell: 'bash'
         env:
-          REPO_TOKEN: '${{ github.token }}'
+          GITHUB_TOKEN: '${{ github.token }}'
         run: |
           guardian drift statefiles \
-            -dir="./"
+            -dir="./" \
             -organization-id="${ORGANIZATION_ID}" \
             -gcs-bucket-query="labels:terraform" \
-            -github-token="${REPO_TOKEN}" \
+            -github-token="${GITHUB_TOKEN}" \
             -github-owner="${GITHUB_OWNER_NAME}" \
             -github-repo="${GITHUB_REPO_NAME}" \
             -github-issue-labels="guardian-statefile-drift,security" \

--- a/abc.templates/drift-workflows/testdata/golden/basic/data/.github/workflows/guardian-drift-detection.yml
+++ b/abc.templates/drift-workflows/testdata/golden/basic/data/.github/workflows/guardian-drift-detection.yml
@@ -66,13 +66,13 @@ jobs:
         run: |
           DRIFTIGNORE_FILE="$(pwd)/.driftignore"
           guardian iam detect-drift \
-            -organization-id="$ORGANIZATION_ID" \
+            -organization-id="${ORGANIZATION_ID}" \
             -gcs-bucket-query="labels:terraform" \
-            -github-token="$REPO_TOKEN" \
-            -github-owner="$GITHUB_OWNER_NAME" \
-            -github-repo="$GITHUB_REPO_NAME" \
+            -github-token="${REPO_TOKEN}" \
+            -github-owner="${GITHUB_OWNER_NAME}" \
+            -github-repo="${GITHUB_REPO_NAME}" \
             -github-issue-labels="guardian-iam-drift,security" \
-            -driftignore-file="$DRIFTIGNORE_FILE"
+            -driftignore-file="${DRIFTIGNORE_FILE}"
 
   statefile_drift:
     name: 'Statefile drift detection'
@@ -102,11 +102,11 @@ jobs:
         run: |
           guardian drift statefiles \
             -dir="./"
-            -organization-id="$ORGANIZATION_ID" \
+            -organization-id="${ORGANIZATION_ID}" \
             -gcs-bucket-query="labels:terraform" \
-            -github-token="$REPO_TOKEN" \
-            -github-owner="$GITHUB_OWNER_NAME" \
-            -github-repo="$GITHUB_REPO_NAME" \
+            -github-token="${REPO_TOKEN}" \
+            -github-owner="${GITHUB_OWNER_NAME}" \
+            -github-repo="${GITHUB_REPO_NAME}" \
             -github-issue-labels="guardian-statefile-drift,security" \
             -github-repo-terraform-topics="terraform,guardian" \
             -ignore-dir-patterns="my-ignore-dir-pattern"


### PR DESCRIPTION
This new workflow 
* Renders the guardian workflows and runs ratchet and actionlint against them. 
* Also checks the abc goldens

NOTE: This workflow will stick around even after we move to the lint.yml for ratchet and actions.