### PR TITLE
fix(github): Paginate query for teams in organization

### DIFF
--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -277,8 +277,12 @@ type team struct {
 type organizationTeamsForUserQuery struct {
 	Organization struct {
 		Teams struct {
-			Nodes []team
-		} `graphql:"teams(first: 100)"`
+			Nodes    []team
+			PageInfo struct {
+				HasNextPage bool
+				EndCursor   githubv4.String
+			}
+		} `graphql:"teams(first: 100, after: $cursor)"`
 	} `graphql:"organization(login: $owner)"`
 }
 
@@ -294,24 +298,34 @@ func (g *GitHub) GetUserTeamMemberships(ctx context.Context, username string) ([
 		return nil, fmt.Errorf("username is required")
 	}
 
-	var teamQuery organizationTeamsForUserQuery
-	if err := g.graphqlClient.Query(ctx, &teamQuery, map[string]any{
+	variables := map[string]any{
 		"owner":    githubv4.String(g.cfg.GitHubOwner),
 		"username": githubv4.String(username),
-	}); err != nil {
-		return nil, fmt.Errorf("failed to query user team memberships: %w", err)
+		"cursor":   (*githubv4.String)(nil),
 	}
 
 	res := make([]string, 0)
-	for _, team := range teamQuery.Organization.Teams.Nodes {
-		for _, m := range team.Members.Nodes {
-			// It is important to check for exact matches of the username, due to the
-			// lack of exact username matching in the GraphQL query.
-			if m.Login == username {
-				res = append(res, team.Name)
-				break
+	for {
+		var query organizationTeamsForUserQuery
+		if err := g.graphqlClient.Query(ctx, &query, variables); err != nil {
+			return nil, fmt.Errorf("failed to query user team memberships: %w", err)
+		}
+
+		for _, team := range query.Organization.Teams.Nodes {
+			for _, m := range team.Members.Nodes {
+				// It is important to check for exact matches of the username, due to the
+				// lack of exact username matching in the GraphQL query.
+				if m.Login == username {
+					res = append(res, team.Name)
+					break
+				}
 			}
 		}
+
+		if !query.Organization.Teams.PageInfo.HasNextPage {
+			break
+		}
+		variables["cursor"] = &query.Organization.Teams.PageInfo.EndCursor
 	}
 
 	return res, nil

--- a/pkg/platform/github_test.go
+++ b/pkg/platform/github_test.go
@@ -1,0 +1,184 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/shurcooL/githubv4"
+
+	gh "github.com/abcxyz/guardian/pkg/github"
+)
+
+type roundTripperFunc func(req *http.Request) *http.Response
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+func TestGitHub_GetUserTeamMemberships(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		username     string
+		mockResponse []string
+		want         []string
+		wantErr      string
+	}{
+		{
+			name:     "success_single_page",
+			username: "testuser",
+			mockResponse: []string{
+				`{
+					"data": {
+						"organization": {
+							"teams": {
+								"nodes": [
+									{
+										"name": "team1",
+										"members": {
+											"nodes": [
+												{
+													"login": "testuser"
+												}
+											]
+										}
+									}
+								],
+								"pageInfo": {
+									"hasNextPage": false,
+									"endCursor": "cursor1"
+								}
+							}
+						}
+					}
+				}`,
+			},
+			want: []string{"team1"},
+		},
+		{
+			name:     "success_multi_page",
+			username: "testuser",
+			mockResponse: []string{
+				`{
+					"data": {
+						"organization": {
+							"teams": {
+								"nodes": [
+									{
+										"name": "team1",
+										"members": {
+											"nodes": [
+												{
+													"login": "testuser"
+												}
+											]
+										}
+									}
+								],
+								"pageInfo": {
+									"hasNextPage": true,
+									"endCursor": "cursor1"
+								}
+							}
+						}
+					}
+				}`,
+				`{
+					"data": {
+						"organization": {
+							"teams": {
+								"nodes": [
+									{
+										"name": "team2",
+										"members": {
+											"nodes": [
+												{
+													"login": "testuser"
+												}
+											]
+										}
+									}
+								],
+								"pageInfo": {
+									"hasNextPage": false,
+									"endCursor": "cursor2"
+								}
+							}
+						}
+					}
+				}`,
+			},
+			want: []string{"team1", "team2"},
+		},
+		{
+			name:     "no_username",
+			username: "",
+			wantErr:  "username is required",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var reqCount int
+			client := githubv4.NewClient(&http.Client{
+				Transport: roundTripperFunc(func(req *http.Request) *http.Response {
+					if reqCount >= len(tc.mockResponse) {
+						return &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"unexpected request"}]}`)),
+						}
+					}
+					resp := tc.mockResponse[reqCount]
+					reqCount++
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(resp)),
+					}
+				}),
+			})
+
+			g := &GitHub{
+				cfg: &gh.Config{
+					GitHubOwner: "abcxyz",
+				},
+				graphqlClient: client,
+			}
+
+			got, err := g.GetUserTeamMemberships(t.Context(), tc.username)
+			if err != nil {
+				if tc.wantErr == "" {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err mismatch got: %v, want to contain: %s", err, tc.wantErr)
+				}
+			} else if tc.wantErr != "" {
+				t.Fatalf("expected error containing %q, got none", tc.wantErr)
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("got mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, if an organization had over 100 teams, it was possible that the team membership lookup used by the policy command would erroneously block actions from users who should be permitted.