### PR TITLE
chore: update default arrayification for guardian admin

### DIFF
--- a/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
@@ -167,5 +167,5 @@ jobs:
           TERRAFORM_CMD: '${{ inputs.command }}'
         shell: 'bash'
         run: |-
-          read -a CLI_ARGS <<< "${TERRAFORM_CMD}"
+          read -a -r CLI_ARGS <<< "${TERRAFORM_CMD}"
           guardian run -dir="${DIRECTORY}" -- "${CLI_ARGS[@]}"

--- a/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
@@ -164,6 +164,8 @@ jobs:
       - name: 'Guardian Admin'
         env:
           DIRECTORY: '${{ matrix.working_directory }}'
+          TERRAFORM_CMD: '${{ inputs.command }}'
         shell: 'bash'
         run: |-
-          guardian run -dir="${DIRECTORY}" -- ${{ inputs.command }}
+          read -a CLI_ARGS <<< "${TERRAFORM_CMD}"
+          guardian run -dir="${DIRECTORY}" -- "${CLI_ARGS[@]}"

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
@@ -167,5 +167,5 @@ jobs:
           TERRAFORM_CMD: '${{ inputs.command }}'
         shell: 'bash'
         run: |-
-          read -a CLI_ARGS <<< "${TERRAFORM_CMD}"
+          read -a -r CLI_ARGS <<< "${TERRAFORM_CMD}"
           guardian run -dir="${DIRECTORY}" -- "${CLI_ARGS[@]}"

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
@@ -164,6 +164,8 @@ jobs:
       - name: 'Guardian Admin'
         env:
           DIRECTORY: '${{ matrix.working_directory }}'
+          TERRAFORM_CMD: '${{ inputs.command }}'
         shell: 'bash'
         run: |-
-          guardian run -dir="${DIRECTORY}" -- ${{ inputs.command }}
+          read -a CLI_ARGS <<< "${TERRAFORM_CMD}"
+          guardian run -dir="${DIRECTORY}" -- "${CLI_ARGS[@]}"


### PR DESCRIPTION
Parse input as array in order to correctly escape.