### PR TITLE
Update abc templates to include an input for allowed-providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ env:
   GUARDIAN_BUCKET_NAME: 'guardian-ci-i-guardian-state-c79e1f4759'
   GUARDIAN_TERRAFORM_VERSION: '1.7.1'
   GUARDIAN_TAGREP_VERSION: '0.0.7'
+  GUARDIAN_ALLOWED_PROVIDERS: 'google,google-beta'
 
 jobs:
   go_test:
@@ -65,18 +66,19 @@ jobs:
           rm -f ./.github/workflow/*
           abc templates render \
             -skip-manifest \
-            -input=terraform_version="${{ env.GUARDIAN_TERRAFORM_VERSION }}" \
-            -input=tagrep_version="${{ env.GUARDIAN_TAGREP_VERSION }}" \
-            -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
-            -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
-            -input=guardian_state_bucket="${{ env.GUARDIAN_BUCKET_NAME }}" \
+            -input=terraform_version="${GUARDIAN_TERRAFORM_VERSION}" \
+            -input=tagrep_version="${GUARDIAN_TAGREP_VERSION}" \
+            -input=guardian_wif_provider="${GUARDIAN_WIF_PROVIDER}" \
+            -input=guardian_service_account="${GUARDIAN_WIF_SERVICE_ACCOUNT}" \
+            -input=guardian_state_bucket="${GUARDIAN_BUCKET_NAME}" \
+            -input=guardian_allowed_providers="${GUARDIAN_ALLOWED_PROVIDERS}" \
             -accept-defaults \
             ./abc.templates/base-workflows
           abc templates render \
             -skip-manifest \
             -input=gcp_organization_id="00000000" \
-            -input=guardian_wif_provider="${{ env.GUARDIAN_WIF_PROVIDER }}" \
-            -input=guardian_service_account="${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}" \
+            -input=guardian_wif_provider="${GUARDIAN_WIF_PROVIDER}" \
+            -input=guardian_service_account="${GUARDIAN_WIF_SERVICE_ACCOUNT}" \
             -accept-defaults \
             ./abc.templates/drift-workflows
 

--- a/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-admin.yml
@@ -38,6 +38,7 @@ env:
   GUARDIAN_WIF_PROVIDER: 'REPLACE_GUARDIAN_WIF_PROVIDER'
   GUARDIAN_WIF_SERVICE_ACCOUNT: 'REPLACE_GUARDIAN_WIF_SERVICE_ACCOUNT'
   GUARDIAN_TERRAFORM_VERSION: 'REPLACE_TERRAFORM_VERSION'
+  GUARDIAN_ALLOWED_PROVIDERS: 'REPLACE_GUARDIAN_ALLOWED_PROVIDERS'
 
 jobs:
   init:
@@ -170,4 +171,4 @@ jobs:
         shell: 'bash'
         run: |-
           read -r -a CLI_ARGS <<< "${TERRAFORM_CMD}"
-          guardian run -dir="${DIRECTORY}" -- "${CLI_ARGS[@]}"
+          guardian run -dir="${DIRECTORY}" -allowed-providers="${GUARDIAN_ALLOWED_PROVIDERS}" -- "${CLI_ARGS[@]}"

--- a/abc.templates/base-workflows/contents/workflows/guardian-apply.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-apply.yml
@@ -32,6 +32,7 @@ env:
   GUARDIAN_WIF_SERVICE_ACCOUNT: 'REPLACE_GUARDIAN_WIF_SERVICE_ACCOUNT'
   GUARDIAN_BUCKET_NAME: 'REPLACE_GUARDIAN_STATE_BUCKET'
   GUARDIAN_TERRAFORM_VERSION: 'REPLACE_TERRAFORM_VERSION'
+  GUARDIAN_ALLOWED_PROVIDERS: 'REPLACE_GUARDIAN_ALLOWED_PROVIDERS'
 
 jobs:
   init:
@@ -125,4 +126,4 @@ jobs:
           # used to create comments on pull requests (access to only this repo)
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
         run: |-
-          guardian apply -dir="${DIRECTORY}" -storage="gcs://${GUARDIAN_BUCKET_NAME}"
+          guardian apply -dir="${DIRECTORY}" -storage="gcs://${GUARDIAN_BUCKET_NAME}" -allowed-providers="${GUARDIAN_ALLOWED_PROVIDERS}"

--- a/abc.templates/base-workflows/contents/workflows/guardian-plan.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-plan.yml
@@ -40,6 +40,7 @@ env:
   GUARDIAN_WIF_SERVICE_ACCOUNT: 'REPLACE_GUARDIAN_WIF_SERVICE_ACCOUNT'
   GUARDIAN_BUCKET_NAME: 'REPLACE_GUARDIAN_STATE_BUCKET'
   GUARDIAN_TERRAFORM_VERSION: 'REPLACE_TERRAFORM_VERSION'
+  GUARDIAN_ALLOWED_PROVIDERS: 'REPLACE_GUARDIAN_ALLOWED_PROVIDERS'
   TAGREP_VERSION: 'REPLACE_TAGREP_VERSION'
 
 jobs:
@@ -177,7 +178,7 @@ jobs:
           # used to create comments on pull requests (access to only this repo)
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
         run: |-
-          guardian plan -dir="${DIRECTORY}" -storage="gcs://${GUARDIAN_BUCKET_NAME}"
+          guardian plan -dir="${DIRECTORY}" -storage="gcs://${GUARDIAN_BUCKET_NAME}" -allowed-providers="${GUARDIAN_ALLOWED_PROVIDERS}"
 
   plan_success:
     if: |

--- a/abc.templates/base-workflows/contents/workflows/guardian-run.yml
+++ b/abc.templates/base-workflows/contents/workflows/guardian-run.yml
@@ -65,6 +65,7 @@ env:
   GUARDIAN_WIF_PROVIDER: 'REPLACE_GUARDIAN_WIF_PROVIDER'
   GUARDIAN_WIF_SERVICE_ACCOUNT: 'REPLACE_GUARDIAN_WIF_SERVICE_ACCOUNT'
   GUARDIAN_TERRAFORM_VERSION: 'REPLACE_TERRAFORM_VERSION'
+  GUARDIAN_ALLOWED_PROVIDERS: 'REPLACE_GUARDIAN_ALLOWED_PROVIDERS'
 
 jobs:
   init:
@@ -161,11 +162,11 @@ jobs:
           DETAILED_EXITCODE: '${{ inputs.detailed-exitcode }}'
         shell: 'bash'
         run: |-
-          guardian run -dir="${DIRECTORY}" -- plan -input=false -detailed-exitcode="${DETAILED_EXITCODE}"
+          guardian run -dir="${DIRECTORY}" -allowed-providers="${GUARDIAN_ALLOWED_PROVIDERS}" -- plan -input=false -detailed-exitcode="${DETAILED_EXITCODE}"
 
       - name: 'Guardian Apply'
         if: |
           inputs.command == 'apply'
         shell: 'bash'
         run: |-
-          guardian run -dir="${DIRECTORY}" -- apply -input=false -auto-approve
+          guardian run -dir="${DIRECTORY}" -allowed-providers="${GUARDIAN_ALLOWED_PROVIDERS}" -- apply -input=false -auto-approve

--- a/abc.templates/base-workflows/spec.yaml
+++ b/abc.templates/base-workflows/spec.yaml
@@ -33,6 +33,8 @@ inputs:
       - rule: 'gcp_matches_service_account(guardian_service_account)'
   - name: 'guardian_state_bucket'
     desc: 'The Google Cloud storage bucket for Guardian state'
+  - name: 'guardian_allowed_providers'
+    desc: 'The comma separated list of allowed providers for Guardian. If left blank, all providers will be allowed.'
 
 steps:
   - desc: 'Include required files and directories'
@@ -63,6 +65,8 @@ steps:
           with: '{{.guardian_service_account}}'
         - to_replace: 'REPLACE_GUARDIAN_STATE_BUCKET'
           with: '{{.guardian_state_bucket}}'
+        - to_replace: 'REPLACE_GUARDIAN_ALLOWED_PROVIDERS'
+          with: '{{.guardian_allowed_providers}}'
         - to_replace: 'REPLACE_GUARDIAN_VERSION_TAG'
           with: '{{ trimPrefix ._git_tag "v" }}'
 

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-admin.yml
@@ -38,6 +38,7 @@ env:
   GUARDIAN_WIF_PROVIDER: 'my-guardian-wif-provider'
   GUARDIAN_WIF_SERVICE_ACCOUNT: 'my-guardian-service-account@abcxyz-my-project.iam.gserviceaccount.com'
   GUARDIAN_TERRAFORM_VERSION: '1.7.4'
+  GUARDIAN_ALLOWED_PROVIDERS: 'google,google-beta'
 
 jobs:
   init:
@@ -170,4 +171,4 @@ jobs:
         shell: 'bash'
         run: |-
           read -r -a CLI_ARGS <<< "${TERRAFORM_CMD}"
-          guardian run -dir="${DIRECTORY}" -- "${CLI_ARGS[@]}"
+          guardian run -dir="${DIRECTORY}" -allowed-providers="${GUARDIAN_ALLOWED_PROVIDERS}" -- "${CLI_ARGS[@]}"

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-apply.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-apply.yml
@@ -32,6 +32,7 @@ env:
   GUARDIAN_WIF_SERVICE_ACCOUNT: 'my-guardian-service-account@abcxyz-my-project.iam.gserviceaccount.com'
   GUARDIAN_BUCKET_NAME: 'my-guardian-state-bucket'
   GUARDIAN_TERRAFORM_VERSION: '1.7.4'
+  GUARDIAN_ALLOWED_PROVIDERS: 'google,google-beta'
 
 jobs:
   init:
@@ -125,4 +126,4 @@ jobs:
           # used to create comments on pull requests (access to only this repo)
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
         run: |-
-          guardian apply -dir="${DIRECTORY}" -storage="gcs://${GUARDIAN_BUCKET_NAME}"
+          guardian apply -dir="${DIRECTORY}" -storage="gcs://${GUARDIAN_BUCKET_NAME}" -allowed-providers="${GUARDIAN_ALLOWED_PROVIDERS}"

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-plan.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-plan.yml
@@ -40,6 +40,7 @@ env:
   GUARDIAN_WIF_SERVICE_ACCOUNT: 'my-guardian-service-account@abcxyz-my-project.iam.gserviceaccount.com'
   GUARDIAN_BUCKET_NAME: 'my-guardian-state-bucket'
   GUARDIAN_TERRAFORM_VERSION: '1.7.4'
+  GUARDIAN_ALLOWED_PROVIDERS: 'google,google-beta'
   TAGREP_VERSION: '0.0.7'
 
 jobs:
@@ -177,7 +178,7 @@ jobs:
           # used to create comments on pull requests (access to only this repo)
           GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
         run: |-
-          guardian plan -dir="${DIRECTORY}" -storage="gcs://${GUARDIAN_BUCKET_NAME}"
+          guardian plan -dir="${DIRECTORY}" -storage="gcs://${GUARDIAN_BUCKET_NAME}" -allowed-providers="${GUARDIAN_ALLOWED_PROVIDERS}"
 
   plan_success:
     if: |

--- a/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-run.yml
+++ b/abc.templates/base-workflows/testdata/golden/basic/data/.github/workflows/guardian-run.yml
@@ -65,6 +65,7 @@ env:
   GUARDIAN_WIF_PROVIDER: 'my-guardian-wif-provider'
   GUARDIAN_WIF_SERVICE_ACCOUNT: 'my-guardian-service-account@abcxyz-my-project.iam.gserviceaccount.com'
   GUARDIAN_TERRAFORM_VERSION: '1.7.4'
+  GUARDIAN_ALLOWED_PROVIDERS: 'google,google-beta'
 
 jobs:
   init:
@@ -161,11 +162,11 @@ jobs:
           DETAILED_EXITCODE: '${{ inputs.detailed-exitcode }}'
         shell: 'bash'
         run: |-
-          guardian run -dir="${DIRECTORY}" -- plan -input=false -detailed-exitcode="${DETAILED_EXITCODE}"
+          guardian run -dir="${DIRECTORY}" -allowed-providers="${GUARDIAN_ALLOWED_PROVIDERS}" -- plan -input=false -detailed-exitcode="${DETAILED_EXITCODE}"
 
       - name: 'Guardian Apply'
         if: |
           inputs.command == 'apply'
         shell: 'bash'
         run: |-
-          guardian run -dir="${DIRECTORY}" -- apply -input=false -auto-approve
+          guardian run -dir="${DIRECTORY}" -allowed-providers="${GUARDIAN_ALLOWED_PROVIDERS}" -- apply -input=false -auto-approve

--- a/abc.templates/base-workflows/testdata/golden/basic/test.yaml
+++ b/abc.templates/base-workflows/testdata/golden/basic/test.yaml
@@ -27,6 +27,8 @@ inputs:
     value: 'my-guardian-wif-provider'
   - name: 'guardian_service_account'
     value: 'my-guardian-service-account@abcxyz-my-project.iam.gserviceaccount.com'
+  - name: 'guardian_allowed_providers'
+    value: 'google,google-beta'
 builtin_vars:
   - name: '_git_tag'
     value: 'v1.0.0'


### PR DESCRIPTION
This does not provide a default value so that Guardian users are nudged toward setting an allow list.