### PR TITLE
feat: add cli scaffolding for guardian report command

### DIFF
--- a/cmd/guardian/main.go
+++ b/cmd/guardian/main.go
@@ -63,6 +63,9 @@ var rootCmd = func() cli.Command {
 						"merge-queue-comment": func() cli.Command {
 							return &workflows.MergeQueueStatusCommentCommand{}
 						},
+						"report": func() cli.Command {
+							return &workflows.ReportCommand{}
+						},
 					},
 				}
 			},

--- a/pkg/commands/workflows/report.go
+++ b/pkg/commands/workflows/report.go
@@ -1,0 +1,127 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflows
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/abcxyz/guardian/internal/metricswrap"
+	"github.com/abcxyz/guardian/pkg/platform"
+	"github.com/abcxyz/pkg/cli"
+)
+
+var _ cli.Command = (*ReportCommand)(nil)
+
+type ReportCommand struct {
+	cli.BaseCommand
+
+	platformConfig platform.Config
+
+	flagType         string
+	flagEntrypoints  string
+	flagArtifactsDir string
+
+	platformClient platform.Platform
+}
+
+func (c *ReportCommand) Desc() string {
+	return `Aggregate and report Guardian plan/apply status on pull requests`
+}
+
+func (c *ReportCommand) Help() string {
+	return `
+Usage: {{ COMMAND }} [options]
+
+	Aggregate and report Guardian plan/apply status on pull requests.
+`
+}
+
+func (c *ReportCommand) Flags() *cli.FlagSet {
+	set := c.NewFlagSet()
+
+	c.platformConfig.RegisterFlags(set)
+
+	f := set.NewSection("COMMAND OPTIONS")
+
+	f.StringVar(&cli.StringVar{
+		Name:    "type",
+		Target:  &c.flagType,
+		Example: "plan",
+		Usage:   "The type of the report, either 'plan' or 'apply'.",
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "entrypoints",
+		Target:  &c.flagEntrypoints,
+		Example: `["terraform/github/abseil"]`,
+		Usage:   "The list of directory entrypoints as a JSON array string.",
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "artifacts-dir",
+		Target:  &c.flagArtifactsDir,
+		Example: "./artifacts",
+		Usage:   "The local path where plan artifacts are downloaded (required for plan type).",
+	})
+
+	set.AfterParse(func(existingErr error) (merr error) {
+		if c.flagType != "plan" && c.flagType != "apply" {
+			merr = errors.Join(merr, fmt.Errorf("missing or invalid flag: type must be 'plan' or 'apply'"))
+		}
+
+		if c.flagEntrypoints == "" {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: entrypoints is required"))
+		}
+
+		if c.flagType == "plan" && c.flagArtifactsDir == "" {
+			merr = errors.Join(merr, fmt.Errorf("missing flag: artifacts-dir is required when type is 'plan'"))
+		}
+
+		return merr
+	})
+
+	return set
+}
+
+func (c *ReportCommand) Run(ctx context.Context, args []string) error {
+	metricswrap.WriteMetric(ctx, "command_workflows_report", 1)
+
+	f := c.Flags()
+	if err := f.Parse(args); err != nil {
+		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+
+	parsedArgs := f.Args()
+	if len(parsedArgs) > 0 {
+		return flag.ErrHelp
+	}
+
+	platform, err := platform.NewPlatform(ctx, &c.platformConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create platform: %w", err)
+	}
+	c.platformClient = platform
+
+	return c.Process(ctx)
+}
+
+func (c *ReportCommand) Process(ctx context.Context) error {
+	// Stub implementation for initial PR
+	c.Outf("report command scaffolding works. type: %s, entrypoints: %s, artifacts: %s", c.flagType, c.flagEntrypoints, c.flagArtifactsDir)
+	return nil
+}

--- a/pkg/commands/workflows/report_test.go
+++ b/pkg/commands/workflows/report_test.go
@@ -1,0 +1,89 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflows
+
+import (
+	"testing"
+
+	"github.com/abcxyz/pkg/testutil"
+)
+
+func TestReportCommandFlags(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name             string
+		flagType         string
+		flagEntrypoints  string
+		flagArtifactsDir string
+		err              string
+	}{
+		{
+			name:            "invalid_type",
+			flagType:        "invalid",
+			flagEntrypoints: "[]",
+			err:             "missing or invalid flag: type must be 'plan' or 'apply'",
+		},
+		{
+			name:            "missing_entrypoints",
+			flagType:        "apply",
+			flagEntrypoints: "",
+			err:             "missing flag: entrypoints is required",
+		},
+		{
+			name:             "missing_artifacts_dir_for_plan",
+			flagType:         "plan",
+			flagEntrypoints:  "[]",
+			flagArtifactsDir: "",
+			err:              "missing flag: artifacts-dir is required when type is 'plan'",
+		},
+		{
+			name:             "valid_plan",
+			flagType:         "plan",
+			flagEntrypoints:  "[]",
+			flagArtifactsDir: "./artifacts",
+		},
+		{
+			name:            "valid_apply",
+			flagType:        "apply",
+			flagEntrypoints: "[]",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &ReportCommand{}
+			f := c.Flags()
+
+			var args []string
+			if tc.flagType != "" {
+				args = append(args, "-type", tc.flagType)
+			}
+			if tc.flagEntrypoints != "" {
+				args = append(args, "-entrypoints", tc.flagEntrypoints)
+			}
+			if tc.flagArtifactsDir != "" {
+				args = append(args, "-artifacts-dir", tc.flagArtifactsDir)
+			}
+
+			err := f.Parse(args)
+			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduce the CLI scaffolding and command registration for the new `guardian workflows report` subcommand.
- Add the `report` command definition to handle aggregated plan and apply reporting.
- Register required command flags: `-type`, `-entrypoints`, and `-artifacts-dir`. Implement input validation constraints.
- Register the command under the `workflows` subcommand factory list in `cmd/guardian/main.go`.
- Add a basic CLI stub process for validation testing.