### PR TITLE
fix: support generic folder matching

### DIFF
--- a/pkg/commands/workflows/report.go
+++ b/pkg/commands/workflows/report.go
@@ -170,12 +170,10 @@ func (c *ReportCommand) Process(ctx context.Context) error {
 	jobStatuses := make(map[string]*platform.Job)
 	for _, entrypoint := range entrypoints {
 		parts := strings.Split(entrypoint, "/")
-		var orgName string
-		if len(parts) >= 2 {
-			if parts[0] == "terraform" {
-				orgName = parts[1]
-			} else {
-				orgName = parts[0]
+		var candidates []string
+		for _, part := range parts {
+			if part != "" {
+				candidates = append(candidates, part)
 			}
 		}
 
@@ -190,8 +188,15 @@ func (c *ReportCommand) Process(ctx context.Context) error {
 			}
 
 			// Works for org batching where job name contains org name in parentheses
-			if orgName != "" && strings.Contains(lowerJobName, "("+strings.ToLower(orgName)+")") {
-				jobStatuses[entrypoint] = job
+			matched := false
+			for _, candidate := range candidates {
+				if candidate != "" && strings.Contains(lowerJobName, "("+strings.ToLower(candidate)+")") {
+					jobStatuses[entrypoint] = job
+					matched = true
+					break
+				}
+			}
+			if matched {
 				break
 			}
 		}
@@ -246,7 +251,11 @@ func (c *ReportCommand) Process(ctx context.Context) error {
 			stat, ok := planStats[entrypoint]
 			if ok {
 				if stat.Err != nil {
-					notes = fmt.Sprintf("⚠️ %s", stat.Err.Error())
+					if hasJob && (job.Conclusion == "skipped" || job.Conclusion == "cancelled") {
+						notes = "-"
+					} else {
+						notes = fmt.Sprintf("⚠️ %s", stat.Err.Error())
+					}
 				} else {
 					statsStr = fmt.Sprintf("<span style=\"white-space: nowrap;\">%+d&nbsp;~%d&nbsp;-%d</span>", stat.Added, stat.Changed, stat.Deleted)
 					if hasJob {
@@ -254,7 +263,11 @@ func (c *ReportCommand) Process(ctx context.Context) error {
 					}
 				}
 			} else if hasJob {
-				notes = "⚠️ Missing tfplan.json"
+				if job.Conclusion == "skipped" || job.Conclusion == "cancelled" {
+					notes = "-"
+				} else {
+					notes = "⚠️ Missing tfplan.json"
+				}
 			} else {
 				notes = "⚠️ Job not found in run"
 			}

--- a/pkg/commands/workflows/report_test.go
+++ b/pkg/commands/workflows/report_test.go
@@ -300,6 +300,107 @@ func TestReportCommandProcess(t *testing.T) {
 			},
 		},
 		{
+			name:                    "plan_success_with_provider_subdirectory",
+			flagType:                "plan",
+			flagEntrypoints:         `["terraform/github/google-gh-automation/repositories/auto-fairy"]`,
+			githubPullRequestNumber: 123,
+			githubRunID:             456,
+			flagArtifactsDir: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				artifactDir := filepath.Join(dir, "tfplan-terraform_github_google-gh-automation_repositories_auto-fairy")
+				if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+					t.Fatalf("failed to create temp dir: %v", err)
+				}
+				planContent := `{
+					"resource_changes": [
+						{"address": "res1", "change": {"actions": ["create"]}}
+					]
+				}`
+				if err := os.WriteFile(filepath.Join(artifactDir, "tfplan.json"), []byte(planContent), 0o600); err != nil {
+					t.Fatalf("failed to write mock tfplan.json: %v", err)
+				}
+				return dir
+			},
+			listJobsResp: []*platform.Job{
+				{ID: 11, Name: "plan (google-gh-automation)", URL: "job_url_11", Conclusion: "success"},
+			},
+			listReportsResp: []*platform.Report{},
+			expPlatformClientReqs: []*platform.Request{
+				{
+					Name:   "ListJobs",
+					Params: []any{int64(456)},
+				},
+				{
+					Name: "ListReports",
+					Params: []any{
+						123,
+						&platform.ListReportsOptions{
+							GitHub: &github.IssueListCommentsOptions{
+								ListOptions: github.ListOptions{
+									PerPage: 100,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "CreateReport",
+					Params: []any{
+						123,
+						"#### 🔱 Guardian 🔱 **`PLAN SUMMARY`**\n\n" +
+							"| Directory | Status | Stats | Notes | Log |\n" +
+							"| :--- | :--- | :--- | :--- | :--- |\n" +
+							"| `terraform/github/google-gh-automation/repositories/auto-fairy` | <span style=\"white-space: nowrap;\">🟩&nbsp;SUCCESS</span> | <span style=\"white-space: nowrap;\">+1&nbsp;~0&nbsp;-0</span> | - | <a href=\"job_url_11\" target=\"_blank\">View Log</a> |\n",
+					},
+				},
+			},
+		},
+		{
+			name:                    "plan_skipped_suppresses_warning",
+			flagType:                "plan",
+			flagEntrypoints:         `["terraform/github/google-gh-automation/repositories/auto-fairy"]`,
+			githubPullRequestNumber: 123,
+			githubRunID:             456,
+			flagArtifactsDir: func(t *testing.T) string {
+				t.Helper()
+				return t.TempDir()
+			},
+			listJobsResp: []*platform.Job{
+				{ID: 11, Name: "plan (google-gh-automation)", URL: "job_url_11", Conclusion: "skipped"},
+			},
+			listReportsResp: []*platform.Report{},
+			expPlatformClientReqs: []*platform.Request{
+				{
+					Name:   "ListJobs",
+					Params: []any{int64(456)},
+				},
+				{
+					Name: "ListReports",
+					Params: []any{
+						123,
+						&platform.ListReportsOptions{
+							GitHub: &github.IssueListCommentsOptions{
+								ListOptions: github.ListOptions{
+									PerPage: 100,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "CreateReport",
+					Params: []any{
+						123,
+						"#### 🔱 Guardian 🔱 **`PLAN SUMMARY`**\n\n" +
+							"| Directory | Status | Stats | Notes | Log |\n" +
+							"| :--- | :--- | :--- | :--- | :--- |\n" +
+							"| `terraform/github/google-gh-automation/repositories/auto-fairy` | <span style=\"white-space: nowrap;\">🟨&nbsp;SKIPPED</span> | - | - | <a href=\"job_url_11\" target=\"_blank\">View Log</a> |\n",
+					},
+				},
+			},
+		},
+		{
 			name:                    "plan_truncated_if_too_long",
 			flagType:                "plan",
 			flagEntrypoints:         `["` + strings.Repeat("a", 60000) + `"]`,


### PR DESCRIPTION
Refactor GHA job mapping and improve artifact warning logic for guardian report.
- Replace the hardcoded org extraction with a generic folder candidate check.
- Suppress false-positive Missing tfplan.json warning notes on GHA jobs that were skipped or cancelled.