### PR TITLE
fix: support underscore slug resolution in guardian report

### DIFF
--- a/pkg/commands/workflows/report.go
+++ b/pkg/commands/workflows/report.go
@@ -412,12 +412,15 @@ func parsePlanFile(p string) (int, int, int, error) {
 }
 
 func findPlanFile(artifactsDir, entrypoint string) (string, error) {
-	slug := strings.ReplaceAll(entrypoint, "/", "-")
+	slugHyphen := strings.ReplaceAll(entrypoint, "/", "-")
+	slugUnderscore := strings.ReplaceAll(entrypoint, "/", "_")
 
 	paths := []string{
 		filepath.Join(artifactsDir, entrypoint, "tfplan.json"),
-		filepath.Join(artifactsDir, "tfplan-"+slug, "tfplan.json"),
-		filepath.Join(artifactsDir, slug, "tfplan.json"),
+		filepath.Join(artifactsDir, "tfplan-"+slugHyphen, "tfplan.json"),
+		filepath.Join(artifactsDir, "tfplan-"+slugUnderscore, "tfplan.json"),
+		filepath.Join(artifactsDir, slugHyphen, "tfplan.json"),
+		filepath.Join(artifactsDir, slugUnderscore, "tfplan.json"),
 	}
 
 	for _, p := range paths {

--- a/pkg/commands/workflows/report_test.go
+++ b/pkg/commands/workflows/report_test.go
@@ -243,6 +243,63 @@ func TestReportCommandProcess(t *testing.T) {
 			},
 		},
 		{
+			name:                    "plan_success_with_underscore_slug",
+			flagType:                "plan",
+			flagEntrypoints:         `["terraform/google-gh-automation/repositories/auto-fairy"]`,
+			githubPullRequestNumber: 123,
+			githubRunID:             456,
+			flagArtifactsDir: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				artifactDir := filepath.Join(dir, "tfplan-terraform_google-gh-automation_repositories_auto-fairy")
+				if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+					t.Fatalf("failed to create temp dir: %v", err)
+				}
+				planContent := `{
+					"resource_changes": [
+						{"address": "res1", "change": {"actions": ["create"]}}
+					]
+				}`
+				if err := os.WriteFile(filepath.Join(artifactDir, "tfplan.json"), []byte(planContent), 0o600); err != nil {
+					t.Fatalf("failed to write mock tfplan.json: %v", err)
+				}
+				return dir
+			},
+			listJobsResp: []*platform.Job{
+				{ID: 11, Name: "plan (google-gh-automation)", URL: "job_url_11", Conclusion: "success"},
+			},
+			listReportsResp: []*platform.Report{},
+			expPlatformClientReqs: []*platform.Request{
+				{
+					Name:   "ListJobs",
+					Params: []any{int64(456)},
+				},
+				{
+					Name: "ListReports",
+					Params: []any{
+						123,
+						&platform.ListReportsOptions{
+							GitHub: &github.IssueListCommentsOptions{
+								ListOptions: github.ListOptions{
+									PerPage: 100,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "CreateReport",
+					Params: []any{
+						123,
+						"#### 🔱 Guardian 🔱 **`PLAN SUMMARY`**\n\n" +
+							"| Directory | Status | Stats | Notes | Log |\n" +
+							"| :--- | :--- | :--- | :--- | :--- |\n" +
+							"| `terraform/google-gh-automation/repositories/auto-fairy` | <span style=\"white-space: nowrap;\">🟩&nbsp;SUCCESS</span> | <span style=\"white-space: nowrap;\">+1&nbsp;~0&nbsp;-0</span> | - | <a href=\"job_url_11\" target=\"_blank\">View Log</a> |\n",
+					},
+				},
+			},
+		},
+		{
 			name:                    "plan_truncated_if_too_long",
 			flagType:                "plan",
 			flagEntrypoints:         `["` + strings.Repeat("a", 60000) + `"]`,


### PR DESCRIPTION
Resolve the no tfplan.json found issue by supporting underscored slugs. Update findPlanFile to check both hyphenated and underscored directory paths when matching downloaded Terraform plan artifacts.