### PR TITLE
fix broken release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,10 +191,10 @@ jobs:
 
           while IFS= read -r -d '' BINARY; do
             chmod +x "${BINARY}"
-            echo $BINARY
+
             FOLDER="$(basename "${BINARY}" ".exe")"
             NAME="${BINARY%%_*}"
-            echo $NAME
+
             # Windows - zip and follow Windows conventions with named subdirectory
             if [ "${FOLDER}" != "${BINARY}" ]; then
               NAME="${NAME}.exe"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,8 +213,8 @@ jobs:
           wait
 
           FILES="$(find ./* -name '*.tar.gz' -o -name '*.zip')"
-          sha256sum "${FILES}" > SHA256SUMS
-          sha512sum "${FILES}" > SHA512SUMS
+          sha256sum ''${FILES}'' > SHA256SUMS
+          sha512sum ''${FILES}'' > SHA512SUMS
 
       - name: 'Upload binaries'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,3 @@ jobs:
             --repo "${REPO}" \
             --cleanup-tag \
             --yes || true
-
-
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,8 +213,8 @@ jobs:
           wait
 
           FILES="$(find ./* -name '*.tar.gz' -o -name '*.zip')"
-          sha256sum ''${FILES}'' > SHA256SUMS
-          sha512sum ''${FILES}'' > SHA512SUMS
+          sha256sum ${FILES} > SHA256SUMS
+          sha512sum ${FILES} > SHA512SUMS
 
       - name: 'Upload binaries'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,12 +189,12 @@ jobs:
         run: |-
           cd dist/
 
-          while IFS= read -r BINARY; do
+          while IFS= read -r -d '' BINARY; do
             chmod +x "${BINARY}"
-
+            echo $BINARY
             FOLDER="$(basename "${BINARY}" ".exe")"
             NAME="${BINARY%%_*}"
-
+            echo $NAME
             # Windows - zip and follow Windows conventions with named subdirectory
             if [ "${FOLDER}" != "${BINARY}" ]; then
               NAME="${NAME}.exe"
@@ -209,11 +209,11 @@ jobs:
               mv "${BINARY}" "${NAME}"
               (tar -czvf "${FOLDER}.tar.gz" "${NAME}" && rm -rf "${NAME}") &
             fi
-          done <   <(find * -type f)
+          done <   <(find . -type f -printf '%P\0')
           wait
 
-          sha256sum $(find * -name '*.tar.gz' -o -name '*.zip') > SHA256SUMS
-          sha512sum $(find * -name '*.tar.gz' -o -name '*.zip') > SHA512SUMS
+          find . \( -name '*.tar.gz' -o -name '*.zip' \) -type f -printf '%P\0' | xargs -0 sha256sum > SHA256SUMS
+          find . \( -name '*.tar.gz' -o -name '*.zip' \) -type f -printf '%P\0' | xargs -0 sha512sum > SHA512SUMS
 
       - name: 'Upload binaries'
         env:
@@ -320,3 +320,6 @@ jobs:
             --repo "${REPO}" \
             --cleanup-tag \
             --yes || true
+
+
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
         run: |-
           cd dist/
 
-          while IFS= read -r -d '' BINARY; do
+          while IFS= read -r BINARY; do
             chmod +x "${BINARY}"
 
             FOLDER="$(basename "${BINARY}" ".exe")"
@@ -209,12 +209,11 @@ jobs:
               mv "${BINARY}" "${NAME}"
               (tar -czvf "${FOLDER}.tar.gz" "${NAME}" && rm -rf "${NAME}") &
             fi
-          done <   <(find ./* -type f)
+          done <   <(find * -type f)
           wait
 
-          FILES="$(find ./* -name '*.tar.gz' -o -name '*.zip')"
-          sha256sum ${FILES} > SHA256SUMS
-          sha512sum ${FILES} > SHA512SUMS
+          sha256sum $(find * -name '*.tar.gz' -o -name '*.zip') > SHA256SUMS
+          sha512sum $(find * -name '*.tar.gz' -o -name '*.zip') > SHA512SUMS
 
       - name: 'Upload binaries'
         env:


### PR DESCRIPTION
This change proposes a fix to address the [broken release workflow](https://github.com/abcxyz/guardian/actions/runs/14525816461/job/40757050540#step:5:34) due to recent [linting updates](https://github.com/abcxyz/guardian/pull/526). 
