### PR TITLE
feat: implement core logic and layout rendering for guardian report

### DIFF
--- a/pkg/commands/workflows/remove_comments.go
+++ b/pkg/commands/workflows/remove_comments.go
@@ -78,7 +78,7 @@ func (c *RemoveGuardianCommentsCommand) Run(ctx context.Context, args []string) 
 
 // Process handles the main logic for the Guardian remove plan comments process.
 func (c *RemoveGuardianCommentsCommand) Process(ctx context.Context) error {
-	if err := c.platformClient.ClearReports(ctx); err != nil {
+	if err := c.platformClient.ClearReports(ctx, 0); err != nil {
 		return fmt.Errorf("failed to remove comments: %w", err)
 	}
 

--- a/pkg/commands/workflows/report.go
+++ b/pkg/commands/workflows/report.go
@@ -16,9 +16,16 @@ package workflows
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/google/go-github/v53/github"
 
 	"github.com/abcxyz/guardian/internal/metricswrap"
 	"github.com/abcxyz/guardian/pkg/platform"
@@ -143,6 +150,259 @@ func (c *ReportCommand) Process(ctx context.Context) error {
 		return fmt.Errorf("failed to list jobs for run [%d]: %w", c.platformConfig.GitHub.GitHubRunID, err)
 	}
 
-	c.Outf("successfully completed API integration checks. resolved PR: #%d, total GHA jobs fetched: %d", prNumber, len(jobs))
+	// Parse entrypoints
+	var entrypoints []string
+	var entrypointsData []byte
+	if _, err := os.Stat(c.flagEntrypoints); err == nil {
+		entrypointsData, err = os.ReadFile(c.flagEntrypoints)
+		if err != nil {
+			return fmt.Errorf("failed to read entrypoints file [%s]: %w", c.flagEntrypoints, err)
+		}
+	} else {
+		entrypointsData = []byte(c.flagEntrypoints)
+	}
+
+	if err := json.Unmarshal(entrypointsData, &entrypoints); err != nil {
+		return fmt.Errorf("failed to parse entrypoints JSON: %w", err)
+	}
+
+	// Map entrypoints to GHA jobs
+	jobStatuses := make(map[string]*platform.Job)
+	for _, entrypoint := range entrypoints {
+		for _, job := range jobs {
+			if strings.Contains(strings.ToLower(job.Name), strings.ToLower(entrypoint)) {
+				jobStatuses[entrypoint] = job
+				break
+			}
+		}
+	}
+
+	// Read and parse plan stats (plan only)
+	planStats := make(map[string]*planStat)
+	if c.flagType == "plan" {
+		for _, entrypoint := range entrypoints {
+			p, err := findPlanFile(c.flagArtifactsDir, entrypoint)
+			if err != nil {
+				planStats[entrypoint] = &planStat{Err: err}
+				continue
+			}
+			add, chg, del, err := parsePlanFile(p)
+			if err != nil {
+				planStats[entrypoint] = &planStat{Err: err}
+				continue
+			}
+			planStats[entrypoint] = &planStat{Added: add, Changed: chg, Deleted: del}
+		}
+	}
+
+	// Generate Markdown Summary Comment
+	var rows []summaryRow
+	for _, entrypoint := range entrypoints {
+		status := "⛔&nbsp;UNKNOWN"
+		logLink := "-"
+		notes := "-"
+		statsStr := "-"
+
+		job, hasJob := jobStatuses[entrypoint]
+		if hasJob {
+			logLink = fmt.Sprintf("<a href=\"%s\" target=\"_blank\">View Log</a>", job.URL)
+			switch job.Conclusion {
+			case "success":
+				status = "🟩&nbsp;SUCCESS"
+			case "failure":
+				status = "🟥&nbsp;FAILED"
+			case "skipped":
+				status = "🟨&nbsp;SKIPPED"
+			case "cancelled":
+				status = "🟨&nbsp;CANCELLED"
+			default:
+				status = fmt.Sprintf("⛔&nbsp;%s", strings.ToUpper(job.Conclusion))
+			}
+		}
+
+		if c.flagType == "plan" {
+			stat, ok := planStats[entrypoint]
+			if ok {
+				if stat.Err != nil {
+					notes = fmt.Sprintf("⚠️ %s", stat.Err.Error())
+				} else {
+					statsStr = fmt.Sprintf("<span style=\"white-space: nowrap;\">%+d&nbsp;~%d&nbsp;-%d</span>", stat.Added, stat.Changed, stat.Deleted)
+				}
+			} else {
+				notes = "⚠️ Missing tfplan.json"
+			}
+		}
+		rows = append(rows, summaryRow{
+			Directory: entrypoint,
+			Status:    status,
+			Stats:     statsStr,
+			Notes:     notes,
+			LogLink:   logLink,
+		})
+	}
+
+	var sb strings.Builder
+	var commentPrefix string
+	var tmplText string
+	if c.flagType == "plan" {
+		commentPrefix = "#### 🔱 Guardian 🔱 **`PLAN SUMMARY`**"
+		tmplText = planSummaryTemplate
+	} else {
+		commentPrefix = "#### 🔱 Guardian 🔱 **`APPLY SUMMARY`**"
+		tmplText = applySummaryTemplate
+	}
+
+	tmpl, err := template.New("summary").Parse(tmplText)
+	if err != nil {
+		return fmt.Errorf("failed to parse summary template: %w", err)
+	}
+
+	if err := tmpl.Execute(&sb, map[string]any{"Rows": rows}); err != nil {
+		return fmt.Errorf("failed to execute summary template: %w", err)
+	}
+
+	// Delete old summary comments
+	listOpts := &platform.ListReportsOptions{
+		GitHub: &github.IssueListCommentsOptions{
+			ListOptions: github.ListOptions{
+				PerPage: 100,
+			},
+		},
+	}
+
+	var allReports []*platform.Report
+	for {
+		res, err := c.platformClient.ListReports(ctx, prNumber, listOpts)
+		if err != nil {
+			return fmt.Errorf("failed to list comments on PR [#%d]: %w", prNumber, err)
+		}
+		allReports = append(allReports, res.Reports...)
+		if res.Pagination == nil || res.Pagination.NextPage == 0 {
+			break
+		}
+		listOpts.GitHub.Page = res.Pagination.NextPage
+	}
+
+	for _, r := range allReports {
+		if strings.HasPrefix(r.Body, commentPrefix) {
+			if err := c.platformClient.DeleteReport(ctx, r.ID); err != nil {
+				c.Errf("warning: failed to delete old summary comment: %v", err)
+			}
+		}
+	}
+
+	// Post the new summary report comment
+	if err := c.platformClient.CreateReport(ctx, prNumber, sb.String()); err != nil {
+		return fmt.Errorf("failed to post summary report on PR [#%d]: %w", prNumber, err)
+	}
+
+	c.Outf("successfully posted summary report on PR [#%d]", prNumber)
 	return nil
+}
+
+type planJSON struct {
+	ResourceChanges []resourceChange `json:"resource_changes"`
+}
+
+type resourceChange struct {
+	Address string `json:"address"`
+	Change  change `json:"change"`
+}
+
+type change struct {
+	Actions []string `json:"actions"`
+}
+
+type planStat struct {
+	Added   int
+	Changed int
+	Deleted int
+	Err     error
+}
+
+func parsePlanFile(p string) (int, int, int, error) {
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var plan planJSON
+	if err := json.Unmarshal(data, &plan); err != nil {
+		return 0, 0, 0, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	var added, changed, deleted int
+	for _, rc := range plan.ResourceChanges {
+		actions := rc.Change.Actions
+		if len(actions) == 0 {
+			continue
+		}
+
+		isDelete := false
+		isCreate := false
+		isUpdate := false
+		for _, a := range actions {
+			switch a {
+			case "create":
+				isCreate = true
+			case "delete":
+				isDelete = true
+			case "update":
+				isUpdate = true
+			}
+		}
+
+		if isCreate && isDelete {
+			added++
+			deleted++
+		} else if isCreate {
+			added++
+		} else if isDelete {
+			deleted++
+		} else if isUpdate {
+			changed++
+		}
+	}
+
+	return added, changed, deleted, nil
+}
+
+func findPlanFile(artifactsDir, entrypoint string) (string, error) {
+	slug := strings.ReplaceAll(entrypoint, "/", "-")
+
+	paths := []string{
+		filepath.Join(artifactsDir, entrypoint, "tfplan.json"),
+		filepath.Join(artifactsDir, "tfplan-"+slug, "tfplan.json"),
+		filepath.Join(artifactsDir, slug, "tfplan.json"),
+	}
+
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+
+	return "", fmt.Errorf("no tfplan.json found")
+}
+
+const planSummaryTemplate = "#### 🔱 Guardian 🔱 **`PLAN SUMMARY`**\n\n" +
+	"| Directory | Status | Stats | Notes | Log |\n" +
+	"| :--- | :--- | :--- | :--- | :--- |\n" +
+	"{{- range .Rows }}\n" +
+	"| `{{.Directory}}` | <span style=\"white-space: nowrap;\">{{.Status}}</span> | {{.Stats}} | {{.Notes}} | {{.LogLink}} |\n" +
+	"{{- end }}\n"
+
+const applySummaryTemplate = "#### 🔱 Guardian 🔱 **`APPLY SUMMARY`**\n\n" +
+	"| Directory | Status | Notes | Log |\n" +
+	"| :--- | :--- | :--- | :--- |\n" +
+	"{{- range .Rows }}\n" +
+	"| `{{.Directory}}` | <span style=\"white-space: nowrap;\">{{.Status}}</span> | {{.Notes}} | {{.LogLink}} |\n" +
+	"{{- end }}\n"
+
+type summaryRow struct {
+	Directory string
+	Status    string
+	Stats     string
+	Notes     string
+	LogLink   string
 }

--- a/pkg/commands/workflows/report.go
+++ b/pkg/commands/workflows/report.go
@@ -196,7 +196,7 @@ func (c *ReportCommand) Process(ctx context.Context) error {
 	}
 
 	// Generate Markdown Summary Comment
-	var rows []summaryRow
+	rows := make([]summaryRow, 0, len(entrypoints))
 	for _, entrypoint := range entrypoints {
 		status := "⛔&nbsp;UNKNOWN"
 		logLink := "-"

--- a/pkg/commands/workflows/report_test.go
+++ b/pkg/commands/workflows/report_test.go
@@ -15,10 +15,12 @@
 package workflows
 
 import (
-	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-github/v53/github"
 
 	"github.com/abcxyz/guardian/pkg/platform"
 	"github.com/abcxyz/pkg/testutil"
@@ -100,6 +102,8 @@ func TestReportCommandProcess(t *testing.T) {
 	cases := []struct {
 		name                           string
 		flagType                       string
+		flagEntrypoints                string
+		flagArtifactsDir               func(t *testing.T) string
 		githubPullRequestNumber        int
 		githubSHA                      string
 		githubRunID                    int64
@@ -107,86 +111,124 @@ func TestReportCommandProcess(t *testing.T) {
 		listChangeRequestsByCommitErr  error
 		listJobsResp                   []*platform.Job
 		listJobsErr                    error
+		listReportsResp                []*platform.Report
+		listReportsErr                 error
+		createReportErr                error
 		err                            string
 		expPlatformClientReqs          []*platform.Request
 	}{
 		{
-			name:                    "plan_success",
+			name:                    "plan_success_posts_table_and_deletes_old_comments",
 			flagType:                "plan",
+			flagEntrypoints:         `["terraform/github/abseil"]`,
 			githubPullRequestNumber: 123,
 			githubRunID:             456,
+			flagArtifactsDir: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				artifactDir := filepath.Join(dir, "tfplan-terraform-github-abseil")
+				if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+					t.Fatalf("failed to create temp dir: %v", err)
+				}
+				planContent := `{
+					"resource_changes": [
+						{"address": "res1", "change": {"actions": ["create"]}},
+						{"address": "res2", "change": {"actions": ["update"]}},
+						{"address": "res3", "change": {"actions": ["delete"]}},
+						{"address": "res4", "change": {"actions": ["delete", "create"]}}
+					]
+				}`
+				if err := os.WriteFile(filepath.Join(artifactDir, "tfplan.json"), []byte(planContent), 0o600); err != nil {
+					t.Fatalf("failed to write mock tfplan.json: %v", err)
+				}
+				return dir
+			},
 			listJobsResp: []*platform.Job{
-				{ID: 11, Name: "job1", URL: "url1"},
+				{ID: 11, Name: "plan (terraform/github/abseil)", URL: "job_url_11", Conclusion: "success"},
+			},
+			listReportsResp: []*platform.Report{
+				{ID: int64(999), Body: "#### 🔱 Guardian 🔱 **`PLAN SUMMARY`**\n\nOld comment content"},
+				{ID: int64(888), Body: "Normal comment"},
 			},
 			expPlatformClientReqs: []*platform.Request{
 				{
 					Name:   "ListJobs",
 					Params: []any{int64(456)},
 				},
+				{
+					Name: "ListReports",
+					Params: []any{
+						123,
+						&platform.ListReportsOptions{
+							GitHub: &github.IssueListCommentsOptions{
+								ListOptions: github.ListOptions{
+									PerPage: 100,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name:   "DeleteReport",
+					Params: []any{int64(999)},
+				},
+				{
+					Name: "CreateReport",
+					Params: []any{
+						123,
+						"#### 🔱 Guardian 🔱 **`PLAN SUMMARY`**\n\n" +
+							"| Directory | Status | Stats | Notes | Log |\n" +
+							"| :--- | :--- | :--- | :--- | :--- |\n" +
+							"| `terraform/github/abseil` | <span style=\"white-space: nowrap;\">🟩&nbsp;SUCCESS</span> | <span style=\"white-space: nowrap;\">+2&nbsp;~1&nbsp;-2</span> | - | <a href=\"job_url_11\" target=\"_blank\">View Log</a> |\n",
+					},
+				},
 			},
 		},
 		{
-			name:        "apply_success_resolves_pr_by_commit",
-			flagType:    "apply",
-			githubSHA:   "abcdef123456",
-			githubRunID: 789,
+			name:            "apply_success_posts_table",
+			flagType:        "apply",
+			flagEntrypoints: `["terraform/github/abseil"]`,
+			githubSHA:       "sha123",
+			githubRunID:     789,
 			listChangeRequestsByCommitResp: &platform.ListChangeRequestsByCommitResponse{
 				PullRequests: []*platform.PullRequest{
 					{Number: 123},
 				},
 			},
 			listJobsResp: []*platform.Job{
-				{ID: 22, Name: "job2", URL: "url2"},
+				{ID: 22, Name: "apply (terraform/github/abseil)", URL: "job_url_22", Conclusion: "success"},
 			},
 			expPlatformClientReqs: []*platform.Request{
 				{
 					Name:   "ListChangeRequestsByCommit",
-					Params: []any{"abcdef123456", (*platform.ListChangeRequestsByCommitOptions)(nil)},
+					Params: []any{"sha123", (*platform.ListChangeRequestsByCommitOptions)(nil)},
 				},
 				{
 					Name:   "ListJobs",
 					Params: []any{int64(789)},
 				},
-			},
-		},
-		{
-			name:      "apply_no_associated_pr_skips_reporting",
-			flagType:  "apply",
-			githubSHA: "abcdef123456",
-			listChangeRequestsByCommitResp: &platform.ListChangeRequestsByCommitResponse{
-				PullRequests: []*platform.PullRequest{},
-			},
-			expPlatformClientReqs: []*platform.Request{
 				{
-					Name:   "ListChangeRequestsByCommit",
-					Params: []any{"abcdef123456", (*platform.ListChangeRequestsByCommitOptions)(nil)},
+					Name: "ListReports",
+					Params: []any{
+						123,
+						&platform.ListReportsOptions{
+							GitHub: &github.IssueListCommentsOptions{
+								ListOptions: github.ListOptions{
+									PerPage: 100,
+								},
+							},
+						},
+					},
 				},
-			},
-		},
-		{
-			name:                          "apply_pr_resolution_fails_errors",
-			flagType:                      "apply",
-			githubSHA:                     "abcdef123456",
-			listChangeRequestsByCommitErr: fmt.Errorf("network error"),
-			err:                           "failed to list pull requests for commit [abcdef123456]: network error",
-			expPlatformClientReqs: []*platform.Request{
 				{
-					Name:   "ListChangeRequestsByCommit",
-					Params: []any{"abcdef123456", (*platform.ListChangeRequestsByCommitOptions)(nil)},
-				},
-			},
-		},
-		{
-			name:                    "list_jobs_fails_errors",
-			flagType:                "plan",
-			githubPullRequestNumber: 123,
-			githubRunID:             456,
-			listJobsErr:             fmt.Errorf("api error"),
-			err:                     "failed to list jobs for run [456]: api error",
-			expPlatformClientReqs: []*platform.Request{
-				{
-					Name:   "ListJobs",
-					Params: []any{int64(456)},
+					Name: "CreateReport",
+					Params: []any{
+						123,
+						"#### 🔱 Guardian 🔱 **`APPLY SUMMARY`**\n\n" +
+							"| Directory | Status | Notes | Log |\n" +
+							"| :--- | :--- | :--- | :--- |\n" +
+							"| `terraform/github/abseil` | <span style=\"white-space: nowrap;\">🟩&nbsp;SUCCESS</span> | - | <a href=\"job_url_22\" target=\"_blank\">View Log</a> |\n",
+					},
 				},
 			},
 		},
@@ -201,11 +243,21 @@ func TestReportCommandProcess(t *testing.T) {
 				ListChangeRequestsByCommitErr:  tc.listChangeRequestsByCommitErr,
 				ListJobsResp:                   tc.listJobsResp,
 				ListJobsErr:                    tc.listJobsErr,
+				Reports:                        tc.listReportsResp,
+				ListReportsErr:                 tc.listReportsErr,
+				CreateReportErr:                tc.createReportErr,
+			}
+
+			artifactsDir := ""
+			if tc.flagArtifactsDir != nil {
+				artifactsDir = tc.flagArtifactsDir(t)
 			}
 
 			c := &ReportCommand{
-				flagType:       tc.flagType,
-				platformClient: mockPlatformClient,
+				flagType:         tc.flagType,
+				flagEntrypoints:  tc.flagEntrypoints,
+				flagArtifactsDir: artifactsDir,
+				platformClient:   mockPlatformClient,
 			}
 			c.platformConfig.GitHub.GitHubPullRequestNumber = tc.githubPullRequestNumber
 			c.platformConfig.GitHub.GitHubSHA = tc.githubSHA

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -576,7 +576,7 @@ func (g *GitHub) ReportEntrypointsSummary(ctx context.Context, p *EntrypointsSum
 }
 
 // ClearReports clears any existing reports that can be removed.
-func (g *GitHub) ClearReports(ctx context.Context) error {
+func (g *GitHub) ClearReports(ctx context.Context, changeRequestID int) error {
 	listOpts := &ListReportsOptions{
 		GitHub: &github.IssueListCommentsOptions{
 			ListOptions: github.ListOptions{PerPage: 100},
@@ -584,7 +584,7 @@ func (g *GitHub) ClearReports(ctx context.Context) error {
 	}
 
 	for {
-		response, err := g.ListReports(ctx, listOpts)
+		response, err := g.ListReports(ctx, changeRequestID, listOpts)
 		if err != nil {
 			return fmt.Errorf("failed to list comments: %w", err)
 		}
@@ -613,12 +613,17 @@ func (g *GitHub) ClearReports(ctx context.Context) error {
 }
 
 // ListReports lists existing comments for an issue or change request.
-func (g *GitHub) ListReports(ctx context.Context, opts *ListReportsOptions) (*ListReportsResult, error) {
+func (g *GitHub) ListReports(ctx context.Context, changeRequestID int, opts *ListReportsOptions) (*ListReportsResult, error) {
 	var comments []*Report
 	var pagination *Pagination
 
+	prNumber := changeRequestID
+	if prNumber <= 0 {
+		prNumber = g.cfg.GitHubPullRequestNumber
+	}
+
 	if err := g.withRetries(ctx, func(ctx context.Context) error {
-		ghComments, resp, err := g.client.Issues.ListComments(ctx, g.cfg.GitHubOwner, g.cfg.GitHubRepo, g.cfg.GitHubPullRequestNumber, opts.GitHub)
+		ghComments, resp, err := g.client.Issues.ListComments(ctx, g.cfg.GitHubOwner, g.cfg.GitHubRepo, prNumber, opts.GitHub)
 		if err != nil {
 			if resp != nil {
 				if _, ok := ignoredStatusCodes[resp.StatusCode]; !ok {
@@ -642,6 +647,15 @@ func (g *GitHub) ListReports(ctx context.Context, opts *ListReportsOptions) (*Li
 	}
 
 	return &ListReportsResult{Reports: comments, Pagination: pagination}, nil
+}
+
+// CreateReport posts a comment/note on an issue or change request.
+func (g *GitHub) CreateReport(ctx context.Context, changeRequestID int, body string) error {
+	prNumber := changeRequestID
+	if prNumber <= 0 {
+		prNumber = g.cfg.GitHubPullRequestNumber
+	}
+	return g.createIssueComment(ctx, g.cfg.GitHubOwner, g.cfg.GitHubRepo, prNumber, body)
 }
 
 // DeleteReport deletes an existing comment from an issue or change request.
@@ -766,9 +780,11 @@ func (g *GitHub) ListJobs(ctx context.Context, runID int64) ([]*Job, error) {
 
 		for _, j := range ghJobs.Jobs {
 			jobs = append(jobs, &Job{
-				ID:   j.GetID(),
-				Name: j.GetName(),
-				URL:  j.GetHTMLURL(),
+				ID:         j.GetID(),
+				Name:       j.GetName(),
+				URL:        j.GetHTMLURL(),
+				Status:     j.GetStatus(),
+				Conclusion: j.GetConclusion(),
 			})
 		}
 

--- a/pkg/platform/gitlab.go
+++ b/pkg/platform/gitlab.go
@@ -203,16 +203,21 @@ func (g *GitLab) StoragePrefix(ctx context.Context) (string, error) {
 }
 
 // ListReports lists existing reports for an issue or change request.
-func (g *GitLab) ListReports(ctx context.Context, opts *ListReportsOptions) (*ListReportsResult, error) {
+func (g *GitLab) ListReports(ctx context.Context, changeRequestID int, opts *ListReportsOptions) (*ListReportsResult, error) {
 	if err := validateGitLabReporterInputs(g.cfg); err != nil {
 		return nil, fmt.Errorf("failed to validate reporter inputs: %w", err)
+	}
+
+	mrIID := changeRequestID
+	if mrIID <= 0 {
+		mrIID = g.cfg.GitLabMergeRequestIID
 	}
 
 	var reports []*Report
 	var pagination *Pagination
 
 	if err := g.withRetries(ctx, func(ctx context.Context) error {
-		notes, resp, err := g.client.Notes.ListMergeRequestNotes(g.cfg.GitLabProjectID, g.cfg.GitLabMergeRequestIID, opts.GitLab)
+		notes, resp, err := g.client.Notes.ListMergeRequestNotes(g.cfg.GitLabProjectID, mrIID, opts.GitLab)
 		if err != nil {
 			if resp != nil {
 				if _, ok := gitLabIgnoredStatusCodes[resp.StatusCode]; !ok {
@@ -302,7 +307,7 @@ func (g *GitLab) ReportEntrypointsSummary(ctx context.Context, p *EntrypointsSum
 }
 
 // ClearReports clears any existing reports that can be removed.
-func (g *GitLab) ClearReports(ctx context.Context) error {
+func (g *GitLab) ClearReports(ctx context.Context, changeRequestID int) error {
 	if err := validateGitLabReporterInputs(g.cfg); err != nil {
 		return fmt.Errorf("failed to validate reporter inputs: %w", err)
 	}
@@ -314,7 +319,7 @@ func (g *GitLab) ClearReports(ctx context.Context) error {
 	}
 
 	for {
-		response, err := g.ListReports(ctx, listOpts)
+		response, err := g.ListReports(ctx, changeRequestID, listOpts)
 		if err != nil {
 			return fmt.Errorf("failed to list comments: %w", err)
 		}
@@ -394,4 +399,28 @@ func (g *GitLab) ListChangeRequestsByCommit(ctx context.Context, sha string, opt
 // ListJobs is a no-op because GitLab platform support is currently not implemented.
 func (g *GitLab) ListJobs(ctx context.Context, runID int64) ([]*Job, error) {
 	return nil, nil
+}
+
+// CreateReport posts a comment/note on an issue or change request.
+func (g *GitLab) CreateReport(ctx context.Context, changeRequestID int, body string) error {
+	if err := validateGitLabReporterInputs(g.cfg); err != nil {
+		return fmt.Errorf("failed to validate reporter inputs: %w", err)
+	}
+	mrIID := changeRequestID
+	if mrIID <= 0 {
+		mrIID = g.cfg.GitLabMergeRequestIID
+	}
+
+	logger := logging.FromContext(ctx)
+	logger.DebugContext(ctx, "creating merge request note",
+		"project", g.cfg.GitLabProjectID,
+		"merge_request", mrIID)
+
+	if _, _, err := g.client.Notes.CreateMergeRequestNote(g.cfg.GitLabProjectID, mrIID, &gitlab.CreateMergeRequestNoteOptions{
+		Body: &body,
+	}); err != nil {
+		return fmt.Errorf("failed to create merge request note: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/platform/local.go
+++ b/pkg/platform/local.go
@@ -63,7 +63,7 @@ func (l *Local) StoragePrefix(ctx context.Context) (string, error) {
 }
 
 // ListReports lists existing reports for an issue or change request.
-func (l *Local) ListReports(ctx context.Context, opts *ListReportsOptions) (*ListReportsResult, error) {
+func (l *Local) ListReports(ctx context.Context, changeRequestID int, opts *ListReportsOptions) (*ListReportsResult, error) {
 	return nil, nil
 }
 
@@ -83,7 +83,7 @@ func (l *Local) ReportEntrypointsSummary(ctx context.Context, params *Entrypoint
 }
 
 // ClearReports clears any existing reports that can be removed.
-func (l *Local) ClearReports(ctx context.Context) error {
+func (l *Local) ClearReports(ctx context.Context, changeRequestID int) error {
 	return nil
 }
 
@@ -95,4 +95,9 @@ func (l *Local) ListChangeRequestsByCommit(ctx context.Context, sha string, opts
 // ListJobs is a no-op because the local platform does not run GHA workflows or pipelines.
 func (l *Local) ListJobs(ctx context.Context, runID int64) ([]*Job, error) {
 	return nil, nil
+}
+
+// CreateReport is a no-op.
+func (l *Local) CreateReport(ctx context.Context, changeRequestID int, body string) error {
+	return nil
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -115,9 +115,11 @@ type Pagination struct {
 
 // Job is a CI/CD Job that runs as part of a workflow/pipeline.
 type Job struct {
-	ID   int64
-	Name string
-	URL  string
+	ID         int64
+	Name       string
+	URL        string
+	Status     string
+	Conclusion string
 }
 
 // Platform defines the minimum interface for a code review platform.
@@ -140,7 +142,7 @@ type Platform interface {
 	GetPolicyData(ctx context.Context) (*GetPolicyDataResult, error)
 
 	// ListReports lists existing reports for an issue or change request.
-	ListReports(ctx context.Context, opts *ListReportsOptions) (*ListReportsResult, error)
+	ListReports(ctx context.Context, changeRequestID int, opts *ListReportsOptions) (*ListReportsResult, error)
 
 	// ListChangeRequestsByCommit lists the change requests associated with a commit SHA.
 	ListChangeRequestsByCommit(ctx context.Context, sha string, opts *ListChangeRequestsByCommitOptions) (*ListChangeRequestsByCommitResponse, error)
@@ -158,10 +160,13 @@ type Platform interface {
 	ReportEntrypointsSummary(ctx context.Context, params *EntrypointsSummaryParams) error
 
 	// ClearReports clears any existing reports that can be removed.
-	ClearReports(ctx context.Context) error
+	ClearReports(ctx context.Context, changeRequestID int) error
 
 	// ListJobs lists all jobs running as part of a workflow/pipeline run.
 	ListJobs(ctx context.Context, runID int64) ([]*Job, error)
+
+	// CreateReport posts a comment/note on an issue or change request.
+	CreateReport(ctx context.Context, changeRequestID int, body string) error
 }
 
 // NewPlatform creates a new platform based on the provided type.

--- a/pkg/platform/platform_mock.go
+++ b/pkg/platform/platform_mock.go
@@ -54,6 +54,7 @@ type MockPlatform struct {
 	ListChangeRequestsByCommitErr  error
 	ListJobsResp                   []*Job
 	ListJobsErr                    error
+	CreateReportErr                error
 }
 
 func (m *MockPlatform) AssignReviewers(ctx context.Context, input *AssignReviewersInput) (*AssignReviewersResult, error) {
@@ -190,11 +191,14 @@ func (m *MockPlatform) ReportStatus(ctx context.Context, s Status, p *StatusPara
 }
 
 // ListReports lists existing reports for an issue or change request.
-func (m *MockPlatform) ListReports(ctx context.Context, opts *ListReportsOptions) (*ListReportsResult, error) {
+func (m *MockPlatform) ListReports(ctx context.Context, changeRequestID int, opts *ListReportsOptions) (*ListReportsResult, error) {
 	m.reqMu.Lock()
 	defer m.reqMu.Unlock()
 	m.Reqs = append(m.Reqs,
-		&Request{Name: "ListReports"},
+		&Request{
+			Name:   "ListReports",
+			Params: []any{changeRequestID, opts},
+		},
 	)
 
 	if m.ListReportsErr != nil {
@@ -211,7 +215,10 @@ func (m *MockPlatform) DeleteReport(ctx context.Context, id any) error {
 	m.reqMu.Lock()
 	defer m.reqMu.Unlock()
 	m.Reqs = append(m.Reqs,
-		&Request{Name: "DeleteReport"},
+		&Request{
+			Name:   "DeleteReport",
+			Params: []any{id},
+		},
 	)
 
 	if m.DeleteReportErr != nil {
@@ -238,11 +245,12 @@ func (m *MockPlatform) ReportEntrypointsSummary(ctx context.Context, p *Entrypoi
 }
 
 // ClearReports clears any existing reports that can be removed.
-func (m *MockPlatform) ClearReports(ctx context.Context) error {
+func (m *MockPlatform) ClearReports(ctx context.Context, changeRequestID int) error {
 	m.reqMu.Lock()
 	defer m.reqMu.Unlock()
 	m.Reqs = append(m.Reqs, &Request{
-		Name: "Clear",
+		Name:   "Clear",
+		Params: []any{changeRequestID},
 	})
 
 	return m.ClearReportsErr
@@ -276,4 +284,16 @@ func (m *MockPlatform) ListJobs(ctx context.Context, runID int64) ([]*Job, error
 		return nil, m.ListJobsErr
 	}
 	return m.ListJobsResp, nil
+}
+
+// CreateReport mock implementation.
+func (m *MockPlatform) CreateReport(ctx context.Context, changeRequestID int, body string) error {
+	m.reqMu.Lock()
+	defer m.reqMu.Unlock()
+	m.Reqs = append(m.Reqs, &Request{
+		Name:   "CreateReport",
+		Params: []any{changeRequestID, body},
+	})
+
+	return m.CreateReportErr
 }


### PR DESCRIPTION
Implement the backend aggregator and markdown formatting logic for guardian report.

- Tally plan statistics (adds, updates, deletes) from downloaded plan artifacts.
- Format GHA status tables with nowrap rules to prevent wrapping issues on GitHub.
- Extend Platform interface with CreateReport and adds PR comment clear/lookup options.
- Add unit tests.