### PR TITLE
Fix abc.templates by replacing deprecated `-reporter=none` flag with `-skip-reporting` flag

### DIFF
--- a/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
@@ -102,7 +102,7 @@ jobs:
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
         run: |-
           guardian policy enforce \
-            -reporter=none \
+            -skip-reporting \
             -dir="${DIRECTORY}" \
             -results-file=policy_results.json
 
@@ -113,7 +113,7 @@ jobs:
           ENTRYPOINT: '${{ inputs.entrypoint }}'
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
         run: |-
-          DIRECTORIES=$(guardian entrypoints -dir="${ENTRYPOINT}" -reporter=none)
+          DIRECTORIES=$(guardian entrypoints -dir="${ENTRYPOINT}" -skip-reporting)
           echo "entrypoints -> ${DIRECTORIES}"
           echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 

--- a/abc.templates/base-workflows/contents/workflows/guardian-run.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-run.yml
@@ -95,7 +95,7 @@ jobs:
           ENTRYPOINT: '${{ inputs.entrypoint }}'
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
         run: |-
-          DIRECTORIES=$(guardian entrypoints -dir="${ENTRYPOINT}" -reporter=none)
+          DIRECTORIES=$(guardian entrypoints -dir="${ENTRYPOINT}" -skip-reporting)
           echo "entrypoints -> ${DIRECTORIES}"
           echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
@@ -102,7 +102,7 @@ jobs:
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
         run: |-
           guardian policy enforce \
-            -reporter=none \
+            -skip-reporting \
             -dir="${DIRECTORY}" \
             -results-file=policy_results.json
 
@@ -113,7 +113,7 @@ jobs:
           ENTRYPOINT: '${{ inputs.entrypoint }}'
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
         run: |-
-          DIRECTORIES=$(guardian entrypoints -dir="${ENTRYPOINT}" -reporter=none)
+          DIRECTORIES=$(guardian entrypoints -dir="${ENTRYPOINT}" -skip-reporting)
           echo "entrypoints -> ${DIRECTORIES}"
           echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-run.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-run.yml
@@ -95,7 +95,7 @@ jobs:
           ENTRYPOINT: '${{ inputs.entrypoint }}'
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
         run: |-
-          DIRECTORIES=$(guardian entrypoints -dir="${ENTRYPOINT}" -reporter=none)
+          DIRECTORIES=$(guardian entrypoints -dir="${ENTRYPOINT}" -skip-reporting)
           echo "entrypoints -> ${DIRECTORIES}"
           echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
This updates the abc.templates with the newer `-skip-reporting` flag for commands that run outside the context of a pull request and don't need a report via PR comment. This flag used to exist as `-reporter=none` but has been deprecated since `v3.0.0+`.