### PR TITLE
fix: Remove empty strings from allow/deny list flags

### DIFF
--- a/pkg/checkterraform/checkterraform.go
+++ b/pkg/checkterraform/checkterraform.go
@@ -66,6 +66,12 @@ func findInvalid(allowed, disallowed, actual []string) []string {
 	return slices.DeleteFunc(result, func(s string) bool { return !slices.Contains(disallowed, s) })
 }
 
+func removeBlankStrings(s []string) []string {
+	return slices.DeleteFunc(slices.Clone(s), func(s string) bool {
+		return strings.TrimSpace(s) == ""
+	})
+}
+
 // CheckProvidersProvisioners returns the result of parsing the terraform content in the given directory (or file).
 // The usual case is to provide disallowed providers and provisioners. This is more permissive, only
 // erroring if those specifically denied matches occur. If allowedProviders or allowedProvisioners is set,
@@ -76,6 +82,11 @@ func CheckProvidersProvisioners(ctx context.Context, dir string, disallowedProvi
 	if err != nil {
 		return ScanResult{}, fmt.Errorf("failed to analyze directory %q: %w", dir, err)
 	}
+
+	allowedProviders = removeBlankStrings(allowedProviders)
+	disallowedProviders = removeBlankStrings(disallowedProviders)
+	allowedProvisioners = removeBlankStrings(allowedProvisioners)
+	disallowedProvisioners = removeBlankStrings(disallowedProvisioners)
 
 	result := ScanResult{
 		Providers:           providers,

--- a/pkg/checkterraform/checkterraform_test.go
+++ b/pkg/checkterraform/checkterraform_test.go
@@ -165,6 +165,18 @@ func TestScan(t *testing.T) {
 			},
 			expError: "terraform contains invalid providers: [random], invalid provisioners: [safe-provisioner]",
 		},
+		{
+			name:                "Empty strings in allowed providers/provisioners should be ignored",
+			filepath:            "testdata/valid.tf",
+			allowedProviders:    []string{""},
+			allowedProvisioners: []string{""},
+			expResult: ScanResult{
+				Providers:           []string{"google", "random"},
+				Provisioners:        []string{"safe-provisioner"},
+				InvalidProviders:    []string{},
+				InvalidProvisioners: []string{},
+			},
+		},
 	}
 
 	cwd, err := os.Getwd()


### PR DESCRIPTION
Calling `strings.Split()` on an empty string returns `[]string{""}`, not `[]string{}` so when this flag was set to an empty list it blocked all usage of Guardian.