### PR TITLE
feat: enable guardian report to retrieve PRs by SHA

### DIFF
--- a/pkg/commands/workflows/report.go
+++ b/pkg/commands/workflows/report.go
@@ -121,7 +121,28 @@ func (c *ReportCommand) Run(ctx context.Context, args []string) error {
 }
 
 func (c *ReportCommand) Process(ctx context.Context) error {
-	// Stub implementation for initial PR
-	c.Outf("report command scaffolding works. type: %s, entrypoints: %s, artifacts: %s", c.flagType, c.flagEntrypoints, c.flagArtifactsDir)
+	var prNumber int
+	if c.flagType == "plan" {
+		prNumber = c.platformConfig.GitHub.GitHubPullRequestNumber
+	} else {
+		// For apply (on push event), look up PR number associated with the commit SHA
+		resp, err := c.platformClient.ListChangeRequestsByCommit(ctx, c.platformConfig.GitHub.GitHubSHA, nil)
+		if err != nil {
+			return fmt.Errorf("failed to list pull requests for commit [%s]: %w", c.platformConfig.GitHub.GitHubSHA, err)
+		}
+		if len(resp.PullRequests) == 0 {
+			c.Outf("no pull requests found for commit [%s], skipping reporting", c.platformConfig.GitHub.GitHubSHA)
+			return nil
+		}
+		prNumber = resp.PullRequests[0].Number
+	}
+
+	// Fetch all Jobs for current run ID
+	jobs, err := c.platformClient.ListJobs(ctx, c.platformConfig.GitHub.GitHubRunID)
+	if err != nil {
+		return fmt.Errorf("failed to list jobs for run [%d]: %w", c.platformConfig.GitHub.GitHubRunID, err)
+	}
+
+	c.Outf("successfully completed API integration checks. resolved PR: #%d, total GHA jobs fetched: %d", prNumber, len(jobs))
 	return nil
 }

--- a/pkg/commands/workflows/report_test.go
+++ b/pkg/commands/workflows/report_test.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/abcxyz/guardian/pkg/platform"
+	"github.com/abcxyz/pkg/testutil"
 )
 
 func TestReportCommandFlags(t *testing.T) {

--- a/pkg/commands/workflows/report_test.go
+++ b/pkg/commands/workflows/report_test.go
@@ -15,8 +15,12 @@
 package workflows
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/abcxyz/guardian/pkg/platform"
 	"github.com/abcxyz/pkg/testutil"
 )
 
