### PR TITLE
Add registry proxy support for routing Terraform providers through a network mirror

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -25,6 +25,17 @@ These options sets the code review platform that Guardian should interact with.
 
 - **-platform="github"** - The code review platform for Guardian to integrate with. Allowed values are ["github", "local"].
 
+### Common Options
+These options apply to commands that interact with Terraform directories (`plan`, `apply`, `run`):
+
+- **-dir="./terraform"** - The location of the terraform directory.
+
+### Registry Proxy Options
+
+These options apply to commands that interact with Terraform directories (`plan`, `apply`, `run`) and route provider requests through a proxy:
+
+- **-registry-proxy="https://localhost:8080/"** - The base URL for a Terraform Provider Registry Proxy or Network Mirror. When set, Guardian routes all provider requests through this proxy, which transparently decides where to fetch each provider from. This option can also be specified with the GUARDIAN_REGISTRY_PROXY environment variable.
+
 ### GitHub Options
 
 These options influence how Guardian interacts with GitHub:

--- a/pkg/commands/apply/apply.go
+++ b/pkg/commands/apply/apply.go
@@ -36,6 +36,7 @@ import (
 	"github.com/abcxyz/guardian/pkg/platform"
 	"github.com/abcxyz/guardian/pkg/storage"
 	"github.com/abcxyz/guardian/pkg/terraform"
+	"github.com/abcxyz/guardian/pkg/terraform/registryproxy"
 	"github.com/abcxyz/guardian/pkg/util"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
@@ -66,6 +67,7 @@ type ApplyCommand struct {
 	platformConfig platform.Config
 
 	flags.CommonFlags
+	flags.RegistryProxyFlags
 
 	flagStorage                string
 	flagAllowLockfileChanges   bool
@@ -100,7 +102,8 @@ func (c *ApplyCommand) Flags() *cli.FlagSet {
 	set := c.NewFlagSet()
 
 	c.platformConfig.RegisterFlags(set)
-	c.Register(set)
+	c.CommonFlags.Register(set)
+	c.RegistryProxyFlags.Register(set)
 
 	f := set.NewSection("COMMAND OPTIONS")
 
@@ -211,6 +214,14 @@ func (c *ApplyCommand) Run(ctx context.Context, args []string) error {
 	c.childPath = childPath
 
 	tfEnvVars := []string{"TF_IN_AUTOMATION=true"}
+	if c.FlagRegistryProxy != "" {
+		cfgPath, cleanup, err := registryproxy.GenerateCLIConfig(ctx, c.FlagRegistryProxy, c.directory)
+		if err != nil {
+			return fmt.Errorf("failed to generate terraform CLI config: %w", err)
+		}
+		defer cleanup()
+		tfEnvVars = append(tfEnvVars, "TF_CLI_CONFIG_FILE="+cfgPath)
+	}
 	c.terraformClient = terraform.NewTerraformClient(c.directory, tfEnvVars)
 
 	platform, err := platform.NewPlatform(ctx, &c.platformConfig)

--- a/pkg/commands/plan/plan.go
+++ b/pkg/commands/plan/plan.go
@@ -36,6 +36,7 @@ import (
 	"github.com/abcxyz/guardian/pkg/platform"
 	"github.com/abcxyz/guardian/pkg/storage"
 	"github.com/abcxyz/guardian/pkg/terraform"
+	"github.com/abcxyz/guardian/pkg/terraform/registryproxy"
 	"github.com/abcxyz/guardian/pkg/util"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
@@ -70,6 +71,7 @@ type PlanCommand struct {
 	platformConfig platform.Config
 
 	flags.CommonFlags
+	flags.RegistryProxyFlags
 
 	flagOutputDir              string
 	flagStorage                string
@@ -103,7 +105,8 @@ func (c *PlanCommand) Flags() *cli.FlagSet {
 	set := c.NewFlagSet()
 
 	c.platformConfig.RegisterFlags(set)
-	c.Register(set)
+	c.CommonFlags.Register(set)
+	c.RegistryProxyFlags.Register(set)
 
 	f := set.NewSection("COMMAND OPTIONS")
 
@@ -235,6 +238,14 @@ func (c *PlanCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	tfEnvVars := []string{"TF_IN_AUTOMATION=true"}
+	if c.FlagRegistryProxy != "" {
+		cfgPath, cleanup, err := registryproxy.GenerateCLIConfig(ctx, c.FlagRegistryProxy, c.directory)
+		if err != nil {
+			return fmt.Errorf("failed to generate terraform CLI config: %w", err)
+		}
+		defer cleanup()
+		tfEnvVars = append(tfEnvVars, "TF_CLI_CONFIG_FILE="+cfgPath)
+	}
 	c.terraformClient = terraform.NewTerraformClient(c.directory, tfEnvVars)
 
 	platform, err := platform.NewPlatform(ctx, &c.platformConfig)

--- a/pkg/commands/run/run.go
+++ b/pkg/commands/run/run.go
@@ -27,6 +27,7 @@ import (
 	"github.com/abcxyz/guardian/pkg/checkterraform"
 	"github.com/abcxyz/guardian/pkg/flags"
 	"github.com/abcxyz/guardian/pkg/terraform"
+	"github.com/abcxyz/guardian/pkg/terraform/registryproxy"
 	"github.com/abcxyz/guardian/pkg/util"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/pointer"
@@ -43,6 +44,7 @@ type RunCommand struct {
 	terraformArgs    []string
 
 	flags.CommonFlags
+	flags.RegistryProxyFlags
 
 	flagAllowedTerraformCommands []string
 	flagAllowLockfileChanges     bool
@@ -70,7 +72,8 @@ Usage: {{ COMMAND }} [options]
 func (c *RunCommand) Flags() *cli.FlagSet {
 	set := c.NewFlagSet()
 
-	c.Register(set)
+	c.CommonFlags.Register(set)
+	c.RegistryProxyFlags.Register(set)
 
 	f := set.NewSection("COMMAND OPTIONS")
 
@@ -163,6 +166,14 @@ func (c *RunCommand) Run(ctx context.Context, args []string) error {
 	c.childPath = childPath
 
 	tfEnvVars := []string{"TF_IN_AUTOMATION=true"}
+	if c.FlagRegistryProxy != "" {
+		cfgPath, cleanup, err := registryproxy.GenerateCLIConfig(ctx, c.FlagRegistryProxy, c.directory)
+		if err != nil {
+			return fmt.Errorf("failed to generate terraform CLI config: %w", err)
+		}
+		defer cleanup()
+		tfEnvVars = append(tfEnvVars, "TF_CLI_CONFIG_FILE="+cfgPath)
+	}
 	c.terraformClient = terraform.NewTerraformClient(c.directory, tfEnvVars)
 
 	return c.Process(ctx)

--- a/pkg/flags/registry_proxy.go
+++ b/pkg/flags/registry_proxy.go
@@ -1,0 +1,41 @@
+// Copyright 2026 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"github.com/abcxyz/pkg/cli"
+)
+
+// RegistryProxyFlags represent the Terraform provider registry proxy flags shared
+// among the Terraform commands. Embed this struct into any command that routes
+// provider requests through a registry proxy or network mirror.
+type RegistryProxyFlags struct {
+	// FlagRegistryProxy is the base URL of the Terraform provider registry proxy
+	// or network mirror through which provider requests are routed.
+	FlagRegistryProxy string
+}
+
+// Register registers the registry proxy flags onto the given flag set.
+func (r *RegistryProxyFlags) Register(set *cli.FlagSet) {
+	f := set.NewSection("REGISTRY PROXY OPTIONS")
+
+	f.StringVar(&cli.StringVar{
+		Name:    "registry-proxy",
+		EnvVar:  "GUARDIAN_REGISTRY_PROXY",
+		Target:  &r.FlagRegistryProxy,
+		Example: "https://localhost:8080/",
+		Usage:   "The base URL for a Terraform Provider Registry Proxy or Network Mirror. When set, Guardian routes all provider requests through the proxy, which transparently decides where to fetch each provider from.",
+	})
+}

--- a/pkg/terraform/registryproxy/registryproxy.go
+++ b/pkg/terraform/registryproxy/registryproxy.go
@@ -1,0 +1,146 @@
+// Copyright 2026 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package registryproxy generates Terraform CLI configuration for Guardian, such
+// as a temporary .terraformrc that routes provider requests through a registry proxy.
+package registryproxy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
+
+	"github.com/abcxyz/pkg/logging"
+)
+
+// GenerateCLIConfig creates a temporary Terraform CLI configuration file (.terraformrc)
+// configured to route all provider requests through the Provider Network Mirror at proxyURL.
+// The proxy is fully transparent: it decides where to fetch each provider from, so all
+// providers ("*/*/*") are routed through it. proxyURL must use the https:// scheme,
+// because Terraform only accepts https network mirror URLs.
+//
+// If TF_CLI_CONFIG_FILE is already set, its contents are preserved by prepending them to
+// the generated config, so top-level directives (such as plugin_cache_dir or credentials)
+// are not lost. Because Terraform permits only one provider_installation block, an existing
+// config that already declares one cannot be merged and results in an error. A relative
+// TF_CLI_CONFIG_FILE is resolved against workingDir, matching how Terraform resolves it
+// (Guardian runs the Terraform subprocess with workingDir as its working directory).
+//
+// It returns the absolute file path, a cleanup function to remove the temporary file, and an error if any.
+// An empty proxyURL returns an empty path and a no-op cleanup with a nil error. The returned cleanup is
+// always non-nil and safe to call, even when an error is returned.
+func GenerateCLIConfig(ctx context.Context, proxyURL, workingDir string) (string, func(), error) {
+	if proxyURL == "" {
+		return "", func() {}, nil
+	}
+
+	u, err := url.Parse(proxyURL)
+	if err != nil {
+		return "", func() {}, fmt.Errorf("invalid registry proxy URL %q: %w", proxyURL, err)
+	}
+	if u.Scheme != "https" {
+		return "", func() {}, fmt.Errorf("registry proxy URL %q must use https:// (Terraform requires network mirror URLs to use https)", proxyURL)
+	}
+
+	if !strings.HasSuffix(proxyURL, "/") {
+		proxyURL += "/"
+	}
+
+	var buf bytes.Buffer
+
+	if existing := os.Getenv("TF_CLI_CONFIG_FILE"); existing != "" {
+		// Terraform resolves a relative TF_CLI_CONFIG_FILE against its working
+		// directory. Guardian runs Terraform with workingDir as that directory, so
+		// resolve it the same way here to read the file Terraform would have used.
+		if !filepath.IsAbs(existing) {
+			existing = filepath.Join(workingDir, existing)
+		}
+		data, err := os.ReadFile(existing)
+		if err != nil {
+			return "", func() {}, fmt.Errorf("failed to read existing TF_CLI_CONFIG_FILE %q: %w", existing, err)
+		}
+		hasBlock, err := hasProviderInstallationBlock(data)
+		if err != nil {
+			return "", func() {}, fmt.Errorf("failed to parse existing TF_CLI_CONFIG_FILE %q: %w", existing, err)
+		}
+		if hasBlock {
+			return "", func() {}, fmt.Errorf("existing TF_CLI_CONFIG_FILE %q declares a provider_installation block, which conflicts with --registry-proxy (Terraform permits only one); remove it or unset TF_CLI_CONFIG_FILE", existing)
+		}
+		logging.FromContext(ctx).InfoContext(ctx, "Merging existing TF_CLI_CONFIG_FILE with registry proxy configuration", "existing_tf_cli_config_file", existing)
+		buf.Write(data)
+		if len(data) > 0 && !bytes.HasSuffix(data, []byte("\n")) {
+			buf.WriteByte('\n')
+		}
+		buf.WriteByte('\n')
+	}
+
+	fmt.Fprintf(&buf, `provider_installation {
+  network_mirror {
+    url     = %q
+    include = ["*/*/*"]
+  }
+}
+`, proxyURL)
+
+	tmpFile, err := os.CreateTemp("", "guardian-terraformrc-*.hcl")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("failed to create temp terraformrc: %w", err)
+	}
+
+	if err := os.Chmod(tmpFile.Name(), 0o600); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+		return "", func() {}, fmt.Errorf("failed to chmod temp terraformrc: %w", err)
+	}
+
+	if _, err := tmpFile.Write(buf.Bytes()); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+		return "", func() {}, fmt.Errorf("failed to write temp terraformrc: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpFile.Name())
+		return "", func() {}, fmt.Errorf("failed to close temp terraformrc: %w", err)
+	}
+
+	cleanup := func() {
+		_ = os.Remove(tmpFile.Name())
+	}
+
+	return tmpFile.Name(), cleanup, nil
+}
+
+// hasProviderInstallationBlock reports whether the given Terraform CLI config source already declares a provider_installation block.
+// It returns an error if the source cannot be parsed, so callers can distinguish a genuine conflicting block from an unparseable config.
+func hasProviderInstallationBlock(src []byte) (bool, error) {
+	f, diags := hclparse.NewParser().ParseHCL(src, "existing.terraformrc")
+	if diags.HasErrors() {
+		return false, fmt.Errorf("parsing HCL: %w", diags)
+	}
+	if f == nil {
+		return false, fmt.Errorf("parsing HCL: parser returned no file")
+	}
+	content, _, _ := f.Body.PartialContent(&hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{{Type: "provider_installation"}},
+	})
+	return content != nil && len(content.Blocks) > 0, nil
+}

--- a/pkg/terraform/registryproxy/registryproxy_test.go
+++ b/pkg/terraform/registryproxy/registryproxy_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registryproxy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hclparse"
+)
+
+func TestGenerateCLIConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		proxyURL     string
+		wantEmpty    bool
+		wantContains []string
+	}{
+		{
+			name:      "empty_url",
+			proxyURL:  "",
+			wantEmpty: true,
+		},
+		{
+			name:     "mirrors_all_providers",
+			proxyURL: "https://localhost:8080",
+			wantContains: []string{
+				`url     = "https://localhost:8080/"`,
+				`include = ["*/*/*"]`,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path, cleanup, err := GenerateCLIConfig(context.Background(), tc.proxyURL, "")
+			if err != nil {
+				t.Fatalf("GenerateCLIConfig() got err %v, want nil", err)
+			}
+			defer cleanup()
+
+			if tc.wantEmpty {
+				if path != "" {
+					t.Errorf("GenerateCLIConfig() path got %q, want empty string", path)
+				}
+				return
+			}
+			if path == "" {
+				t.Fatal("GenerateCLIConfig() path got empty string, want non-empty path")
+			}
+
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("Stat() got err %v, want nil", err)
+			}
+
+			if runtime.GOOS != "windows" {
+				if perm := info.Mode().Perm(); perm != 0o600 {
+					t.Errorf("Perm() got %v, want 0o600", perm)
+				}
+			}
+
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("ReadFile() got err %v, want nil", err)
+			}
+
+			content := string(data)
+			for _, want := range tc.wantContains {
+				if !strings.Contains(content, want) {
+					t.Errorf("GenerateCLIConfig() content got:\n%s\nwant substring %q", content, want)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateCLIConfig_NonHTTPSURL(t *testing.T) {
+	t.Parallel()
+
+	for _, proxyURL := range []string{"http://localhost:8080", "localhost:8080"} {
+		_, cleanup, err := GenerateCLIConfig(context.Background(), proxyURL, "")
+		cleanup()
+		if err == nil {
+			t.Errorf("GenerateCLIConfig(%q) got nil err, want error for non-https URL", proxyURL)
+		}
+	}
+}
+
+func TestGenerateCLIConfig_MergesExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "existing.tfrc")
+	existingContent := "plugin_cache_dir = \"/tmp/plugin-cache\"\ndisable_checkpoint = true\n"
+	if err := os.WriteFile(existing, []byte(existingContent), 0o600); err != nil {
+		t.Fatalf("WriteFile() got err %v, want nil", err)
+	}
+	t.Setenv("TF_CLI_CONFIG_FILE", existing)
+
+	path, cleanup, err := GenerateCLIConfig(context.Background(), "https://localhost:8080", "")
+	if err != nil {
+		t.Fatalf("GenerateCLIConfig() got err %v, want nil", err)
+	}
+	defer cleanup()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() got err %v, want nil", err)
+	}
+
+	content := string(data)
+	for _, want := range []string{
+		`plugin_cache_dir = "/tmp/plugin-cache"`,
+		"disable_checkpoint = true",
+		`url     = "https://localhost:8080/"`,
+		`include = ["*/*/*"]`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("GenerateCLIConfig() content got:\n%s\nwant substring %q", content, want)
+		}
+	}
+}
+
+func TestGenerateCLIConfig_ResolvesRelativeExistingAgainstWorkingDir(t *testing.T) {
+	// A relative TF_CLI_CONFIG_FILE must be resolved against the Terraform working
+	// directory (workingDir), not the current process working directory, to match how
+	// Terraform itself resolves it. Guardian runs Terraform with workingDir as its cwd.
+	workingDir := t.TempDir()
+	existingContent := `plugin_cache_dir = "/tmp/plugin-cache"` + "\n"
+	if err := os.WriteFile(filepath.Join(workingDir, "existing.tfrc"), []byte(existingContent), 0o600); err != nil {
+		t.Fatalf("WriteFile() got err %v, want nil", err)
+	}
+	// Deliberately a relative path; it only resolves correctly against workingDir.
+	t.Setenv("TF_CLI_CONFIG_FILE", "existing.tfrc")
+
+	path, cleanup, err := GenerateCLIConfig(context.Background(), "https://localhost:8080", workingDir)
+	if err != nil {
+		t.Fatalf("GenerateCLIConfig() got err %v, want nil", err)
+	}
+	defer cleanup()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() got err %v, want nil", err)
+	}
+
+	content := string(data)
+	for _, want := range []string{
+		`plugin_cache_dir = "/tmp/plugin-cache"`,
+		`url     = "https://localhost:8080/"`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("GenerateCLIConfig() content got:\n%s\nwant substring %q", content, want)
+		}
+	}
+}
+
+func TestGenerateCLIConfig_ConflictingProviderInstallation(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "existing.tfrc")
+	existingContent := "provider_installation {\n  direct {}\n}\n"
+	if err := os.WriteFile(existing, []byte(existingContent), 0o600); err != nil {
+		t.Fatalf("WriteFile() got err %v, want nil", err)
+	}
+	t.Setenv("TF_CLI_CONFIG_FILE", existing)
+
+	_, cleanup, err := GenerateCLIConfig(context.Background(), "https://localhost:8080", "")
+	defer cleanup()
+	if err == nil {
+		t.Fatal("GenerateCLIConfig() got nil err, want error for existing provider_installation block")
+	}
+	if !strings.Contains(err.Error(), "provider_installation") {
+		t.Errorf("GenerateCLIConfig() err got %q, want it to mention provider_installation", err)
+	}
+}
+
+func TestGenerateCLIConfig_ExistingConfigWithoutTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "existing.tfrc")
+	// Deliberately omit the trailing newline to exercise the separator logic that
+	// keeps the existing directive from being glued onto the appended block.
+	existingContent := `plugin_cache_dir = "/tmp/plugin-cache"`
+	if err := os.WriteFile(existing, []byte(existingContent), 0o600); err != nil {
+		t.Fatalf("WriteFile() got err %v, want nil", err)
+	}
+	t.Setenv("TF_CLI_CONFIG_FILE", existing)
+
+	path, cleanup, err := GenerateCLIConfig(context.Background(), "https://localhost:8080", "")
+	if err != nil {
+		t.Fatalf("GenerateCLIConfig() got err %v, want nil", err)
+	}
+	defer cleanup()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() got err %v, want nil", err)
+	}
+
+	// The merged output must remain valid HCL. Without newline normalization the
+	// existing directive and the appended block would run together on one line.
+	if _, diags := hclparse.NewParser().ParseHCL(data, filepath.Base(path)); diags.HasErrors() {
+		t.Errorf("ParseHCL() got diagnostics %v, want none; merged content:\n%s", diags, data)
+	}
+
+	content := string(data)
+	for _, want := range []string{
+		`plugin_cache_dir = "/tmp/plugin-cache"`,
+		`url     = "https://localhost:8080/"`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("GenerateCLIConfig() content got:\n%s\nwant substring %q", content, want)
+		}
+	}
+}
+
+func TestGenerateCLIConfig_UnparseableExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "existing.tfrc")
+	// An unterminated block is not valid HCL, so parsing fails and the merge must
+	// fail closed rather than emit a possibly-invalid config.
+	existingContent := "broken {"
+	if err := os.WriteFile(existing, []byte(existingContent), 0o600); err != nil {
+		t.Fatalf("WriteFile() got err %v, want nil", err)
+	}
+	t.Setenv("TF_CLI_CONFIG_FILE", existing)
+
+	_, cleanup, err := GenerateCLIConfig(context.Background(), "https://localhost:8080", "")
+	defer cleanup()
+	if err == nil {
+		t.Fatal("GenerateCLIConfig() got nil err, want error for unparseable existing config")
+	}
+}


