### PR TITLE
fix: Add missing DIRECTORY env for guardian-admin

### DIFF
--- a/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
@@ -41,7 +41,6 @@ env:
 
 jobs:
   init:
-    if: 'github.ref == ''refs/heads/main'''
     runs-on: 'ubuntu-latest'
 
     permissions:

--- a/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
@@ -100,6 +100,7 @@ jobs:
       - name: 'Enforce Policy'
         shell: 'bash'
         env:
+          DIRECTORY: '${{ inputs.entrypoint }}'
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
         run: |-
           guardian policy enforce \

--- a/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   init:
-    if: github.ref == 'refs/heads/main'
+    if: 'github.ref == ''refs/heads/main'''
     runs-on: 'ubuntu-latest'
 
     permissions:

--- a/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
@@ -41,6 +41,7 @@ env:
 
 jobs:
   init:
+    if: github.ref == 'refs/heads/main'
     runs-on: 'ubuntu-latest'
 
     permissions:

--- a/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   init:
-    if: 'github.ref == ''refs/heads/main'''
+    if: '${{ github.ref == 'refs/heads/main' }}'
     runs-on: 'ubuntu-latest'
 
     permissions:

--- a/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   init:
-    if: '${{ github.ref == 'refs/heads/main' }}'
+    if: 'github.ref == ''refs/heads/main'''
     runs-on: 'ubuntu-latest'
 
     permissions:

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
@@ -41,6 +41,7 @@ env:
 
 jobs:
   init:
+    if: github.ref == 'refs/heads/main'
     runs-on: 'ubuntu-latest'
 
     permissions:
@@ -100,6 +101,7 @@ jobs:
       - name: 'Enforce Policy'
         shell: 'bash'
         env:
+          DIRECTORY: '${{ inputs.entrypoint }}'
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
         run: |-
           guardian policy enforce \

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
@@ -41,7 +41,6 @@ env:
 
 jobs:
   init:
-    if: 'github.ref == ''refs/heads/main'''
     runs-on: 'ubuntu-latest'
 
     permissions:

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   init:
-    if: github.ref == 'refs/heads/main'
+    if: 'github.ref == ''refs/heads/main'''
     runs-on: 'ubuntu-latest'
 
     permissions:

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   init:
-    if: 'github.ref == ''refs/heads/main'''
+    if: '${{ github.ref == 'refs/heads/main' }}'
     runs-on: 'ubuntu-latest'
 
     permissions:

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   init:
-    if: '${{ github.ref == 'refs/heads/main' }}'
+    if: 'github.ref == ''refs/heads/main'''
     runs-on: 'ubuntu-latest'
 
     permissions:


### PR DESCRIPTION
missing DIRECTORY in env, so DIRECTORY evals to empty string