@@ -83,6 +87,137 @@ func TestReportCommandFlags(t *testing.T) {
 			err := f.Parse(args)
 			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
 				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestReportCommandProcess(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	cases := []struct {
+		name                           string
+		flagType                       string
+		githubPullRequestNumber        int
+		githubSHA                      string
+		githubRunID                    int64
+		listChangeRequestsByCommitResp *platform.ListChangeRequestsByCommitResponse
+		listChangeRequestsByCommitErr  error
+		listJobsResp                  []*platform.Job
+		listJobsErr                   error
+		err                            string
+		expPlatformClientReqs          []*platform.Request
+	}{
+		{
+			name:                    "plan_success",
+			flagType:                "plan",
+			githubPullRequestNumber: 123,
+			githubRunID:            456,
+			listJobsResp: []*platform.Job{
+				{ID: 11, Name: "job1", URL: "url1"},
+			},
+			expPlatformClientReqs: []*platform.Request{
+				{
+					Name:   "ListJobs",
+					Params: []any{int64(456)},
+				},
+			},
+		},
+		{
+			name:      "apply_success_resolves_pr_by_commit",
+			flagType:  "apply",
+			githubSHA: "abcdef123456",
+			githubRunID: 789,
+			listChangeRequestsByCommitResp: &platform.ListChangeRequestsByCommitResponse{
+				PullRequests: []*platform.PullRequest{
+					{Number: 123},
+				},
+			},
+			listJobsResp: []*platform.Job{
+				{ID: 22, Name: "job2", URL: "url2"},
+			},
+			expPlatformClientReqs: []*platform.Request{
+				{
+					Name:   "ListChangeRequestsByCommit",
+					Params: []any{"abcdef123456", (*platform.ListChangeRequestsByCommitOptions)(nil)},
+				},
+				{
+					Name:   "ListJobs",
+					Params: []any{int64(789)},
+				},
+			},
+		},
+		{
+			name:      "apply_no_associated_pr_skips_reporting",
+			flagType:  "apply",
+			githubSHA: "abcdef123456",
+			listChangeRequestsByCommitResp: &platform.ListChangeRequestsByCommitResponse{
+				PullRequests: []*platform.PullRequest{},
+			},
+			expPlatformClientReqs: []*platform.Request{
+				{
+					Name:   "ListChangeRequestsByCommit",
+					Params: []any{"abcdef123456", (*platform.ListChangeRequestsByCommitOptions)(nil)},
+				},
+			},
+		},
+		{
+			name:      "apply_pr_resolution_fails_errors",
+			flagType:  "apply",
+			githubSHA: "abcdef123456",
+			listChangeRequestsByCommitErr: fmt.Errorf("network error"),
+			err: "failed to list pull requests for commit [abcdef123456]: network error",
+			expPlatformClientReqs: []*platform.Request{
+				{
+					Name:   "ListChangeRequestsByCommit",
+					Params: []any{"abcdef123456", (*platform.ListChangeRequestsByCommitOptions)(nil)},
+				},
+			},
+		},
+		{
+			name:                    "list_jobs_fails_errors",
+			flagType:                "plan",
+			githubPullRequestNumber: 123,
+			githubRunID:            456,
+			listJobsErr:            fmt.Errorf("api error"),
+			err:                    "failed to list jobs for run [456]: api error",
+			expPlatformClientReqs: []*platform.Request{
+				{
+					Name:   "ListJobs",
+					Params: []any{int64(456)},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockPlatformClient := &platform.MockPlatform{
+				ListChangeRequestsByCommitResp: tc.listChangeRequestsByCommitResp,
+				ListChangeRequestsByCommitErr:  tc.listChangeRequestsByCommitErr,
+				ListJobsResp:                  tc.listJobsResp,
+				ListJobsErr:                   tc.listJobsErr,
+			}
+
+			c := &ReportCommand{
+				flagType: tc.flagType,
+				platformClient: mockPlatformClient,
+			}
+			c.platformConfig.GitHub.GitHubPullRequestNumber = tc.githubPullRequestNumber
+			c.platformConfig.GitHub.GitHubSHA = tc.githubSHA
+			c.platformConfig.GitHub.GitHubRunID = tc.githubRunID
+
+			err := c.Process(ctx)
+			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
+				t.Error(diff)
+			}
+
+			if diff := cmp.Diff(mockPlatformClient.Reqs, tc.expPlatformClientReqs); diff != "" {
+				t.Errorf("MockPlatform requests mismatch (-got,+want):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/commands/workflows/report_test.go
+++ b/pkg/commands/workflows/report_test.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/abcxyz/guardian/pkg/platform"
-	"github.com/abcxyz/pkg/testutil"
 )
 
 func TestReportCommandFlags(t *testing.T) {
@@ -105,8 +105,8 @@ func TestReportCommandProcess(t *testing.T) {
 		githubRunID                    int64
 		listChangeRequestsByCommitResp *platform.ListChangeRequestsByCommitResponse
 		listChangeRequestsByCommitErr  error
-		listJobsResp                  []*platform.Job
-		listJobsErr                   error
+		listJobsResp                   []*platform.Job
+		listJobsErr                    error
 		err                            string
 		expPlatformClientReqs          []*platform.Request
 	}{
@@ -114,7 +114,7 @@ func TestReportCommandProcess(t *testing.T) {
 			name:                    "plan_success",
 			flagType:                "plan",
 			githubPullRequestNumber: 123,
-			githubRunID:            456,
+			githubRunID:             456,
 			listJobsResp: []*platform.Job{
 				{ID: 11, Name: "job1", URL: "url1"},
 			},
@@ -126,9 +126,9 @@ func TestReportCommandProcess(t *testing.T) {
 			},
 		},
 		{
-			name:      "apply_success_resolves_pr_by_commit",
-			flagType:  "apply",
-			githubSHA: "abcdef123456",
+			name:        "apply_success_resolves_pr_by_commit",
+			flagType:    "apply",
+			githubSHA:   "abcdef123456",
 			githubRunID: 789,
 			listChangeRequestsByCommitResp: &platform.ListChangeRequestsByCommitResponse{
 				PullRequests: []*platform.PullRequest{
@@ -164,11 +164,11 @@ func TestReportCommandProcess(t *testing.T) {
 			},
 		},
 		{
-			name:      "apply_pr_resolution_fails_errors",
-			flagType:  "apply",
-			githubSHA: "abcdef123456",
+			name:                          "apply_pr_resolution_fails_errors",
+			flagType:                      "apply",
+			githubSHA:                     "abcdef123456",
 			listChangeRequestsByCommitErr: fmt.Errorf("network error"),
-			err: "failed to list pull requests for commit [abcdef123456]: network error",
+			err:                           "failed to list pull requests for commit [abcdef123456]: network error",
 			expPlatformClientReqs: []*platform.Request{
 				{
 					Name:   "ListChangeRequestsByCommit",
@@ -180,9 +180,9 @@ func TestReportCommandProcess(t *testing.T) {
 			name:                    "list_jobs_fails_errors",
 			flagType:                "plan",
 			githubPullRequestNumber: 123,
-			githubRunID:            456,
-			listJobsErr:            fmt.Errorf("api error"),
-			err:                    "failed to list jobs for run [456]: api error",
+			githubRunID:             456,
+			listJobsErr:             fmt.Errorf("api error"),
+			err:                     "failed to list jobs for run [456]: api error",
 			expPlatformClientReqs: []*platform.Request{
 				{
 					Name:   "ListJobs",
@@ -199,12 +199,12 @@ func TestReportCommandProcess(t *testing.T) {
 			mockPlatformClient := &platform.MockPlatform{
 				ListChangeRequestsByCommitResp: tc.listChangeRequestsByCommitResp,
 				ListChangeRequestsByCommitErr:  tc.listChangeRequestsByCommitErr,
-				ListJobsResp:                  tc.listJobsResp,
-				ListJobsErr:                   tc.listJobsErr,
+				ListJobsResp:                   tc.listJobsResp,
+				ListJobsErr:                    tc.listJobsErr,
 			}
 
 			c := &ReportCommand{
-				flagType: tc.flagType,
+				flagType:       tc.flagType,
 				platformClient: mockPlatformClient,
 			}
 			c.platformConfig.GitHub.GitHubPullRequestNumber = tc.githubPullRequestNumber

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -709,15 +709,8 @@ func validateGitHubReporterInputs(cfg *gh.Config) error {
 	return merr
 }
 
-// Job is the GitHub Job that runs as part of a workflow.
-type job struct {
-	ID   int64
-	Name string
-	URL  string
-}
-
 func (g *GitHub) resolveJobLogsURL(ctx context.Context) (string, error) {
-	var jobs []*job
+	var jobs []*Job
 
 	if err := g.withRetries(ctx, func(ctx context.Context) error {
 		ghJobs, resp, err := g.client.Actions.ListWorkflowJobs(ctx, g.cfg.GitHubOwner, g.cfg.GitHubRepo, g.cfg.GitHubRunID, nil)
@@ -731,7 +724,7 @@ func (g *GitHub) resolveJobLogsURL(ctx context.Context) (string, error) {
 		}
 
 		for _, workflowJob := range ghJobs.Jobs {
-			jobs = append(jobs, &job{ID: workflowJob.GetID(), Name: workflowJob.GetName(), URL: *workflowJob.HTMLURL})
+			jobs = append(jobs, &Job{ID: workflowJob.GetID(), Name: workflowJob.GetName(), URL: workflowJob.GetHTMLURL()})
 		}
 		return nil
 	}); err != nil {
@@ -744,6 +737,48 @@ func (g *GitHub) resolveJobLogsURL(ctx context.Context) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("failed to resolve direct URL to job logs: no job found matching name %s", g.cfg.GitHubJobName)
+}
+
+// ListJobs lists all jobs running as part of a GHA workflow run with pagination.
+func (g *GitHub) ListJobs(ctx context.Context, runID int64) ([]*Job, error) {
+	var jobs []*Job
+	listOpts := &github.ListWorkflowJobsOptions{
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
+	}
+
+	for {
+		var ghJobs *github.Jobs
+		var nextPage int
+		if err := g.withRetries(ctx, func(ctx context.Context) error {
+			var resp *github.Response
+			var err error
+			ghJobs, resp, err = g.client.Actions.ListWorkflowJobs(ctx, g.cfg.GitHubOwner, g.cfg.GitHubRepo, runID, listOpts)
+			if err != nil {
+				return maybeRetryable(resp, fmt.Errorf("failed to list jobs for workflow run [%d]: %w", runID, err))
+			}
+			nextPage = resp.NextPage
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+
+		for _, j := range ghJobs.Jobs {
+			jobs = append(jobs, &Job{
+				ID:   j.GetID(),
+				Name: j.GetName(),
+				URL:  j.GetHTMLURL(),
+			})
+		}
+
+		if nextPage == 0 {
+			break
+		}
+		listOpts.Page = nextPage
+	}
+
+	return jobs, nil
 }
 
 // PullRequest is a GitHub pull request.

--- a/pkg/platform/gitlab.go
+++ b/pkg/platform/gitlab.go
@@ -391,7 +391,7 @@ func (g *GitLab) ListChangeRequestsByCommit(ctx context.Context, sha string, opt
 	return nil, nil
 }
 
-// ListJobs is a no-op.
+// ListJobs is a no-op because GitLab platform support is currently not implemented.
 func (g *GitLab) ListJobs(ctx context.Context, runID int64) ([]*Job, error) {
 	return nil, nil
 }

--- a/pkg/platform/gitlab.go
+++ b/pkg/platform/gitlab.go
@@ -390,3 +390,8 @@ func (g *GitLab) withRetries(ctx context.Context, retryFunc retry.RetryFunc) err
 func (g *GitLab) ListChangeRequestsByCommit(ctx context.Context, sha string, opts *ListChangeRequestsByCommitOptions) (*ListChangeRequestsByCommitResponse, error) {
 	return nil, nil
 }
+
+// ListJobs is a no-op.
+func (g *GitLab) ListJobs(ctx context.Context, runID int64) ([]*Job, error) {
+	return nil, nil
+}

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -92,7 +92,7 @@ func (l *Local) ListChangeRequestsByCommit(ctx context.Context, sha string, opts
 	return nil, nil
 }
 
-// ListJobs is a no-op.
+// ListJobs is a no-op because the local platform does not run GHA workflows or pipelines.
 func (l *Local) ListJobs(ctx context.Context, runID int64) ([]*Job, error) {
 	return nil, nil
 }

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -91,3 +91,8 @@ func (l *Local) ClearReports(ctx context.Context) error {
 func (l *Local) ListChangeRequestsByCommit(ctx context.Context, sha string, opts *ListChangeRequestsByCommitOptions) (*ListChangeRequestsByCommitResponse, error) {
 	return nil, nil
 }
+
+// ListJobs is a no-op.
+func (l *Local) ListJobs(ctx context.Context, runID int64) ([]*Job, error) {
+	return nil, nil
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -113,6 +113,13 @@ type Pagination struct {
 	NextPage int
 }
 
+// Job is a CI/CD Job that runs as part of a workflow/pipeline.
+type Job struct {
+	ID   int64
+	Name string
+	URL  string
+}
+
 // Platform defines the minimum interface for a code review platform.
 type Platform interface {
 	// AssignReviewers assigns principals to review a change request.
@@ -152,6 +159,9 @@ type Platform interface {
 
 	// ClearReports clears any existing reports that can be removed.
 	ClearReports(ctx context.Context) error
+
+	// ListJobs lists all jobs running as part of a workflow/pipeline run.
+	ListJobs(ctx context.Context, runID int64) ([]*Job, error)
 }
 
 // NewPlatform creates a new platform based on the provided type.

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -52,8 +52,8 @@ type MockPlatform struct {
 
 	ListChangeRequestsByCommitResp *ListChangeRequestsByCommitResponse
 	ListChangeRequestsByCommitErr  error
-	ListJobsResp                  []*Job
-	ListJobsErr                   error
+	ListJobsResp                   []*Job
+	ListJobsErr                    error
 }
 
 func (m *MockPlatform) AssignReviewers(ctx context.Context, input *AssignReviewersInput) (*AssignReviewersResult, error) {

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -49,6 +49,11 @@ type MockPlatform struct {
 	ReportStatusErr             error
 	ReportEntrypointsSummaryErr error
 	ClearReportsErr             error
+
+	ListChangeRequestsByCommitResp *ListChangeRequestsByCommitResponse
+	ListChangeRequestsByCommitErr  error
+	ListJobsResp                  []*Job
+	ListJobsErr                   error
 }
 
 func (m *MockPlatform) AssignReviewers(ctx context.Context, input *AssignReviewersInput) (*AssignReviewersResult, error) {
@@ -245,5 +250,30 @@ func (m *MockPlatform) ClearReports(ctx context.Context) error {
 
 // ListChangeRequestsByCommit lists the change requests associated with a commit SHA.
 func (m *MockPlatform) ListChangeRequestsByCommit(ctx context.Context, sha string, opts *ListChangeRequestsByCommitOptions) (*ListChangeRequestsByCommitResponse, error) {
-	return nil, nil
+	m.reqMu.Lock()
+	defer m.reqMu.Unlock()
+	m.Reqs = append(m.Reqs, &Request{
+		Name:   "ListChangeRequestsByCommit",
+		Params: []any{sha, opts},
+	})
+
+	if m.ListChangeRequestsByCommitErr != nil {
+		return nil, m.ListChangeRequestsByCommitErr
+	}
+	return m.ListChangeRequestsByCommitResp, nil
+}
+
+// ListJobs lists the jobs from GHA workflows.
+func (m *MockPlatform) ListJobs(ctx context.Context, runID int64) ([]*Job, error) {
+	m.reqMu.Lock()
+	defer m.reqMu.Unlock()
+	m.Reqs = append(m.Reqs, &Request{
+		Name:   "ListJobs",
+		Params: []any{runID},
+	})
+
+	if m.ListJobsErr != nil {
+		return nil, m.ListJobsErr
+	}
+	return m.ListJobsResp, nil
 }


### PR DESCRIPTION
Implement the logic for the `guardian report`. Enable the CLI to retrieve Pull Requests by commit SHA and fetch workflow jobs with pagination.
- Exposed a public `Job` struct in `pkg/platform/platform.go` representing a generic CI/CD execution job.
- Implement `ListJobs` for `GitHub` platform with paginated GHA `ListWorkflowJobs` API calls to prevent data truncation.
- Update `ReportCommand.Process` to lookup PR by commit SHA (for push events) and fetch workflow jobs using the new `ListJobs` interface.
- Add `TestReportCommandProcess` unit tests.