### PR DESCRIPTION
## Summary

Adds support for routing Terraform provider downloads through a Provider
Registry Proxy / Network Mirror via a new `--registry-proxy` flag.

This is useful in locked-down or air-gapped CI environments where direct
access to the public Terraform registry is unavailable and providers must be
fetched through an internal network mirror.

## What's included

**1. `pkg/terraform/registryproxy` package**

- `GenerateCLIConfig` produces a temporary Terraform CLI configuration
  (`.terraformrc`) containing a `provider_installation` `network_mirror`
  block that routes all providers (`"*/*/*"`) through the given proxy URL.
- Returns the config path, an always-safe cleanup function, and an error.
- When `TF_CLI_CONFIG_FILE` is already set, its contents are preserved by
  prepending them, so top-level directives (e.g. `plugin_cache_dir`,
  `credentials`) survive.
- Because Terraform permits only one `provider_installation` block, an
  existing config that already declares one fails fast with an actionable
  error (block detection uses `hcl/v2`).
- Proxy URLs must be `https` (Terraform only accepts https network mirror
  URLs); non-https URLs are rejected up front. An unparseable existing
  `TF_CLI_CONFIG_FILE` surfaces a parse error rather than being misreported
  as a conflicting `provider_installation` block.

**2. `--registry-proxy` flag wired into `plan`, `apply`, and `run`**

- New `RegistryProxyFlags` section exposing `--registry-proxy` (with a
  `GUARDIAN_REGISTRY_PROXY` env var fallback).
- When set, the command generates a temporary terraformrc via
  `registryproxy.GenerateCLIConfig` and passes it to Terraform through
  `TF_CLI_CONFIG_FILE`, removing the file after the command completes.
- Documented under a new Registry Proxy Options section in `cli.md`.

## Testing

- `go build ./...`
- `go test ./pkg/terraform/registryproxy/`
