### PR TITLE
Revert "fix(entrypoints): Walk up directory path for all changed file…

### DIFF
--- a/pkg/commands/entrypoints/entrypoints.go
+++ b/pkg/commands/entrypoints/entrypoints.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"io/fs"
-	"path/filepath"
 	"slices"
 
 	"golang.org/x/exp/maps"
@@ -50,7 +49,6 @@ type EntrypointsCommand struct {
 	flagDetectChanges           bool
 	flagFailUnresolvableModules bool
 	flagMaxDepth                int
-	flagMaxWalkbackDepth        int
 	flagSkipReporting           bool
 
 	parsedFlagMaxDepth *int
@@ -59,11 +57,6 @@ type EntrypointsCommand struct {
 
 	newGitClient func(ctx context.Context, dir string) git.Git
 }
-
-const (
-	// Set a maximum limit to ensure we have an upper bound on how much time we spend.
-	maxWalkbackDepthLimit = 100
-)
 
 func (c *EntrypointsCommand) Desc() string {
 	return `Determine the entrypoint directories to run Guardian commands`
@@ -129,13 +122,6 @@ func (c *EntrypointsCommand) Flags() *cli.FlagSet {
 		Target:  &c.flagMaxDepth,
 		Usage:   `How far to traverse the filesystem beneath the target directory for entrypoints.`,
 		Default: -1,
-	})
-
-	f.IntVar(&cli.IntVar{
-		Name:    "max-walkback-depth",
-		Target:  &c.flagMaxWalkbackDepth,
-		Usage:   fmt.Sprintf("How far to walk up the directory tree to find a parent entrypoint or module for changed files. Cannot exceed %d. Zero disables this feature.", maxWalkbackDepthLimit),
-		Default: 5,
 	})
 
 	f.BoolVar(&cli.BoolVar{
@@ -295,30 +281,6 @@ func (c *EntrypointsCommand) findEntrypointDirs(ctx context.Context, dir string)
 	return entrypointDirs, nil
 }
 
-// matchClosestAncestorDirectory walks up the directory tree from changedDir to find the closest matching module or entrypoint in the usage graph, up to maxWalkbackDepth.
-func matchClosestAncestorDirectory(ctx context.Context, dir string, moduleUsageGraph *terraform.ModuleUsageGraph, maxWalkbackDepth int) (string, []string, bool) {
-	if maxWalkbackDepth < 0 || maxWalkbackDepth > maxWalkbackDepthLimit {
-		maxWalkbackDepth = maxWalkbackDepthLimit
-	}
-
-	for curr, count := dir, 0; count <= maxWalkbackDepth; curr, count = filepath.Dir(curr), count+1 {
-		entrypoints := moduleUsageGraph.ModulesToEntrypoints[curr]
-		_, isEntrypoint := moduleUsageGraph.EntrypointToModules[curr]
-		if len(entrypoints) > 0 || isEntrypoint {
-			return curr, maps.Keys(entrypoints), true
-		}
-
-		// Return without a warning log here. We've made it all the way back to the filesystem root,
-		// so we know for sure that an entrypoint doesn't exist.
-		if filepath.Dir(curr) == curr {
-			return "", nil, false
-		}
-	}
-
-	logging.FromContext(ctx).WarnContext(ctx, "Entypoint for %q not found by walking up %d levels. Giving up.", dir, maxWalkbackDepthLimit)
-	return "", nil, false
-}
-
 // detectChanges detects changed and removed entrypoints using git diff.
 func (c *EntrypointsCommand) detectEntrypointChanges(ctx context.Context, dir string) ([]string, error) {
 	logger := logging.FromContext(ctx)
@@ -339,14 +301,14 @@ func (c *EntrypointsCommand) detectEntrypointChanges(ctx context.Context, dir st
 
 	modifiedEntrypoints := make(map[string]struct{})
 
-	for _, d := range diffDirs {
-		matchedDir, entrypoints, ok := matchClosestAncestorDirectory(ctx, d, moduleUsageGraph, c.flagMaxWalkbackDepth)
-		if !ok {
-			continue
+	for _, changedFile := range diffDirs {
+		if entrypoints, ok := moduleUsageGraph.ModulesToEntrypoints[changedFile]; ok {
+			for entrypoint := range entrypoints {
+				modifiedEntrypoints[entrypoint] = struct{}{}
+			}
 		}
-		modifiedEntrypoints[matchedDir] = struct{}{}
-		for _, entrypoint := range entrypoints {
-			modifiedEntrypoints[entrypoint] = struct{}{}
+		if _, ok := moduleUsageGraph.EntrypointToModules[changedFile]; ok {
+			modifiedEntrypoints[changedFile] = struct{}{}
 		}
 	}
 

--- a/pkg/commands/entrypoints/entrypoints_test.go
+++ b/pkg/commands/entrypoints/entrypoints_test.go
@@ -39,19 +39,18 @@ func TestEntrypointsProcess(t *testing.T) {
 	}
 
 	cases := []struct {
-		name                 string
-		flagDir              []string
-		flagGuardianDirs     []string
-		flagDestRef          string
-		flagSourceRef        string
-		flagDetectChanges    bool
-		flagMaxDepth         int
-		flagMaxWalkbackDepth int
-		newGitClient         func(ctx context.Context, dir string) git.Git
-		platformClient       *platform.MockPlatform
-		err                  string
-		expStdout            string
-		expStderr            string
+		name              string
+		flagDir           []string
+		flagGuardianDirs  []string
+		flagDestRef       string
+		flagSourceRef     string
+		flagDetectChanges bool
+		flagMaxDepth      int
+		newGitClient      func(ctx context.Context, dir string) git.Git
+		platformClient    *platform.MockPlatform
+		err               string
+		expStdout         string
+		expStderr         string
 	}{
 		{
 			name:              "success",
@@ -161,28 +160,11 @@ func TestEntrypointsProcess(t *testing.T) {
 			expStdout: `["testdata/entrypoint1/project1","testdata/entrypoint1/project2"]`,
 		},
 		{
-			name:                 "changes_in_subdirectory_detected",
-			flagDir:              []string{"testdata/entrypoint1"},
-			flagDestRef:          "main",
-			flagSourceRef:        "ldap/feature",
-			flagDetectChanges:    true,
-			flagMaxWalkbackDepth: maxWalkbackDepthLimit,
-			newGitClient: func(ctx context.Context, dir string) git.Git {
-				return &git.MockGitClient{
-					DiffResp: []string{
-						filepath.Join(cwd, "testdata/entrypoint1/project1/files"),
-					},
-				}
-			},
-			expStdout: `["testdata/entrypoint1/project1"]`,
-		},
-		{
-			name:                 "walkback_depth_zero",
-			flagDir:              []string{"testdata/entrypoint1"},
-			flagDestRef:          "main",
-			flagSourceRef:        "ldap/feature",
-			flagDetectChanges:    true,
-			flagMaxWalkbackDepth: 0,
+			name:              "no_changes_without_add_entrypoint",
+			flagDir:           []string{"testdata/entrypoint1"},
+			flagDestRef:       "main",
+			flagSourceRef:     "ldap/feature",
+			flagDetectChanges: true,
 			newGitClient: func(ctx context.Context, dir string) git.Git {
 				return &git.MockGitClient{
 					DiffResp: []string{
@@ -191,86 +173,6 @@ func TestEntrypointsProcess(t *testing.T) {
 				}
 			},
 			expStdout: `[]`,
-		},
-		{
-			name:                 "walkback_depth_one_direct_child",
-			flagDir:              []string{"testdata/entrypoint1"},
-			flagDestRef:          "main",
-			flagSourceRef:        "ldap/feature",
-			flagDetectChanges:    true,
-			flagMaxWalkbackDepth: 1,
-			newGitClient: func(ctx context.Context, dir string) git.Git {
-				return &git.MockGitClient{
-					DiffResp: []string{
-						filepath.Join(cwd, "testdata/entrypoint1/project1/files"),
-					},
-				}
-			},
-			expStdout: `["testdata/entrypoint1/project1"]`,
-		},
-		{
-			name:                 "walkback_depth_one_nested_child",
-			flagDir:              []string{"testdata/entrypoint1"},
-			flagDestRef:          "main",
-			flagSourceRef:        "ldap/feature",
-			flagDetectChanges:    true,
-			flagMaxWalkbackDepth: 1,
-			newGitClient: func(ctx context.Context, dir string) git.Git {
-				return &git.MockGitClient{
-					DiffResp: []string{
-						filepath.Join(cwd, "testdata/entrypoint1/project1/files/sub"),
-					},
-				}
-			},
-			expStdout: `[]`,
-		},
-		{
-			name:                 "walkback_depth_two_nested_child",
-			flagDir:              []string{"testdata/entrypoint1"},
-			flagDestRef:          "main",
-			flagSourceRef:        "ldap/feature",
-			flagDetectChanges:    true,
-			flagMaxWalkbackDepth: 2,
-			newGitClient: func(ctx context.Context, dir string) git.Git {
-				return &git.MockGitClient{
-					DiffResp: []string{
-						filepath.Join(cwd, "testdata/entrypoint1/project1/files/sub"),
-					},
-				}
-			},
-			expStdout: `["testdata/entrypoint1/project1"]`,
-		},
-		{
-			name:                 "walkback_hits_root",
-			flagDir:              []string{"testdata/entrypoint1"},
-			flagDestRef:          "main",
-			flagSourceRef:        "ldap/feature",
-			flagDetectChanges:    true,
-			flagMaxWalkbackDepth: maxWalkbackDepthLimit,
-			newGitClient: func(ctx context.Context, dir string) git.Git {
-				return &git.MockGitClient{
-					DiffResp: []string{
-						filepath.Join(cwd, "testdata/entrypoint1/project3"),
-					},
-				}
-			},
-			expStdout: `[]`,
-		},
-		{
-			name:                 "nearest_entrypoint_returned",
-			flagDir:              []string{"testdata/nested_entrypoints"},
-			flagDestRef:          "main",
-			flagSourceRef:        "ldap/feature",
-			flagDetectChanges:    true,
-			flagMaxWalkbackDepth: maxWalkbackDepthLimit,
-			newGitClient: func(ctx context.Context, dir string) git.Git {
-				return &git.MockGitClient{
-					DiffResp: []string{
-						filepath.Join(cwd, "testdata/nested_entrypoints/subdir/entrypoint2/subsub"),
-					},
-				}
-			},
-			expStdout: `["testdata/nested_entrypoints/subdir/entrypoint2"]`,
 		},
 		{
 			name:              "changes_with_add_entrypoint",
@@ -338,15 +240,14 @@ func TestEntrypointsProcess(t *testing.T) {
 			mockPlatformClient := &platform.MockPlatform{}
 
 			c := &EntrypointsCommand{
-				flagDir:              tc.flagDir,
-				flagGuardianDirs:     tc.flagGuardianDirs,
-				flagDestRef:          tc.flagDestRef,
-				flagSourceRef:        tc.flagSourceRef,
-				flagDetectChanges:    tc.flagDetectChanges,
-				flagMaxDepth:         tc.flagMaxDepth,
-				flagMaxWalkbackDepth: tc.flagMaxWalkbackDepth,
-				platformClient:       mockPlatformClient,
-				newGitClient:         tc.newGitClient,
+				flagDir:           tc.flagDir,
+				flagGuardianDirs:  tc.flagGuardianDirs,
+				flagDestRef:       tc.flagDestRef,
+				flagSourceRef:     tc.flagSourceRef,
+				flagDetectChanges: tc.flagDetectChanges,
+				flagMaxDepth:      tc.flagMaxDepth,
+				platformClient:    mockPlatformClient,
+				newGitClient:      tc.newGitClient,
 			}
 
 			_, stdout, stderr := c.Pipe()

--- a/pkg/commands/entrypoints/testdata/nested_entrypoints/main.tf
+++ b/pkg/commands/entrypoints/testdata/nested_entrypoints/main.tf
@@ -1,3 +1,0 @@
-terraform {
-  backend "local" {}
-}

--- a/pkg/commands/entrypoints/testdata/nested_entrypoints/subdir/entrypoint2/main.tf
+++ b/pkg/commands/entrypoints/testdata/nested_entrypoints/subdir/entrypoint2/main.tf
@@ -1,3 +1,0 @@
-terraform {
-  backend "local" {}
-}

--- a/pkg/commands/entrypoints/testdata/nested_entrypoints/subdir/entrypoint2/subsub/file.txt
+++ b/pkg/commands/entrypoints/testdata/nested_entrypoints/subdir/entrypoint2/subsub/file.txt
@@ -1,1 +1,0 @@
-changed file


### PR DESCRIPTION
…s looking for entry points (#595)"

This reverts commit 8ba9105a3c3efef46b4c03fbfcd2be8635aacc1e. This encountered unexpected errors with logs being included in stdout which broke the Guardian workflows using "guardian entrypoints" commands.