### PR TITLE
fix: support org coalesced job matching and comment truncation

### DIFF
--- a/pkg/commands/workflows/report.go
+++ b/pkg/commands/workflows/report.go
@@ -280,7 +280,7 @@ func (c *ReportCommand) Process(ctx context.Context) error {
 	}
 
 	currentLen := len(commentPrefix) + 200
-	var finalRows []summaryRow
+	finalRows := make([]summaryRow, 0, len(rows))
 	var truncated bool
 	for _, r := range rows {
 		rowLen := len(r.Directory) + len(r.Status) + len(r.Stats) + len(r.Notes) + len(r.LogLink) + 20

--- a/pkg/commands/workflows/report.go
+++ b/pkg/commands/workflows/report.go
@@ -169,8 +169,28 @@ func (c *ReportCommand) Process(ctx context.Context) error {
 	// Map entrypoints to GHA jobs
 	jobStatuses := make(map[string]*platform.Job)
 	for _, entrypoint := range entrypoints {
+		parts := strings.Split(entrypoint, "/")
+		var orgName string
+		if len(parts) >= 2 {
+			if parts[0] == "terraform" {
+				orgName = parts[1]
+			} else {
+				orgName = parts[0]
+			}
+		}
+
 		for _, job := range jobs {
-			if strings.Contains(strings.ToLower(job.Name), strings.ToLower(entrypoint)) {
+			lowerJobName := strings.ToLower(job.Name)
+			lowerEntrypoint := strings.ToLower(entrypoint)
+
+			// Works for standard matrix where job name contains full entrypoint path
+			if strings.Contains(lowerJobName, lowerEntrypoint) {
+				jobStatuses[entrypoint] = job
+				break
+			}
+
+			// Works for org batching where job name contains org name in parentheses
+			if orgName != "" && strings.Contains(lowerJobName, "("+strings.ToLower(orgName)+")") {
 				jobStatuses[entrypoint] = job
 				break
 			}
@@ -218,6 +238,8 @@ func (c *ReportCommand) Process(ctx context.Context) error {
 			default:
 				status = fmt.Sprintf("⛔&nbsp;%s", strings.ToUpper(job.Conclusion))
 			}
+		} else {
+			notes = "⚠️ Job not found in run"
 		}
 
 		if c.flagType == "plan" {
@@ -227,9 +249,14 @@ func (c *ReportCommand) Process(ctx context.Context) error {
 					notes = fmt.Sprintf("⚠️ %s", stat.Err.Error())
 				} else {
 					statsStr = fmt.Sprintf("<span style=\"white-space: nowrap;\">%+d&nbsp;~%d&nbsp;-%d</span>", stat.Added, stat.Changed, stat.Deleted)
+					if hasJob {
+						notes = "-"
+					}
 				}
-			} else {
+			} else if hasJob {
 				notes = "⚠️ Missing tfplan.json"
+			} else {
+				notes = "⚠️ Job not found in run"
 			}
 		}
 		rows = append(rows, summaryRow{
@@ -241,7 +268,7 @@ func (c *ReportCommand) Process(ctx context.Context) error {
 		})
 	}
 
-	var sb strings.Builder
+	const maxLength = 60000
 	var commentPrefix string
 	var tmplText string
 	if c.flagType == "plan" {
@@ -252,12 +279,29 @@ func (c *ReportCommand) Process(ctx context.Context) error {
 		tmplText = applySummaryTemplate
 	}
 
+	currentLen := len(commentPrefix) + 200
+	var finalRows []summaryRow
+	var truncated bool
+	for _, r := range rows {
+		rowLen := len(r.Directory) + len(r.Status) + len(r.Stats) + len(r.Notes) + len(r.LogLink) + 20
+		if currentLen+rowLen > maxLength {
+			truncated = true
+			break
+		}
+		finalRows = append(finalRows, r)
+		currentLen += rowLen
+	}
+
+	var sb strings.Builder
 	tmpl, err := template.New("summary").Parse(tmplText)
 	if err != nil {
 		return fmt.Errorf("failed to parse summary template: %w", err)
 	}
 
-	if err := tmpl.Execute(&sb, map[string]any{"Rows": rows}); err != nil {
+	if err := tmpl.Execute(&sb, map[string]any{
+		"Rows":      finalRows,
+		"Truncated": truncated,
+	}); err != nil {
 		return fmt.Errorf("failed to execute summary template: %w", err)
 	}
 
@@ -388,16 +432,18 @@ func findPlanFile(artifactsDir, entrypoint string) (string, error) {
 const planSummaryTemplate = "#### 🔱 Guardian 🔱 **`PLAN SUMMARY`**\n\n" +
 	"| Directory | Status | Stats | Notes | Log |\n" +
 	"| :--- | :--- | :--- | :--- | :--- |\n" +
-	"{{- range .Rows }}\n" +
+	"{{range .Rows}}" +
 	"| `{{.Directory}}` | <span style=\"white-space: nowrap;\">{{.Status}}</span> | {{.Stats}} | {{.Notes}} | {{.LogLink}} |\n" +
-	"{{- end }}\n"
+	"{{end}}" +
+	"{{if .Truncated}}\n\n> ⚠️ **Notice**: The report was truncated due to the character limit. Please check the full list and output artifacts in GitHub Actions logs.\n{{end}}"
 
 const applySummaryTemplate = "#### 🔱 Guardian 🔱 **`APPLY SUMMARY`**\n\n" +
 	"| Directory | Status | Notes | Log |\n" +
 	"| :--- | :--- | :--- | :--- |\n" +
-	"{{- range .Rows }}\n" +
+	"{{range .Rows}}" +
 	"| `{{.Directory}}` | <span style=\"white-space: nowrap;\">{{.Status}}</span> | {{.Notes}} | {{.LogLink}} |\n" +
-	"{{- end }}\n"
+	"{{end}}" +
+	"{{if .Truncated}}\n\n> ⚠️ **Notice**: The report was truncated due to the character limit.\n{{end}}"
 
 type summaryRow struct {
 	Directory string

--- a/pkg/commands/workflows/report_test.go
+++ b/pkg/commands/workflows/report_test.go
@@ -17,6 +17,7 @@ package workflows
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -180,6 +181,105 @@ func TestReportCommandProcess(t *testing.T) {
 							"| Directory | Status | Stats | Notes | Log |\n" +
 							"| :--- | :--- | :--- | :--- | :--- |\n" +
 							"| `terraform/github/abseil` | <span style=\"white-space: nowrap;\">🟩&nbsp;SUCCESS</span> | <span style=\"white-space: nowrap;\">+2&nbsp;~1&nbsp;-2</span> | - | <a href=\"job_url_11\" target=\"_blank\">View Log</a> |\n",
+					},
+				},
+			},
+		},
+		{
+			name:                    "plan_success_with_org_coalescing",
+			flagType:                "plan",
+			flagEntrypoints:         `["terraform/google-gh-automation/repositories/auto-fairy"]`,
+			githubPullRequestNumber: 123,
+			githubRunID:             456,
+			flagArtifactsDir: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				artifactDir := filepath.Join(dir, "tfplan-terraform-google-gh-automation-repositories-auto-fairy")
+				if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+					t.Fatalf("failed to create temp dir: %v", err)
+				}
+				planContent := `{
+					"resource_changes": [
+						{"address": "res1", "change": {"actions": ["create"]}}
+					]
+				}`
+				if err := os.WriteFile(filepath.Join(artifactDir, "tfplan.json"), []byte(planContent), 0o600); err != nil {
+					t.Fatalf("failed to write mock tfplan.json: %v", err)
+				}
+				return dir
+			},
+			listJobsResp: []*platform.Job{
+				{ID: 11, Name: "plan (google-gh-automation)", URL: "job_url_11", Conclusion: "success"},
+			},
+			listReportsResp: []*platform.Report{},
+			expPlatformClientReqs: []*platform.Request{
+				{
+					Name:   "ListJobs",
+					Params: []any{int64(456)},
+				},
+				{
+					Name: "ListReports",
+					Params: []any{
+						123,
+						&platform.ListReportsOptions{
+							GitHub: &github.IssueListCommentsOptions{
+								ListOptions: github.ListOptions{
+									PerPage: 100,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "CreateReport",
+					Params: []any{
+						123,
+						"#### 🔱 Guardian 🔱 **`PLAN SUMMARY`**\n\n" +
+							"| Directory | Status | Stats | Notes | Log |\n" +
+							"| :--- | :--- | :--- | :--- | :--- |\n" +
+							"| `terraform/google-gh-automation/repositories/auto-fairy` | <span style=\"white-space: nowrap;\">🟩&nbsp;SUCCESS</span> | <span style=\"white-space: nowrap;\">+1&nbsp;~0&nbsp;-0</span> | - | <a href=\"job_url_11\" target=\"_blank\">View Log</a> |\n",
+					},
+				},
+			},
+		},
+		{
+			name:                    "plan_truncated_if_too_long",
+			flagType:                "plan",
+			flagEntrypoints:         `["` + strings.Repeat("a", 60000) + `"]`,
+			githubPullRequestNumber: 123,
+			githubRunID:             456,
+			flagArtifactsDir: func(t *testing.T) string {
+				t.Helper()
+				return t.TempDir()
+			},
+			listJobsResp:    []*platform.Job{},
+			listReportsResp: []*platform.Report{},
+			expPlatformClientReqs: []*platform.Request{
+				{
+					Name:   "ListJobs",
+					Params: []any{int64(456)},
+				},
+				{
+					Name: "ListReports",
+					Params: []any{
+						123,
+						&platform.ListReportsOptions{
+							GitHub: &github.IssueListCommentsOptions{
+								ListOptions: github.ListOptions{
+									PerPage: 100,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "CreateReport",
+					Params: []any{
+						123,
+						"#### 🔱 Guardian 🔱 **`PLAN SUMMARY`**\n\n" +
+							"| Directory | Status | Stats | Notes | Log |\n" +
+							"| :--- | :--- | :--- | :--- | :--- |\n\n\n" +
+							"> ⚠️ **Notice**: The report was truncated due to the character limit. Please check the full list and output artifacts in GitHub Actions logs.\n",
 					},
 				},
 			},


### PR DESCRIPTION
Fix two potential failure points in the workflows report.
- Updated job resolution logic to support matching both direct repo directories and organization batch names (e.g. plan (google-gh-automation)).
- Enforce a 60,000 character limit on PR comment bodies to prevent GitHub API payload size errors on very large PRs.
- Add more tests.